### PR TITLE
Add Plant Notes

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -461,7 +461,7 @@ class PlantDevice(Entity):
             f"{ATTR_HUMIDITY}_status": self.humidity_status,
             f"{ATTR_DLI}_status": self.dli_status,
             f"{ATTR_SPECIES}_original": self.species,
-            f"{ATTR_NOTES}_original": self.notes,
+            f"{ATTR_NOTES}": self.notes,
         }
         return attributes
 

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -45,6 +45,7 @@ from .const import (
     ATTR_METERS,
     ATTR_MIN,
     ATTR_MOISTURE,
+    ATTR_NOTES,
     ATTR_PLANT,
     ATTR_SENSOR,
     ATTR_SENSORS,
@@ -337,6 +338,10 @@ class PlantDevice(Entity):
         self.species = self._config.options.get(
             ATTR_SPECIES, self._config.data[FLOW_PLANT_INFO].get(ATTR_SPECIES)
         )
+        # Get notes from options or from initial config
+        self.notes = self._config.options.get(
+            ATTR_NOTES, self._config.data[FLOW_PLANT_INFO].get(ATTR_NOTES, "")
+        )
         # Get display_species from options or from initial config
         self.display_species = (
             self._config.options.get(
@@ -456,6 +461,7 @@ class PlantDevice(Entity):
             f"{ATTR_HUMIDITY}_status": self.humidity_status,
             f"{ATTR_DLI}_status": self.dli_status,
             f"{ATTR_SPECIES}_original": self.species,
+            f"{ATTR_NOTES}_original": self.notes,
         }
         return attributes
 

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -340,7 +340,7 @@ class PlantDevice(Entity):
         )
         # Get notes from options or from initial config
         self.notes = self._config.options.get(
-            ATTR_NOTES, self._config.data[FLOW_PLANT_INFO].get(ATTR_NOTES, "")
+            ATTR_NOTES, self._config.data[FLOW_PLANT_INFO].get(ATTR_NOTES)
         )
         # Get display_species from options or from initial config
         self.display_species = (

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -463,6 +463,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ):
                 user_input[OPB_DISPLAY_PID] = ""
 
+            notes_val = user_input.get(ATTR_NOTES, "")
+            user_input[ATTR_NOTES] = notes_val
+
             return self.async_create_entry(title="", data=user_input)
 
         self.plant = self.hass.data[DOMAIN][self.entry.entry_id]["plant"]
@@ -519,6 +522,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         # data_schema[vol.Optional(CONF_CHECK_DAYS, default=self.plant.check_days)] = int
 
+        # Use .notes if present, else empty
+        current_notes = getattr(self.plant, "notes", "")
+        data_schema[vol.Optional(ATTR_NOTES, description={"suggested_value": current_notes})] = cv.string
+
         return self.async_show_form(step_id="init", data_schema=vol.Schema(data_schema))
 
     async def update_plant_options(
@@ -564,6 +571,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         new_species = entry.options.get(ATTR_SPECIES)
         force_new_species = entry.options.get(FLOW_FORCE_SPECIES_UPDATE)
+
+        new_notes = entry.options.get(ATTR_NOTES, "")
+        self.plant.notes = new_notes
+
         if new_species is not None and (
             new_species != self.plant.species or force_new_species is True
         ):
@@ -607,7 +618,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 self.plant.species = new_species
 
             # We need to reset the force_update option back to False, or else
-            # this will only be run once (unchanged options are will not trigger the flow)
+            # this will only be run once (unchanged options won't trigger the flow)
             options = dict(entry.options)
             data = dict(entry.data)
             options[FLOW_FORCE_SPECIES_UPDATE] = False

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -572,7 +572,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         new_species = entry.options.get(ATTR_SPECIES)
         force_new_species = entry.options.get(FLOW_FORCE_SPECIES_UPDATE)
 
-        new_notes = entry.options.get(ATTR_NOTES, "")
+        new_notes = entry.options.get(ATTR_NOTES)
         self.plant.notes = new_notes
 
         if new_species is not None and (

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -30,6 +30,7 @@ from .const import (
     ATTR_SELECT,
     ATTR_SENSORS,
     ATTR_SPECIES,
+    ATTR_NOTES,
     CONF_MAX_CONDUCTIVITY,
     CONF_MAX_DLI,
     CONF_MAX_HUMIDITY,
@@ -109,6 +110,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if valid:
                 # Store info to use in next step
                 self.plant_info = user_input
+                self.plant_info[ATTR_NOTES] = user_input.get(ATTR_NOTES, "")
                 self.plant_info[ATTR_SEARCH_FOR] = user_input[ATTR_SPECIES]
                 _LOGGER.debug("Plant_info: %s", self.plant_info)
 
@@ -122,6 +124,9 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             vol.Required(ATTR_NAME, default=self.plant_info.get(ATTR_NAME)): cv.string,
             vol.Optional(
                 ATTR_SPECIES, default=self.plant_info.get(ATTR_SPECIES, "")
+            ): cv.string,
+            vol.Optional(
+                ATTR_NOTES, default=self.plant_info.get(ATTR_NOTES, "")
             ): cv.string,
         }
 

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -31,6 +31,7 @@ ATTR_PLANT = "plant"
 ATTR_SPECIES = "species"
 ATTR_IMAGE = "image"
 ATTR_SEARCH_FOR = "search_for"
+ATTR_NOTES = "notes"
 
 # Readings are used by humans
 READING_BATTERY = "battery"

--- a/custom_components/plant/strings.json
+++ b/custom_components/plant/strings.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Plant name",
           "species": "Species",
+          "notes": "Plant notes",
           "temperature_sensor": "Temperature sensor",
           "moisture_sensor": "Soil moisture sensor",
           "conductivity_sensor": "Conductivity sensor",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Illuminance check days",
           "species": "Species",
+          "notes": "Plant notes",
           "force_update": "Force refresh data from OpenPlantbook",
           "display_pid": "Plant species to display",
           "temperature_sensor": "Temperature sensor",

--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Pflanzenname",
           "species": "Sorte",
+          "notes": "Pflanzennotizen",
           "temperature_sensor": "Temperatursensor",
           "moisture_sensor": "Bodenfeuchtesensor",
           "conductivity_sensor": "Leitfähigkeitssensor",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Beleuchtungsstärke-Kontrolltage",
           "species": "Species",
+          "notes": "Pflanzennotizen",
           "force_update": "Aktualisierung der Daten aus OpenPlantbook erzwingen",
           "display_pid": "Anzuzeigende Pflanzenarten",
           "temperature_sensor": "Temperatursensor",

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Plant name",
           "species": "Species",
+          "notes": "Plant notes",
           "temperature_sensor": "Temperature sensor",
           "moisture_sensor": "Soil moisture sensor",
           "conductivity_sensor": "Conductivity sensor",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Illuminance check days",
           "species": "Species",
+          "notes": "Plant notes",
           "force_update": "Force refresh data from OpenPlantbook",
           "display_pid": "Plant species to display",
           "temperature_sensor": "Temperature sensor",

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Nombre de la planta",
           "species": "Especie",
+          "notes": "Notas de la planta",
           "temperature_sensor": "Sensor de Temperatura",
           "moisture_sensor": "Sensor de Humedad del suelo",
           "conductivity_sensor": "Sensor Conductividad",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Días de control de la iluminación",
           "species": "Especie",
+          "notes": "Notas de la planta",
           "force_update": "Forzar la actualización de los datos de OpenPlantbook",
           "display_pid": "Especies vegetales para mostrar",
           "temperature_sensor": "Sensor de Temperatura",

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Nom de la plante",
           "species": "Espèce",
+          "notes": "Notes sur la plante",
           "temperature_sensor": "Capteur de température",
           "moisture_sensor": "Capteur d'humidité du sol",
           "conductivity_sensor": "Capteur de conductivité",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Contrôles des jours d'ensoleillement",
           "species": "Espèce",
+          "notes": "Notes sur la plante",
           "force_update": "Forcer la mise à jour des données depuis OpenPlantbook",
           "display_pid": "Espèce de plante à afficher",
           "temperature_sensor": "Capteur de température",

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Növény neve",
           "species": "Faj",
+          "notes": "Növény megjegyzések",
           "temperature_sensor": "Hőmérséklet érzékelő",
           "moisture_sensor": "Talajnedvesség érzékelő",
           "conductivity_sensor": "Talajvezetőképesség érzékelő",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Fényerősség ellenőrzési napok",
           "species": "Faj",
+          "notes": "Növény megjegyzések",
           "force_update": "OpenPlantbookból származó adatok frissítésének kényszerítése",
           "display_pid": "Megjelenítendő növényfaj",
           "temperature_sensor": "Hőmérséklet érzékelő",

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Plantnaam",
           "species": "Soort",
+          "notes": "Plantnotities",
           "temperature_sensor": "Temperatuursensor",
           "moisture_sensor": "Bodemvochtsensor",
           "conductivity_sensor": "Geleidbaarheidssensor",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Lichtsterktecontroledagen",
           "species": "Soort",
+          "notes": "Plantnotities",
           "force_update": "Forceer ophalen data van OpenPlantbook",
           "display_pid": "Te tonen plantsoort",
           "temperature_sensor": "Temperatuursensor",

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -8,6 +8,7 @@
         "data": {
           "name": "Nome da planta",
           "species": "Especie",
+          "notes": "Notas da planta",
           "temperature_sensor": "Sensor de Temperatura",
           "moisture_sensor": "Sensor de húmidade de solo",
           "conductivity_sensor": "Sensor de Condutividade",
@@ -59,6 +60,7 @@
         "data": {
           "check_days": "Verificar por dias",
           "species": "Especies",
+          "notes": "Notas da planta",
           "force_update": "Forçar a atuailização de  OpenPlantbook",
           "display_pid": "Especies de plantas a mostrar",
           "temperature_sensor": "Sensor de Temperatura",


### PR DESCRIPTION
I've implemented Plant Notes! 🎉

This adds the backend stuff ofc, I've also submitted a PR for lovelace-flower-card, it's here: (UPCOMING ASAP). Plant notes are configured as normal in Configure.

<img width="736" alt="plant notes" src="https://github.com/user-attachments/assets/7d7e5f9e-4a2f-4b4b-bf1d-cac937accaaf" />

Multiline is supported in the plant notes.

I've also added all languages too (Translate translated, but should be fine). 

Take a look - I'll correct any issues! 🙂