### PR TITLE
Add version and issue_tracker to manifest

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,9 @@
   "domain": "plant",
   "name": "Plant Monitor",
   "documentation": "https://www.home-assistant.io/integrations/plant",
+  "issue_tracker": "https://github.com/Olen/homeassistant-plant/issues",
   "after_dependencies": ["recorder"],
   "codeowners": ["@ChristianKuehnel"],
-  "quality_scale": "internal"
+  "quality_scale": "internal",
+  "version": "0.2"
 }


### PR DESCRIPTION
HI :) Thanks for the great work, I had a few minutes so I thought I'd chime in.
Since HA update 2021.4 lack of "version" in manifest.json results in a warning, starting from 2021.6 this will result in the component not being loaded. Also proposed to add link to the issue tracker, as the documentation link only points to the original internal integration, and that's not very helpful.