### PR TITLE
Fix error when DLI sensor is disabled

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -516,8 +516,8 @@ class PlantDevice(Entity):
                 ATTR_SENSOR: self.dli.entity_id,
             },
         }
-        if self.dli.state and self.dli.state != STATE_UNKNOWN:
-            response[ATTR_DLI][ATTR_CURRENT] = float(self.dli.state)
+        if self.dli.native_value is not None and self.dli.native_value != STATE_UNKNOWN:
+            response[ATTR_DLI][ATTR_CURRENT] = float(self.dli.native_value)
 
         return response
 
@@ -770,9 +770,9 @@ class PlantDevice(Entity):
         # Check DLI from the previous day against max/min DLI
         if (
             self.dli is not None
+            and self.dli.native_value is not None
             and self.dli.native_value != STATE_UNKNOWN
             and self.dli.native_value != STATE_UNAVAILABLE
-            and self.dli.state is not None
         ):
             known_state = True
             if float(self.dli.extra_state_attributes["last_period"]) > 0 and float(


### PR DESCRIPTION
## Summary

Fixes the error that occurs when the DLI sensor is disabled:

```
AttributeError: 'NoneType' object has no attribute 'default_language_platform_translations'
```

## Root Cause

When accessing `.state` on a sensor that has `_attr_translation_key` set, Home Assistant tries to look up translations for the unit of measurement. If the entity is disabled, `self.platform` is None and the translation lookup fails.

## Fix

Changed to use `native_value` consistently instead of `.state` when checking DLI sensor values. This avoids triggering the translation lookup on disabled entities.

## Test plan

- [x] All 158 tests pass
- [ ] Manual testing: Disable DLI sensor, verify no errors in logs
- [ ] Manual testing: Plant still updates correctly with DLI disabled

Fixes #210, #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)