### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,19 @@
 
 This integration can automatically fetch data from [OpenPlantBook](https://open.plantbook.io/docs.html) if you are a registered user. Registration is free.
 
-# BREAKING CHANGES
-
->**Warning**
->
-> **This integration is *not* compatible with the original plant integration in HA.**
-
-> **Note** 
->
-> This integration will try to convert all `plant:` entries from `configuration.yaml` to the new format.  After migration, you can (and should) remove your `plant:` entries from your YAML-configuration.   
-> If something goes wrong during migration, delete all the plants from the UI, and correct any problems in your yaml config.  Then they will be migrated again at next restart.  Auto migration will not be done if there are existing plants of the new format already registered in HA.
-
 > **Warning**
-> 
-> Please notice that the `entity_id` of the plants will **NOT** be preserved during auto-migration.  Also, since the "layout" of the new integration is completely different from the old one, you probably have to update and modify any automations, scripts, blueprints etc. you have made based on the old version.
 >
-> Make sure you check you plant settings after the first restart. You can find the configuration options in the Integrations page under Settings in Home Assistant.
+> **This integration is *not* compatible with the original built-in plant integration in Home Assistant.**
 
 Plants are set up in the UI and all configuration of your plants can be managed there or by automations and scripts.
 
-All existing entries in `configuration.yaml` from version 1 will be migrated to the new format automatically.  Notice that some options (like `warn_low_brightness`) will not be migrated over, but can be easily changed in the UI configuration after migration. 
-
-## Plants are now treated as _devices_
+## Plants are treated as _devices_
 
 This means that the main plant entity references other entities, and they are grouped together in the GUI as a single device.
 
 ![image](https://user-images.githubusercontent.com/203184/184302443-9d9fb1f2-4b2a-48bb-a479-1cd3a6e634af.png)
 
-This also means that this version is _not_ compatible with earlier releases from this repository, or with the "plant" integration that is part of your default Home Assistant installation 
-
-## Highlights 
+## Highlights
 
 ### Use the UI to set up plant devices
 * Config Flow is used to set up the plants
@@ -48,9 +31,6 @@ This also means that this version is _not_ compatible with earlier releases from
 
 ![image](https://user-images.githubusercontent.com/203184/184302654-dd1f46ec-d645-4d95-b25d-7202faa944cc.png) ![image](https://user-images.githubusercontent.com/203184/184302847-8e593300-2c68-49f3-803c-8a3f5323f7f8.png)
 
-
-
-
 * Max and min temperature is now dependent on the unit of measurement - currently °C and °F is supported.
   * The values will be updated if you change your units in the Home Assistant settings
 
@@ -64,30 +44,25 @@ What I personally do, to make a clearer separation between the physical sensor a
 And all my plants sensors have entity_ids like `sensor.rose_moisture`, `sensor.chili_conductivity` etc.
 
 That way, if I need to replace a (physical) sensor for e.g. my "Rose" plant, it is very easy to grasp the concept and use
-```
+```yaml
 service: plant.replace_sensor
 data:
   meter_entity: sensor.rose_illumination
   new_sensor: sensor.ble_sensor_12_illumination
 ```
 
-
-
 * The new sensor values are immediately picked up by the plant integration without any need to restart
 
 ### Better handling of species, image and problem triggers
 
 * If you change the species of a plant in the UI, new data are fetched from OpenPlantbook
-* You can optionally select to force a refresh of plant data from OpenPlantbook, even if you do not change the species.  
+* You can optionally select to force a refresh of plant data from OpenPlantbook, even if you do not change the species.
 * Image can also be updated from the UI
 * You can chose to disable problem triggers on all sensors.
 
 ![image](https://user-images.githubusercontent.com/203184/184301674-0461813a-a665-4e93-b5a8-7c9575fe4782.png)
 
 These updates are immediately reflected in HA without restarting anything.
-
-
-
 
 ### Daily Light Integral
 
@@ -118,7 +93,7 @@ For technical details on how DLI is calculated in this integration, see [DLI.md]
 
 * [OpenPlantbook integration](https://github.com/Olen/home-assistant-openplantbook)
 
-OpenPlantbook is not a strict requirement, but a strong recommendation. Without the OpenPlantbook integration, you need to set and adjust all the thresholds for every plant manually.  With the OpenPlantbook integration added, all data is fetched from OpenPlanbook automatically, and it makes setting up and maintaining plants much, much easier.   
+OpenPlantbook is not a strict requirement, but a strong recommendation. Without the OpenPlantbook integration, you need to set and adjust all the thresholds for every plant manually.  With the OpenPlantbook integration added, all data is fetched from OpenPlanbook automatically, and it makes setting up and maintaining plants much, much easier.
 
 # Installation
 
@@ -126,12 +101,12 @@ OpenPlantbook is not a strict requirement, but a strong recommendation. Without 
 
 _Not required, but strongly recommended_
 
-* Upgrade to the latest version of the OpenPlantbook integration: https://github.com/Olen/home-assistant-openplantbook 
-* Set it up, and add your client_id and secret, and test it by using e.g. the `openplantbook.search` service call to search for something.   
+* Upgrade to the latest version of the OpenPlantbook integration: https://github.com/Olen/home-assistant-openplantbook
+* Set it up, and add your client_id and secret, and test it by using e.g. the `openplantbook.search` service call to search for something.
 
 ### Install new flower-card for Lovelace
 
-_Currently this is the only card in lovelace that support this integration.  Feel free to fork and update - or create PRs - for other lovelace cards._ 
+_Currently this is the only card in lovelace that support this integration.  Feel free to fork and update - or create PRs - for other lovelace cards._
 
 * Install verson 2 of the Flower Card from https://github.com/Olen/lovelace-flower-card/
 
@@ -150,21 +125,7 @@ _Currently this is the only card in lovelace that support this integration.  Fee
 * Copy the entire `custom_components/plant/` directory to your server's `<config>/custom_components` directory
 * Restart Home Assistant
 
-
-The first restart might take some time, as it tries to convert all your plants from your configuration.yaml to the new format.  You can follow this process in the log-file.
-
-After Home Assistant is restarted, you will find all your plants under "Settings" - "Devices and Services" - "Devices".  It will take a minute or two before the current values start to update.
-
-> **Warning**
-> The `entity_id` of your plants will probably have changed from the old integration to the new one.  This means that any automations, scripts etc. that use the entity_id or reacts to changes in your plants status will need to be updated.  You probably also need to change the way you read data from the plant device in any such components.
-
-> **Warning**
-> This integration is NOT compatible with the built in original plant component.  This means that e.g. the plant cards etc. in the UI, and any blueprints etc. that are built for the original plant intergation wil NOT work with this version.
-
-
-## Migration from yaml-config
-When the integration is first installed, and HomeAssistant is restarted for the first time, all old `plant:` entries will be migrated.
-The migration will set up all sensors, thresholds etc. from your yaml-config, and if species is set and OpenPlantbook is set up, it will fill in missing data with data from Openplantbook, or from default values if OpenPlantbook is not set up.
+After Home Assistant is restarted, you can add plants under "Settings" - "Devices and Services" - "Add Integration" - "Plant Monitor".
 
 ## Problem reports
 By default, all problems (e.g. every time a sensor reports a value that is above or below the threshold set in "limits"), the plant state will be set to "problem".
@@ -186,8 +147,6 @@ If no matches are found, the configuration flow will continue directly to the ne
 In the following step, the threshold values from OpenPlantbook for the chosen species is pre filled and the image from OpenPlantbook is also displayed.  If you chose the incorrect species, you can uncheck the _"This is the plant I was looking for"_ checkbox, and you will be directed back to the dropdown of species to select another one.
 If no match is found in OpenPlantbook, the thresholds are pre filled with some default values that you probably want to adjust.
 
-If the species is found in OpenPlantbook, the image link is pre filled with the URL to the image there.  You may overrride this with your own links.  Both linkst starting with `http` and local images in your "www"-folder, e.g. `/local/...` are supported.
-
 ### Changing the species / refreshing data
 
 If you later want to change the species of a plant, you do that under "Configuration" of the selected device.
@@ -197,10 +156,36 @@ If you later want to change the species of a plant, you do that under "Configura
 ![image](https://user-images.githubusercontent.com/203184/184328930-8be5fc06-1761-4067-a785-7c46c0b73162.png)
 
 From there, you have the option to set a new species. If you change the species, data for the new species will be automatically fetched from OpenPlantbook.  The species will have to be entered **exactly** as the "pid" in OpenPlantbook (including any punctations etc.).  If the species is found in OpenPlantbook, the thresholds are updated to the new values.  Also, if the current image links to OpenPlantbook or the image link is empty, the URL to the image in OpenPlanbook is added.  If the current image points to a local file, or a different URL, the image is **not** replaced unless "Force refresh" is checked.  The "Species to display" is not changed if you change the species unless "Force refresh" is checked.
-If no species are found in OpenPlantbook, the thresholds and image will be retained with their current values. 
+If no species are found in OpenPlantbook, the thresholds and image will be retained with their current values.
 
 If you just want to refresh the data from OpenPlantbook, without changing the species - for instance if you have private species defined in OpenPlantbook that are not found during setup, you check the "Force refresh" checkbox, and data will be fetched from OpenPlantbook without needing to change the species.  If this checkbox is checked, both the image and the "Species to display" is updated if the species is found in OpenPlantbook.
-If no species is found in OpenPlantbook, nothing is changed. 
+If no species is found in OpenPlantbook, nothing is changed.
+
+## Plant Images
+
+The plant image can be set in two ways:
+
+### 1. From OpenPlantbook (automatic)
+If the species is found in OpenPlantbook, the image URL is automatically fetched. The integration validates that the image URL is accessible before using it.
+
+### 2. Custom images
+
+You can override the image with your own. The following formats are supported:
+
+**HTTP/HTTPS URLs:**
+```
+https://example.com/my-plant.jpg
+```
+
+**Local images in the `www` folder:**
+
+Place your image in your Home Assistant `config/www/` folder (create it if it doesn't exist), then reference it using the `/local/` path:
+```
+/local/plants/my-plant.jpg
+```
+This corresponds to the file at `config/www/plants/my-plant.jpg`.
+
+> **Note:** Only images in the `www` folder are accessible via `/local/`. Arbitrary filesystem paths (like `/mnt/...` or `/media/...`) and media source URIs (`media-source://...`) are **not supported**.
 
 ## FAQ
 
@@ -210,9 +195,9 @@ Home Assistant is _very_ good at remembering old configuration of entities if ne
 
 ### I can add new plants, but the I can't select the correct sensor (typically "Moisture" or "Humidity") from the list of physical sensors
 
-The dropdowns of available sensors are based on the `Device Class` of the originating (physical) sensor.  Quite some integrations in Home Assistant do NOT report the correct `Device Class` for their sensors.  
+The dropdowns of available sensors are based on the `Device Class` of the originating (physical) sensor.  Quite some integrations in Home Assistant do NOT report the correct `Device Class` for their sensors.
 
-E.g. A humidity sensor should have Device Class `SensorDeviceClass.HUMIDITY` and a moisture sensor should use the device class `SensorDeviceClass.MOISTURE`  
+E.g. A humidity sensor should have Device Class `SensorDeviceClass.HUMIDITY` and a moisture sensor should use the device class `SensorDeviceClass.MOISTURE`
 A list of the supported Device Classes is available [here](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes)
 
 If the wrong device class is used for a sensor, it will not show up in the list of available sensors.
@@ -222,7 +207,7 @@ So what you need to do is:
 2) You can create the plant without the sensor in question, and then use the Action (Service Call) ["Replace Sensor"](https://github.com/Olen/homeassistant-plant/?tab=readme-ov-file#easier-to-replace-sensors) to add the physical sensor after the plant is set up.  The checks for replacing a sensor are slightly more relaxed than the initial setup.
 3) Another option is to create template-sensors that incorporate the correct Device Class.  Add something like this to your `configuration.yaml`:
 
-```
+```yaml
 template:
   - sensor:
       - name: "Soil Moisture"                                       # Choose your desired friendly name
@@ -232,8 +217,25 @@ template:
         device_class: "moisture"                                    # This will give it the appropriate icon and state representation
 ```
 
+### My local image path doesn't work
+
+Local images must be placed in your Home Assistant `www` folder and referenced using the `/local/` prefix.
+
+**Correct:** `/local/plants/rose.jpg` (file at `config/www/plants/rose.jpg`)
+
+**Incorrect:**
+- `/mnt/nas/photos/plant.jpg` - Arbitrary filesystem paths are not supported
+- `media-source://media_source/local/plants/plant.jpg` - Media source URIs are not supported
+- `file:///config/www/plants/rose.jpg` - File URIs are not supported
+
+See the [Plant Images](#plant-images) section for details.
+
+### I removed a sensor but it comes back after restart
+
+When you remove a sensor using the `plant.replace_sensor` service (by passing an empty `new_sensor`), the change is now persisted to the configuration. If you're running an older version, update to the latest release.
+
 
 <a href="https://www.buymeacoffee.com/olatho" target="_blank">
-<img src="https://user-images.githubusercontent.com/203184/184674974-db7b9e53-8c5a-40a0-bf71-c01311b36b0a.png" style="height: 50px !important;"> 
+<img src="https://user-images.githubusercontent.com/203184/184674974-db7b9e53-8c5a-40a0-bf71-c01311b36b0a.png" style="height: 50px !important;">
 </a>
 


### PR DESCRIPTION
## Summary

Improves the README documentation based on issue #215 and general cleanup:

## Changes

- **Removed deprecated version 1 migration section** - This was for migrating from YAML config which is no longer relevant
- **Added new "Plant Images" section** - Clearly explains supported image formats:
  - HTTP/HTTPS URLs
  - Local images via `/local/` path (must be in `www` folder)
  - Explicitly notes what is NOT supported (filesystem paths, media-source URIs)
- **Added FAQ entries:**
  - "My local image path doesn't work" - Common user issue
  - "I removed a sensor but it comes back after restart" - Fixed in recent PR
- **Cleaned up repetitive warnings** - Reduced redundancy
- **Simplified installation instructions** - Removed migration-specific content

## Addresses

- #215 - Better handling of local image sources (documentation aspect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)