### PR TITLE
Use device_class `illuminance threshold` for min illuminance number entity

### DIFF
--- a/custom_components/plant/plant_thresholds.py
+++ b/custom_components/plant/plant_thresholds.py
@@ -449,7 +449,7 @@ class PlantMinIlluminance(PlantMinMax):
 
     @property
     def device_class(self):
-        return SensorDeviceClass.ILLUMINANCE
+        return f"{SensorDeviceClass.ILLUMINANCE} threshold"
 
 
 class PlantMaxDli(PlantMinMax):


### PR DESCRIPTION
The max illuminance entity was already setting this properly but it seems like this one was set incorrectly.

Btw I just made this quick fix via vscode in github, but happy to add any tests if needed.