### PR TITLE
fix: Fix runtime error during unload due to call signature mismatch

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -262,7 +262,7 @@ async def _plant_add_to_device_registry(
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_forward_entry_unload(entry, PLATFORMS)
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)


### PR DESCRIPTION
The correct method that mirrors what `async_forward_entry_setups(entry, platforms)` does is `async_unload_platforms(entry, platforms)`, and not `async_forward_entry_unload(entry, platform)`, because the latter only supports a single platform.

(I admit that the naming of the methods is misleading, and should probably be fixed in the Home Assistant core code, but that is a separate problem).

The usage of the wrong method currently causes a runtime exception during unload, which causes the unload to fail.
