### PR TITLE
Bump version to 2026.1.0-beta2

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -16,5 +16,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.1.0-beta1"
+  "version": "2026.1.0-beta2"
 }


### PR DESCRIPTION
## Summary

- Bump version to 2026.1.0-beta2

## Changes since beta1

- Add translation support for entity names (#299)
  - Entity names now translatable via Home Assistant's translation system
  - Translations available in 9 languages (de, dk, en, es, fr, hu, nl, pt, zh-Hans)
  - Note: Translations were AI-generated - native speakers welcome to submit corrections

🤖 Generated with [Claude Code](https://claude.com/claude-code)