### PR TITLE
Fix OPB value types and validate image URLs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -230,6 +230,10 @@ def mock_openplantbook_services() -> Generator[MagicMock, None, None]:
                 )
         return None
 
+    async def mock_validate_image_url(self, url):
+        """Mock image URL validation - always return True for test URLs."""
+        return url is not None and url != ""
+
     with patch(
         "homeassistant.core.ServiceRegistry.async_services",
         return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
@@ -238,7 +242,11 @@ def mock_openplantbook_services() -> Generator[MagicMock, None, None]:
             "homeassistant.core.ServiceRegistry.async_call",
             side_effect=mock_service_call,
         ):
-            yield
+            with patch(
+                "custom_components.plant.plant_helpers.PlantHelper.validate_image_url",
+                mock_validate_image_url,
+            ):
+                yield
 
 
 @pytest.fixture

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -363,3 +363,66 @@ class TestPlantHelperEdgeCases:
         # Empty string should be converted to None/empty
         plant_info = result[FLOW_PLANT_INFO]
         assert plant_info[OPB_DISPLAY_PID] == "" or plant_info[OPB_DISPLAY_PID] is None
+
+
+class TestToIntHelper:
+    """Tests for the _to_int helper function."""
+
+    def test_to_int_with_int(self) -> None:
+        """Test _to_int with integer input."""
+        from custom_components.plant.plant_helpers import _to_int
+
+        assert _to_int(42, 0) == 42
+        assert _to_int(0, 10) == 0
+        assert _to_int(-5, 0) == -5
+
+    def test_to_int_with_string(self) -> None:
+        """Test _to_int with string input (common from OPB API)."""
+        from custom_components.plant.plant_helpers import _to_int
+
+        assert _to_int("42", 0) == 42
+        assert _to_int("100", 0) == 100
+        assert _to_int("-10", 0) == -10
+
+    def test_to_int_with_none(self) -> None:
+        """Test _to_int with None returns default."""
+        from custom_components.plant.plant_helpers import _to_int
+
+        assert _to_int(None, 50) == 50
+        assert _to_int(None, 0) == 0
+
+    def test_to_int_with_invalid_string(self) -> None:
+        """Test _to_int with invalid string returns default."""
+        from custom_components.plant.plant_helpers import _to_int
+
+        assert _to_int("not a number", 25) == 25
+        assert _to_int("", 10) == 10
+
+    def test_to_int_with_float_string(self) -> None:
+        """Test _to_int with float string converts via float and rounds."""
+        from custom_components.plant.plant_helpers import _to_int
+
+        # Float strings should be converted via float() then rounded
+        assert _to_int("42.5", 0) == 42  # rounds to nearest even (banker's rounding)
+        assert _to_int("42.6", 0) == 43
+        assert _to_int("42.4", 0) == 42
+
+    def test_to_int_with_float(self) -> None:
+        """Test _to_int with actual float values."""
+        from custom_components.plant.plant_helpers import _to_int
+
+        assert _to_int(42.5, 0) == 42
+        assert _to_int(42.9, 0) == 42  # int() truncates, doesn't round
+
+
+class TestImageValidation:
+    """Tests for image URL validation."""
+
+    async def test_validate_image_url_empty(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Test that empty URL returns False."""
+        helper = PlantHelper(hass)
+        assert await helper.validate_image_url("") is False
+        assert await helper.validate_image_url(None) is False


### PR DESCRIPTION
## Summary

Fixes issues 1 and 2 from #286:

- **Issue 1**: Cast OpenPlantbook values to int - OPB API sometimes returns values as strings
- **Issue 2**: Validate OPB image URLs before use - falls back to empty image if URL returns non-200

## Changes

### _to_int() helper function
- Safely converts any value to int with a default fallback
- Handles string integers: `"42"` → `42`
- Handles float strings: `"42.5"` → `42` (rounded)
- Returns default for invalid values

### validate_image_url() method
- Makes HTTP HEAD request to check if URL is accessible
- Returns `False` for broken URLs (404, timeout, etc.)
- OPB images that return non-200 are replaced with empty string

## Test plan

- [x] All 158 tests pass
- [x] Lint checks pass
- [ ] Manual testing: Add a plant with OPB species that returns string values
- [ ] Manual testing: Add a plant with OPB species that has broken image URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)