### PR TITLE
Add configurable lux to PPFD conversion factor per plant

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -449,6 +449,7 @@ class PlantDevice(Entity):
         self.micro_dli = None
         self.ppfd = None
         self.total_integral = None
+        self.lux_to_ppfd = None
 
         self.conductivity_status = None
         self.illuminance_status = None
@@ -697,6 +698,10 @@ class PlantDevice(Entity):
         """Add the intermediate calculation entities"""
         self.ppfd = ppfd
         self.total_integral = total_integral
+
+    def add_lux_to_ppfd(self, lux_to_ppfd: Entity) -> None:
+        """Add the lux to PPFD conversion factor entity"""
+        self.lux_to_ppfd = lux_to_ppfd
 
     def update(self) -> None:
         """Run on every update of the entities"""

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -72,6 +72,7 @@ TRANSLATION_KEY_MAX_CONDUCTIVITY = "max_conductivity"
 TRANSLATION_KEY_MIN_CONDUCTIVITY = "min_conductivity"
 TRANSLATION_KEY_MAX_HUMIDITY = "max_humidity"
 TRANSLATION_KEY_MIN_HUMIDITY = "min_humidity"
+TRANSLATION_KEY_LUX_TO_PPFD = "lux_to_ppfd"
 
 
 ATTR_MAX_ILLUMINANCE_HISTORY = "max_illuminance"
@@ -163,8 +164,9 @@ OPB_DISPLAY_PID = "display_pid"
 # PPFD to DLI: /1000000 * 3600 to get from microseconds to hours
 PPFD_DLI_FACTOR = 0.0036
 # See https://www.apogeeinstruments.com/conversion-ppfd-to-lux/
-# This equals normal sunlight
+# This equals normal sunlight. Grow lights may need different values.
 DEFAULT_LUX_TO_PPFD = 0.0185
+CONF_LUX_TO_PPFD = "lux_to_ppfd"
 
 
 SERVICE_REPLACE_SENSOR = "replace_sensor"

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -530,9 +530,19 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         See https://community.home-assistant.io/t/light-accumulation-for-xiaomi-flower-sensor/111180/3
         https://www.apogeeinstruments.com/conversion-ppfd-to-lux/
         μmol/m²/s
+
+        The conversion factor is configurable per plant to account for different
+        light sources (sunlight ~0.0185, LED grow lights ~0.014-0.020, HPS ~0.013).
         """
         if value is not None and value != STATE_UNAVAILABLE and value != STATE_UNKNOWN:
-            value = float(value) * DEFAULT_LUX_TO_PPFD / 1000000
+            # Use plant's configurable conversion factor, fallback to default
+            lux_to_ppfd = DEFAULT_LUX_TO_PPFD
+            if (
+                self._plant.lux_to_ppfd is not None
+                and self._plant.lux_to_ppfd.native_value is not None
+            ):
+                lux_to_ppfd = float(self._plant.lux_to_ppfd.native_value)
+            value = float(value) * lux_to_ppfd / 1000000
         else:
             value = None
 

--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Minimale Luftfeuchtigkeit"
+      },
+      "lux_to_ppfd": {
+        "name": "Lux-zu-PPFD-Faktor"
       }
     }
   },

--- a/custom_components/plant/translations/dk.json
+++ b/custom_components/plant/translations/dk.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Minimal luftfugtighed"
+      },
+      "lux_to_ppfd": {
+        "name": "Lux til PPFD faktor"
       }
     }
   },

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Minimum air humidity"
+      },
+      "lux_to_ppfd": {
+        "name": "Lux to PPFD factor"
       }
     }
   },

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Humedad del aire mínima"
+      },
+      "lux_to_ppfd": {
+        "name": "Factor Lux a PPFD"
       }
     }
   },

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Humidité de l'air minimale"
+      },
+      "lux_to_ppfd": {
+        "name": "Facteur Lux vers PPFD"
       }
     }
   },

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Minimális levegő páratartalom"
+      },
+      "lux_to_ppfd": {
+        "name": "Lux-PPFD átalakítási tényező"
       }
     }
   },

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Minimale luchtvochtigheid"
+      },
+      "lux_to_ppfd": {
+        "name": "Lux naar PPFD factor"
       }
     }
   },

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "Humidade do ar mínima"
+      },
+      "lux_to_ppfd": {
+        "name": "Fator Lux para PPFD"
       }
     }
   },

--- a/custom_components/plant/translations/zh-Hans.json
+++ b/custom_components/plant/translations/zh-Hans.json
@@ -63,6 +63,9 @@
       },
       "min_humidity": {
         "name": "最小空气湿度"
+      },
+      "lux_to_ppfd": {
+        "name": "勒克斯转PPFD系数"
       }
     }
   },


### PR DESCRIPTION
## Summary

Adds a new number entity that allows users to configure the lux-to-PPFD conversion factor per plant. This is useful for plants under grow lights which have different spectral characteristics than sunlight.

The conversion factor varies based on light source:
- Sunlight: ~0.0185 (default)
- LED grow lights: ~0.014-0.020 depending on spectrum
- HPS lights: ~0.013
- Fluorescent: ~0.013-0.014

See https://www.apogeeinstruments.com/conversion-ppfd-to-lux/ for reference.

## Changes

- Add `PlantLuxToPpfd` number entity with configurable range 0.001-0.1
- Add `suggested_display_precision=4` for proper GUI display (shows 4 decimal places)
- Update PPFD calculation in sensor.py to use plant's configurable factor
- Add `lux_to_ppfd` attribute to `PlantDevice`
- Add translations for all supported languages (en, de, dk, es, fr, hu, nl, pt, zh-Hans)
- Add comprehensive tests for the new entity

Closes #239

## Test plan

- [x] All 166 tests pass
- [x] hassfest validation passes
- [x] Code formatting passes
- [ ] Manual test: Change lux_to_ppfd value and verify PPFD calculation updates

🤖 Generated with [Claude Code](https://claude.ai/code)