### PR TITLE
Fix Unicode character for conductivity unit

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -111,10 +111,10 @@ DATA_UPDATED = "plant_data_updated"
 
 
 UNIT_PPFD = "mol/s⋅m²"
-UNIT_MICRO_PPFD = "μmol/s⋅m²"
+UNIT_MICRO_PPFD = "µmol/s⋅m²"
 UNIT_DLI = "mol/d⋅m²"
-UNIT_MICRO_DLI = "μmol/d⋅m²"
-UNIT_CONDUCTIVITY = "μS/cm"
+UNIT_MICRO_DLI = "µmol/d⋅m²"
+# Note: For conductivity, use UnitOfConductivity.MICROSIEMENS_PER_CM from homeassistant.const
 
 FLOW_WRONG_PLANT = "wrong_plant"
 FLOW_RIGHT_PLANT = "right_plant"

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     STATE_UNKNOWN,
+    UnitOfConductivity,
     UnitOfTemperature,
 )
 from homeassistant.core import Event, HomeAssistant, callback
@@ -85,7 +86,6 @@ from .const import (
     TRANSLATION_KEY_MIN_ILLUMINANCE,
     TRANSLATION_KEY_MIN_MOISTURE,
     TRANSLATION_KEY_MIN_TEMPERATURE,
-    UNIT_CONDUCTIVITY,
     UNIT_DLI,
 )
 
@@ -332,8 +332,9 @@ class PlantMaxTemperature(PlantMinMax):
             return
         new_state = self._attr_state
         if (
-            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°F"
-            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
+            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.FAHRENHEIT
+            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            == UnitOfTemperature.CELSIUS
         ):
             new_state = round(
                 TemperatureConverter.convert(
@@ -349,8 +350,9 @@ class PlantMaxTemperature(PlantMinMax):
             )
 
         if (
-            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
-            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°F"
+            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
+            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            == UnitOfTemperature.FAHRENHEIT
         ):
             new_state = round(
                 TemperatureConverter.convert(
@@ -404,8 +406,9 @@ class PlantMinTemperature(PlantMinMax):
             return
         new_state = self._attr_state
         if (
-            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°F"
-            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
+            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.FAHRENHEIT
+            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            == UnitOfTemperature.CELSIUS
         ):
             new_state = round(
                 TemperatureConverter.convert(
@@ -421,8 +424,9 @@ class PlantMinTemperature(PlantMinMax):
             )
 
         if (
-            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°C"
-            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == "°F"
+            old_attributes.get(ATTR_UNIT_OF_MEASUREMENT) == UnitOfTemperature.CELSIUS
+            and new_attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            == UnitOfTemperature.FAHRENHEIT
         ):
             new_state = round(
                 TemperatureConverter.convert(
@@ -537,7 +541,7 @@ class PlantMaxConductivity(PlantMinMax):
 
     _attr_device_class = f"{ATTR_CONDUCTIVITY} threshold"
     _attr_icon = ICON_CONDUCTIVITY
-    _attr_native_unit_of_measurement = UNIT_CONDUCTIVITY
+    _attr_native_unit_of_measurement = UnitOfConductivity.MICROSIEMENS_PER_CM
     _attr_native_max_value = 3000
     _attr_native_min_value = 0
     _attr_native_step = 50
@@ -560,7 +564,7 @@ class PlantMinConductivity(PlantMinMax):
 
     _attr_device_class = f"{ATTR_CONDUCTIVITY} threshold"
     _attr_icon = ICON_CONDUCTIVITY
-    _attr_native_unit_of_measurement = UNIT_CONDUCTIVITY
+    _attr_native_unit_of_measurement = UnitOfConductivity.MICROSIEMENS_PER_CM
     _attr_native_max_value = 3000
     _attr_native_min_value = 0
     _attr_native_step = 50

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -79,7 +79,6 @@ from .const import (
     TRANSLATION_KEY_PPFD,
     TRANSLATION_KEY_TEMPERATURE,
     TRANSLATION_KEY_TOTAL_LIGHT_INTEGRAL,
-    UNIT_CONDUCTIVITY,
     UNIT_DLI,
     UNIT_PPFD,
 )
@@ -655,7 +654,7 @@ class PlantDummyConductivity(PlantDummyStatus):
         )
         self._attr_unique_id = f"{config.entry_id}-dummy-conductivity"
         self._attr_icon = ICON_CONDUCTIVITY
-        self._attr_native_unit_of_measurement = UNIT_CONDUCTIVITY
+        self._attr_native_unit_of_measurement = UnitOfConductivity.MICROSIEMENS_PER_CM
         self._attr_native_value = random.randint(40, 200) * 10
 
         super().__init__(hass, config, plantdevice)

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.components.number import NumberMode
-from homeassistant.const import LIGHT_LUX, PERCENTAGE
+from homeassistant.const import LIGHT_LUX, PERCENTAGE, UnitOfConductivity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
@@ -13,7 +13,6 @@ from custom_components.plant.const import (
     ATTR_PLANT,
     ATTR_THRESHOLDS,
     DOMAIN,
-    UNIT_CONDUCTIVITY,
     UNIT_DLI,
 )
 
@@ -154,7 +153,10 @@ class TestConductivityThresholds:
         assert threshold is not None
         assert "max" in threshold.name.lower()
         assert "conductivity" in threshold.name.lower()
-        assert threshold.native_unit_of_measurement == UNIT_CONDUCTIVITY
+        assert (
+            threshold.native_unit_of_measurement
+            == UnitOfConductivity.MICROSIEMENS_PER_CM
+        )
         assert threshold.native_step == 50
 
     async def test_min_conductivity_threshold(


### PR DESCRIPTION
## Summary

Use Home Assistant's unit constants instead of custom ones or hardcoded strings:

- Use `UnitOfConductivity.MICROSIEMENS_PER_CM` instead of custom `UNIT_CONDUCTIVITY`
  (was using wrong Unicode: Greek mu U+03BC instead of micro sign U+00B5)
- Use `UnitOfTemperature.CELSIUS/FAHRENHEIT` constants instead of hardcoded `"°C"`/`"°F"` strings
- Fix `UNIT_MICRO_PPFD` and `UNIT_MICRO_DLI` to use correct micro sign character

## Related

This aligns with the fix in Olen/home-assistant-openplantbook#51 which addresses the same Unicode issue.

**Background:** There are two similar-looking characters:
- `μ` Greek small letter mu (U+03BC) - wrong for units
- `µ` Micro sign (U+00B5) - correct for units like µS/cm

Home Assistant uses U+00B5 (micro sign) in its constants.

## Test plan

- [x] All 133 tests pass
- [x] Black formatting check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)