### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.components.utility_meter.const import (
 )
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
+    Platform,
     ATTR_ENTITY_PICTURE,
     ATTR_ICON,
     ATTR_NAME,
@@ -72,7 +73,7 @@ from .const import (
 from .plant_helpers import PlantHelper
 
 _LOGGER = logging.getLogger(__name__)
-
+PLATFORMS = [Platform.NUMBER, Platform.SENSOR]
 
 # Use this during testing to generate some dummy-sensors
 # to provide random readings for temperature, moisture etc.
@@ -139,8 +140,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     plant = PlantDevice(hass, entry)
     hass.data[DOMAIN][entry.entry_id][ATTR_PLANT] = plant
 
-    await hass.config_entries.async_forward_entry_setups(entry, ["number"])
-    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     plant_entities = [
         plant,
@@ -258,21 +258,21 @@ async def _plant_add_to_device_registry(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.config_entries.async_forward_entry_unload(entry, "sensor")
-    await hass.config_entries.async_forward_entry_unload(entry, "number")
+    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, PLATFORMS)
 
-    hass.data[DOMAIN].pop(entry.entry_id)
-    hass.data[DATA_UTILITY].pop(entry.entry_id)
-    _LOGGER.info(hass.data[DOMAIN])
-    for entry_id in list(hass.data[DOMAIN].keys()):
-        if len(hass.data[DOMAIN][entry_id]) == 0:
-            _LOGGER.info("Removing entry %s", entry_id)
-            del hass.data[DOMAIN][entry_id]
-    if len(hass.data[DOMAIN]) == 0:
-        _LOGGER.info("Removing domain %s", DOMAIN)
-        hass.services.async_remove(DOMAIN, SERVICE_REPLACE_SENSOR)
-        del hass.data[DOMAIN]
-    return True
+    if unload_ok:
+        hass.data[DOMAIN].pop(entry.entry_id)
+        hass.data[DATA_UTILITY].pop(entry.entry_id)
+        _LOGGER.info(hass.data[DOMAIN])
+        for entry_id in list(hass.data[DOMAIN].keys()):
+            if len(hass.data[DOMAIN][entry_id]) == 0:
+                _LOGGER.info("Removing entry %s", entry_id)
+                del hass.data[DOMAIN][entry_id]
+        if len(hass.data[DOMAIN]) == 0:
+            _LOGGER.info("Removing domain %s", DOMAIN)
+            hass.services.async_remove(DOMAIN, SERVICE_REPLACE_SENSOR)
+            del hass.data[DOMAIN]
+    return unload_ok
 
 
 @websocket_api.websocket_command(


### PR DESCRIPTION
- setup platform in one call
- workaround for error message when the configuration has been reloaded.

1. when the configuration will be reloaded (#180)
![grafik](https://github.com/user-attachments/assets/c991e8b9-cbe4-4990-b12a-7db0a953267c)

2. a Popup will be shown to restart HomeAssistant
![grafik](https://github.com/user-attachments/assets/b071023e-3806-449c-b5ec-7851a09ac655)

3. without a restart, the "reload" option is no longer available
![grafik](https://github.com/user-attachments/assets/803c72ea-cd06-4d4c-a160-8e254b26cfd6)

4. After a restart, everything is working as expected.
--> I am pretty sure, that this can be improved even further, maybe by removing the "reload" option itself (not sure, why it would be required at all)