### PR TITLE
fix: Restrict the conductivity sensor selection to conductivity sensors

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -142,7 +142,12 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             }
         )
         data_schema[FLOW_SENSOR_CONDUCTIVITY] = selector(
-            {ATTR_ENTITY: {ATTR_DOMAIN: DOMAIN_SENSOR}}
+            {
+                ATTR_ENTITY: {
+                    ATTR_DEVICE_CLASS: SensorDeviceClass.CONDUCTIVITY,
+                    ATTR_DOMAIN: DOMAIN_SENSOR,
+                }
+            }
         )
         data_schema[FLOW_SENSOR_ILLUMINANCE] = selector(
             {


### PR DESCRIPTION
As the title says: For a cleaner user experience, only sensors of type `SensorDeviceClass.CONDUCTIVITY` should be shown when selecting a conductivity sensor. This matches the behavior of the other sensor selection dropdowns in the same dialog.