### PR TITLE
Changes in setup entity platforms with group integration

### DIFF
--- a/custom_components/plant/group.py
+++ b/custom_components/plant/group.py
@@ -6,10 +6,16 @@ from homeassistant.components.group import GroupIntegrationRegistry
 from homeassistant.const import STATE_OK, STATE_PROBLEM
 from homeassistant.core import HomeAssistant, callback
 
+from .const import DOMAIN
 
 @callback
 def async_describe_on_off_states(
     hass: HomeAssistant, registry: GroupIntegrationRegistry
 ) -> None:
     """Describe group on off states."""
-    registry.on_off_states({STATE_OK}, STATE_PROBLEM)
+    registry.on_off_states(
+            DOMAIN,
+            {STATE_OK},
+            STATE_OK,
+            STATE_PROBLEM,
+    )

--- a/custom_components/plant/group.py
+++ b/custom_components/plant/group.py
@@ -8,6 +8,7 @@ from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
 
+
 @callback
 def async_describe_on_off_states(
     hass: HomeAssistant, registry: GroupIntegrationRegistry

--- a/custom_components/plant/group.py
+++ b/custom_components/plant/group.py
@@ -14,8 +14,8 @@ def async_describe_on_off_states(
 ) -> None:
     """Describe group on off states."""
     registry.on_off_states(
-            DOMAIN,
-            {STATE_OK},
-            STATE_OK,
-            STATE_PROBLEM,
+        DOMAIN,
+        {STATE_OK},
+        STATE_OK,
+        STATE_PROBLEM,
     )


### PR DESCRIPTION
Adapted the group to the new inner workings of HA documented here: https://developers.home-assistant.io/blog/2024/05/10/group-integration/

Thanks to @kauthmbt's pointer in https://github.com/Olen/homeassistant-plant/issues/168#issuecomment-2151700499

Tested locally, error is gone, component works fine

Fixes #168 