### PR TITLE
Add async_remove_entry for proper entity cleanup on device deletion

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -309,8 +309,10 @@ async def init_integration(
     yield mock_config_entry
 
     # Cleanup: unload the integration to cancel any lingering timers
-    await hass.config_entries.async_unload(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    # Check if entry still exists (test may have removed it)
+    if hass.config_entries.async_get_entry(mock_config_entry.entry_id):
+        await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
 
 @pytest.fixture
@@ -327,5 +329,7 @@ async def init_integration_no_sensors(
     yield mock_config_entry_no_sensors
 
     # Cleanup: unload the integration to cancel any lingering timers
-    await hass.config_entries.async_unload(mock_config_entry_no_sensors.entry_id)
-    await hass.async_block_till_done()
+    # Check if entry still exists (test may have removed it)
+    if hass.config_entries.async_get_entry(mock_config_entry_no_sensors.entry_id):
+        await hass.config_entries.async_unload(mock_config_entry_no_sensors.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Summary

- Add `async_remove_entry()` to properly clean up entity and device registry entries when a plant is permanently removed
- Fix issue where HA would retain cached values/entities after device deletion, causing problems when re-adding similar plants
- Use safer `.pop(key, None)` in `async_unload_entry` to avoid potential KeyError

## Test plan

- [x] Verify `test_remove_entry` test passes
- [x] All existing tests pass (134 tests)
- [ ] Manual testing: Remove a plant device, verify entities/device are cleaned up in registry
- [ ] Manual testing: Re-add a plant with same name, verify fresh values are used

🤖 Generated with [Claude Code](https://claude.com/claude-code)