### PR TITLE
Fix issue with call_async

### DIFF
--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -102,32 +102,31 @@ class PlantHelper:
             return None
 
         try:
-            plant_search = await self.hass.services.async_call(
+            await self.hass.services.async_call(
                 domain=DOMAIN_PLANTBOOK,
                 service=OPB_SEARCH,
                 service_data={"alias": species},
                 blocking=True,
-                # limit=30,  Has been removed in 2023.7  https://developers.home-assistant.io/blog/2023/06/14/service-calls/
+                # limit=30,  Has been removed in 2023.7  https://developers.home-assistant.io/blog/2023/06/14/service-calls/                
             )
         except KeyError:
             _LOGGER.warning("Openplantook does not work")
             return None
-        if plant_search:
-            _LOGGER.info(
-                "Result: %s",
-                self.hass.states.get(f"{DOMAIN_PLANTBOOK}.{OPB_SEARCH_RESULT}"),
-            )
-            if (
-                int(
-                    self.hass.states.get(
-                        f"{DOMAIN_PLANTBOOK}.{OPB_SEARCH_RESULT}"
-                    ).state
-                )
-                > 0
-            ):
-                return self.hass.states.get(
+        _LOGGER.info(
+            "Result: %s",
+            self.hass.states.get(f"{DOMAIN_PLANTBOOK}.{OPB_SEARCH_RESULT}"),
+        )
+        if (
+            int(
+                self.hass.states.get(
                     f"{DOMAIN_PLANTBOOK}.{OPB_SEARCH_RESULT}"
-                ).attributes
+                ).state
+            )
+            > 0
+        ):
+            return self.hass.states.get(
+                f"{DOMAIN_PLANTBOOK}.{OPB_SEARCH_RESULT}"
+            ).attributes
         return None
 
     async def openplantbook_get(self, species: str) -> dict[str:Any] | None:
@@ -137,20 +136,18 @@ class PlantHelper:
         if not species or species == "":
             return None
 
-        plant_get = await self.hass.services.async_call(
+        await self.hass.services.async_call(
             domain=DOMAIN_PLANTBOOK,
             service=OPB_GET,
             service_data={ATTR_SPECIES: species.lower()},
-            blocking=True,
-            # limit=30,
+            blocking=True
         )
-        if plant_get:
-            opb_plant = self.hass.states.get(
-                f"{DOMAIN_PLANTBOOK}.{slugify(species, separator='_')}"
-            )
-            _LOGGER.debug("Result for %s: %s", species, opb_plant)
-            if opb_plant is not None:
-                return opb_plant.attributes
+        opb_plant = self.hass.states.get(
+            f"{DOMAIN_PLANTBOOK}.{slugify(species, separator='_')}"
+        )
+        _LOGGER.debug("Result for %s: %s", species, opb_plant)
+        if opb_plant is not None:
+            return opb_plant.attributes
 
         _LOGGER.info("Did not find '%s' in OpenPlantbook", species)
         create_notification(


### PR DESCRIPTION
The change of call_async did not just remove the `timeout` value, it also changed the call to not return the true/false value related to timeouts. 

As far as I can tell, this pull request should fix that issue. As blocking is set to true it will wait until the `obp_plant` entity has been set. 