### PR TITLE
Use imported websocket function `async_register_command` instead of accessing it directly

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -221,7 +221,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         return
 
     hass.services.async_register(DOMAIN, SERVICE_REPLACE_SENSOR, replace_sensor)
-    hass.components.websocket_api.async_register_command(ws_get_info)
+    websocket_api.async_register_command(hass, ws_get_info)
     plant.async_schedule_update_ha_state(True)
 
     # Lets add the dummy sensors automatically if we are testing stuff


### PR DESCRIPTION
Fix for 
> 2024-03-01 08:51:31.990 WARNING (MainThread) [homeassistant.helpers.frame] Detected that custom integration 'plant' accesses hass.components.websocket_api. This is deprecated and will stop working in Home Assistant 2024.9, it should be updated to import functions used from websocket_api directly at custom_components/plant/init.py, line 224: hass.components.websocket_api.async_register_command(ws_get_info)

Tested locally on HA 2024.4: works fine

Fixes #145