### PR TITLE
fix #122

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -12,8 +12,7 @@ from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     STATE_UNKNOWN,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfTemperature,
 )
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -352,8 +351,8 @@ class PlantMaxTemperature(PlantMinMax):
             new_state = round(
                 TemperatureConerter.convert(
                     temperature=float(self.state),
-                    from_unit=TEMP_FAHRENHEIT,
-                    to_unit=TEMP_CELSIUS,
+                    from_unit=UnitOfTemperature.FAHRENHEIT,
+                    to_unit=UnitOfTemperature.CELSIUS,
                 )
             )
             _LOGGER.debug(
@@ -369,8 +368,8 @@ class PlantMaxTemperature(PlantMinMax):
             new_state = round(
                 TemperatureConerter.convert(
                     temperature=float(self.state),
-                    from_unit=TEMP_CELSIUS,
-                    to_unit=TEMP_FAHRENHEIT,
+                    from_unit=UnitOfTemperature.CELSIUS,
+                    to_unit=UnitOfTemperature.FAHRENHEIT,
                 )
             )
             _LOGGER.debug(
@@ -424,8 +423,8 @@ class PlantMinTemperature(PlantMinMax):
             new_state = round(
                 TemperatureConerter.convert(
                     temperature=float(self.state),
-                    from_unit=TEMP_FAHRENHEIT,
-                    to_unit=TEMP_CELSIUS,
+                    from_unit=UnitOfTemperature.FAHRENHEIT,
+                    to_unit=UnitOfTemperature.CELSIUS,
                 )
             )
             _LOGGER.debug(
@@ -443,8 +442,8 @@ class PlantMinTemperature(PlantMinMax):
             new_state = round(
                 TemperatureConerter.convert(
                     temperature=float(self.state),
-                    from_unit=TEMP_CELSIUS,
-                    to_unit=TEMP_FAHRENHEIT,
+                    from_unit=UnitOfTemperature.CELSIUS,
+                    to_unit=UnitOfTemperature.FAHRENHEIT,
                 )
             )
             _LOGGER.debug(

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -10,7 +10,7 @@ import voluptuous as vol
 from homeassistant.components.persistent_notification import (
     create as create_notification,
 )
-from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_NAME, TEMP_CELSIUS
+from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_NAME, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.temperature import display_temp
@@ -165,13 +165,13 @@ class PlantHelper:
         max_temp = display_temp(
             self.hass,
             DEFAULT_MAX_TEMPERATURE,
-            TEMP_CELSIUS,
+            UnitOfTemperature.CELSIUS,
             0,
         )
         min_temp = display_temp(
             self.hass,
             DEFAULT_MIN_TEMPERATURE,
-            TEMP_CELSIUS,
+            UnitOfTemperature.CELSIUS,
             0,
         )
         max_conductivity = DEFAULT_MAX_CONDUCTIVITY
@@ -240,7 +240,7 @@ class PlantHelper:
                     CONF_PLANTBOOK_MAPPING[CONF_MAX_TEMPERATURE],
                     DEFAULT_MAX_TEMPERATURE,
                 ),
-                TEMP_CELSIUS,
+                UnitOfTemperature.CELSIUS,
                 0,
             )
             min_temp = display_temp(
@@ -249,7 +249,7 @@ class PlantHelper:
                     CONF_PLANTBOOK_MAPPING[CONF_MIN_TEMPERATURE],
                     DEFAULT_MIN_TEMPERATURE,
                 ),
-                TEMP_CELSIUS,
+                UnitOfTemperature.CELSIUS,
                 0,
             )
             opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_MMOL])

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -535,7 +535,7 @@ class PlantTotalLightIntegral(IntegrationSensor):
             source_entity=illuminance_ppfd_sensor.entity_id,
             unique_id=f"{config.entry_id}-ppfd-integral",
             unit_prefix=None,
-            unit_time=UnitOfTime.Seconds,
+            unit_time=UnitOfTime.SECONDS,
         )
         self._unit_of_measurement = UNIT_DLI
         self.entity_id = async_generate_entity_id(

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
     PERCENTAGE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
-    TIME_SECONDS,
+    UnitOfTime,
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -535,7 +535,7 @@ class PlantTotalLightIntegral(IntegrationSensor):
             source_entity=illuminance_ppfd_sensor.entity_id,
             unique_id=f"{config.entry_id}-ppfd-integral",
             unit_prefix=None,
-            unit_time=TIME_SECONDS,
+            unit_time=UnitOfTime.Seconds,
         )
         self._unit_of_measurement = UNIT_DLI
         self.entity_id = async_generate_entity_id(


### PR DESCRIPTION
This should fix reported issue #122

This PR caused another issue: 

```
Logger: homeassistant.components.sensor
Source: helpers/entity_platform.py:360
Integration: Sensor (documentation, issues)
First occurred: 2:43:34 PM (8 occurrences)
Last logged: 2:43:34 PM

Error while setting up plant platform for sensor
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity_platform.py", line 360, in _async_setup_platform
    await asyncio.shield(task)
  File "/config/custom_components/plant/sensor.py", line 125, in async_setup_entry
    pintegral = PlantTotalLightIntegral(hass, entry, pcurppfd, plant)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/plant/sensor.py", line 540, in __init__
    unit_time=UnitOfTime.Seconds,
              ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/enum.py", line 784, in __getattr__
    raise AttributeError(name) from None
AttributeError: Seconds
```

Not sure, what I need to change here... to fix this error :-(

[update]
this error should also be fixed