### PR TITLE
Add plant name to options dialog

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -518,7 +518,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             )
         ] = cv.boolean
 
-        return self.async_show_form(step_id="init", data_schema=vol.Schema(data_schema))
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(data_schema),
+            description_placeholders={"plant_name": self.plant.name},
+        )
 
 
 async def update_plant_options(

--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Optionen",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Beleuchtungsstärke-Kontrolltage",
           "species": "Species",

--- a/custom_components/plant/translations/dk.json
+++ b/custom_components/plant/translations/dk.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Indstillinger",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Dage til kontrol af lysstyrke",
           "species": "Art",

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "",
+        "description": "Configure options for **{plant_name}**",
         "data": {
           "check_days": "Illuminance check days",
           "species": "Species",

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Opciones",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Días de control de la iluminación",
           "species": "Especie",

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Contrôles des jours d'ensoleillement",
           "species": "Espèce",

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Opciók",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Fényerősség ellenőrzési napok",
           "species": "Faj",

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "Opties",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Lichtsterktecontroledagen",
           "species": "Soort",

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "opcções",
-        "description": "descrição",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Verificar por dias",
           "species": "Especies",

--- a/custom_components/plant/translations/zh-Hans.json
+++ b/custom_components/plant/translations/zh-Hans.json
@@ -121,7 +121,7 @@
     "step": {
       "init": {
         "title": "选项",
-        "description": "",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "光照检查天数",
           "species": "植物种类",


### PR DESCRIPTION
## Summary

Displays the plant name in the Configure/Options dialog so users know which plant they are configuring.

## Before
The options dialog just shows "Options" with no indication of which plant is being configured.

## After
The options dialog now shows "Configure options for **Plant Name**" in the description.

## Changes

- Updated `config_flow.py` to pass the plant name as a description placeholder
- Updated all translation files (en, de, dk, es, fr, hu, nl, pt, zh-Hans) to include the `{plant_name}` placeholder

## Test plan

- [x] All 158 tests pass
- [ ] Manual testing: Open options for a plant, verify the plant name is shown

Fixes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)