### PR TITLE
Fix entity translations by removing _attr_name

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -193,6 +193,8 @@ class PlantMinMax(RestoreNumber):
     _attr_has_entity_name = True
     _attr_entity_category = EntityCategory.CONFIG
     _attr_mode = NumberMode.BOX
+    # Subclasses should override this for entity_id generation
+    _entity_id_key: str | None = None
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -202,7 +204,7 @@ class PlantMinMax(RestoreNumber):
         self.hass = hass
         self._plant = plantdevice
         self.entity_id = async_generate_entity_id(
-            f"{DOMAIN}.{{}}", self._attr_name, current_ids={}
+            f"{DOMAIN}.{{}}", self._entity_id_key, current_ids={}
         )
         # pylint: disable=no-member
         if (
@@ -296,8 +298,8 @@ class PlantMaxMoisture(PlantMinMax):
     _attr_native_max_value = 100
     _attr_native_min_value = 0
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MAX} {READING_MOISTURE}"
     _attr_translation_key = TRANSLATION_KEY_MAX_MOISTURE
+    _entity_id_key = f"{ATTR_MAX} {READING_MOISTURE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -319,8 +321,8 @@ class PlantMinMoisture(PlantMinMax):
     _attr_native_max_value = 100
     _attr_native_min_value = 0
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MIN} {READING_MOISTURE}"
     _attr_translation_key = TRANSLATION_KEY_MIN_MOISTURE
+    _entity_id_key = f"{ATTR_MIN} {READING_MOISTURE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -341,8 +343,8 @@ class PlantMaxTemperature(PlantMinMax):
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MAX} {READING_TEMPERATURE}"
     _attr_translation_key = TRANSLATION_KEY_MAX_TEMPERATURE
+    _entity_id_key = f"{ATTR_MAX} {READING_TEMPERATURE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -415,8 +417,8 @@ class PlantMinTemperature(PlantMinMax):
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MIN} {READING_TEMPERATURE}"
     _attr_translation_key = TRANSLATION_KEY_MIN_TEMPERATURE
+    _entity_id_key = f"{ATTR_MIN} {READING_TEMPERATURE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -490,8 +492,8 @@ class PlantMaxIlluminance(PlantMinMax):
     _attr_native_max_value = 200000
     _attr_native_min_value = 0
     _attr_native_step = 500
-    _attr_name = f"{ATTR_MAX} {READING_ILLUMINANCE}"
     _attr_translation_key = TRANSLATION_KEY_MAX_ILLUMINANCE
+    _entity_id_key = f"{ATTR_MAX} {READING_ILLUMINANCE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -513,8 +515,8 @@ class PlantMinIlluminance(PlantMinMax):
     _attr_native_max_value = 200000
     _attr_native_min_value = 0
     _attr_native_step = 500
-    _attr_name = f"{ATTR_MIN} {READING_ILLUMINANCE}"
     _attr_translation_key = TRANSLATION_KEY_MIN_ILLUMINANCE
+    _entity_id_key = f"{ATTR_MIN} {READING_ILLUMINANCE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -536,8 +538,8 @@ class PlantMaxDli(PlantMinMax):
     _attr_native_max_value = 100
     _attr_native_min_value = 0
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MAX} {READING_DLI}"
     _attr_translation_key = TRANSLATION_KEY_MAX_DLI
+    _entity_id_key = f"{ATTR_MAX} {READING_DLI}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -559,8 +561,8 @@ class PlantMinDli(PlantMinMax):
     _attr_native_max_value = 100
     _attr_native_min_value = 0
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MIN} {READING_DLI}"
     _attr_translation_key = TRANSLATION_KEY_MIN_DLI
+    _entity_id_key = f"{ATTR_MIN} {READING_DLI}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -582,8 +584,8 @@ class PlantMaxConductivity(PlantMinMax):
     _attr_native_max_value = 3000
     _attr_native_min_value = 0
     _attr_native_step = 50
-    _attr_name = f"{ATTR_MAX} {READING_CONDUCTIVITY}"
     _attr_translation_key = TRANSLATION_KEY_MAX_CONDUCTIVITY
+    _entity_id_key = f"{ATTR_MAX} {READING_CONDUCTIVITY}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -605,8 +607,8 @@ class PlantMinConductivity(PlantMinMax):
     _attr_native_max_value = 3000
     _attr_native_min_value = 0
     _attr_native_step = 50
-    _attr_name = f"{ATTR_MIN} {READING_CONDUCTIVITY}"
     _attr_translation_key = TRANSLATION_KEY_MIN_CONDUCTIVITY
+    _entity_id_key = f"{ATTR_MIN} {READING_CONDUCTIVITY}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -628,8 +630,8 @@ class PlantMaxHumidity(PlantMinMax):
     _attr_native_max_value = 100
     _attr_native_min_value = 0
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MAX} {READING_HUMIDITY}"
     _attr_translation_key = TRANSLATION_KEY_MAX_HUMIDITY
+    _entity_id_key = f"{ATTR_MAX} {READING_HUMIDITY}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -651,8 +653,8 @@ class PlantMinHumidity(PlantMinMax):
     _attr_native_max_value = 100
     _attr_native_min_value = 0
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MIN} {READING_HUMIDITY}"
     _attr_translation_key = TRANSLATION_KEY_MIN_HUMIDITY
+    _entity_id_key = f"{ATTR_MIN} {READING_HUMIDITY}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -674,8 +676,8 @@ class PlantMaxCo2(PlantMinMax):
     _attr_native_max_value = 5000
     _attr_native_min_value = 0
     _attr_native_step = 50
-    _attr_name = f"{ATTR_MAX} {READING_CO2}"
     _attr_translation_key = TRANSLATION_KEY_MAX_CO2
+    _entity_id_key = f"{ATTR_MAX} {READING_CO2}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -697,8 +699,8 @@ class PlantMinCo2(PlantMinMax):
     _attr_native_max_value = 5000
     _attr_native_min_value = 0
     _attr_native_step = 50
-    _attr_name = f"{ATTR_MIN} {READING_CO2}"
     _attr_translation_key = TRANSLATION_KEY_MIN_CO2
+    _entity_id_key = f"{ATTR_MIN} {READING_CO2}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -719,8 +721,8 @@ class PlantMaxSoilTemperature(PlantMinMax):
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MAX} {READING_SOIL_TEMPERATURE}"
     _attr_translation_key = TRANSLATION_KEY_MAX_SOIL_TEMPERATURE
+    _entity_id_key = f"{ATTR_MAX} {READING_SOIL_TEMPERATURE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -786,8 +788,8 @@ class PlantMinSoilTemperature(PlantMinMax):
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
     _attr_native_step = 1
-    _attr_name = f"{ATTR_MIN} {READING_SOIL_TEMPERATURE}"
     _attr_translation_key = TRANSLATION_KEY_MIN_SOIL_TEMPERATURE
+    _entity_id_key = f"{ATTR_MIN} {READING_SOIL_TEMPERATURE}"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -864,8 +866,8 @@ class PlantLuxToPpfd(PlantMinMax):
     _attr_native_min_value = 0.001
     _attr_native_step = 0.0001
     _attr_suggested_display_precision = 4
-    _attr_name = "lux to ppfd"
     _attr_translation_key = TRANSLATION_KEY_LUX_TO_PPFD
+    _entity_id_key = "lux to ppfd"
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -178,6 +178,9 @@ class PlantCurrentStatus(RestoreSensor):
     # Subclasses should override this with their FLOW_SENSOR_* constant
     _config_key: str | None = None
 
+    # Subclasses should override this with their READING_* constant for entity_id generation
+    _entity_id_key: str | None = None
+
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
@@ -189,7 +192,7 @@ class PlantCurrentStatus(RestoreSensor):
         self._tracker = []
         self._follow_external = True
         self.entity_id = async_generate_entity_id(
-            f"{DOMAIN}.{{}}", self._attr_name, current_ids={}
+            f"{DOMAIN}.{{}}", self._entity_id_key, current_ids={}
         )
         if (
             not self._attr_native_value
@@ -412,9 +415,9 @@ class PlantCurrentIlluminance(PlantCurrentStatus):
     _attr_icon = ICON_ILLUMINANCE
     _attr_native_unit_of_measurement = LIGHT_LUX
     _attr_suggested_display_precision = 1
-    _attr_name = READING_ILLUMINANCE
     _attr_translation_key = TRANSLATION_KEY_ILLUMINANCE
     _config_key = FLOW_SENSOR_ILLUMINANCE
+    _entity_id_key = READING_ILLUMINANCE
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -435,9 +438,9 @@ class PlantCurrentConductivity(PlantCurrentStatus):
     _attr_icon = ICON_CONDUCTIVITY
     _attr_native_unit_of_measurement = UnitOfConductivity.MICROSIEMENS_PER_CM
     _attr_suggested_display_precision = 1
-    _attr_name = READING_CONDUCTIVITY
     _attr_translation_key = TRANSLATION_KEY_CONDUCTIVITY
     _config_key = FLOW_SENSOR_CONDUCTIVITY
+    _entity_id_key = READING_CONDUCTIVITY
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -458,9 +461,9 @@ class PlantCurrentMoisture(PlantCurrentStatus):
     _attr_icon = ICON_MOISTURE
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_suggested_display_precision = 1
-    _attr_name = READING_MOISTURE
     _attr_translation_key = TRANSLATION_KEY_MOISTURE
     _config_key = FLOW_SENSOR_MOISTURE
+    _entity_id_key = READING_MOISTURE
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -478,9 +481,9 @@ class PlantCurrentTemperature(PlantCurrentStatus):
     _attr_icon = ICON_TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_suggested_display_precision = 1
-    _attr_name = READING_TEMPERATURE
     _attr_translation_key = TRANSLATION_KEY_TEMPERATURE
     _config_key = FLOW_SENSOR_TEMPERATURE
+    _entity_id_key = READING_TEMPERATURE
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -500,9 +503,9 @@ class PlantCurrentHumidity(PlantCurrentStatus):
     _attr_icon = ICON_HUMIDITY
     _attr_native_unit_of_measurement = PERCENTAGE
     _attr_suggested_display_precision = 1
-    _attr_name = READING_HUMIDITY
     _attr_translation_key = TRANSLATION_KEY_HUMIDITY
     _config_key = FLOW_SENSOR_HUMIDITY
+    _entity_id_key = READING_HUMIDITY
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -520,9 +523,9 @@ class PlantCurrentCo2(PlantCurrentStatus):
     _attr_icon = ICON_CO2
     _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
     _attr_suggested_display_precision = 0
-    _attr_name = READING_CO2
     _attr_translation_key = TRANSLATION_KEY_CO2
     _config_key = FLOW_SENSOR_CO2
+    _entity_id_key = READING_CO2
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -540,9 +543,9 @@ class PlantCurrentSoilTemperature(PlantCurrentStatus):
     _attr_icon = ICON_SOIL_TEMPERATURE
     _attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
     _attr_suggested_display_precision = 1
-    _attr_name = READING_SOIL_TEMPERATURE
     _attr_translation_key = TRANSLATION_KEY_SOIL_TEMPERATURE
     _config_key = FLOW_SENSOR_SOIL_TEMPERATURE
+    _entity_id_key = READING_SOIL_TEMPERATURE
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -563,8 +566,8 @@ class PlantCurrentPpfd(PlantCurrentStatus):
     _attr_entity_registry_visible_default = False
     _attr_icon = ICON_PPFD
     _attr_native_unit_of_measurement = UNIT_PPFD
-    _attr_name = READING_PPFD
     _attr_translation_key = TRANSLATION_KEY_PPFD
+    _entity_id_key = READING_PPFD
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -577,7 +580,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         super().__init__(hass, config, plantdevice)
         self._follow_unit = False
         self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}", self._attr_name, current_ids={}
+            f"{DOMAIN_SENSOR}.{{}}", self._entity_id_key, current_ids={}
         )
 
     def ppfd(self, value: float | int | str) -> float | str:
@@ -672,7 +675,7 @@ class PlantTotalLightIntegral(IntegrationSensor):
         )
         self._unit_of_measurement = UNIT_DLI
         self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}", self.name, current_ids={}
+            f"{DOMAIN_SENSOR}.{{}}", f"Total {READING_PPFD} Integral", current_ids={}
         )
 
     @property
@@ -773,7 +776,7 @@ class PlantDailyLightIntegral(UtilityMeterSensor):
             periodically_resetting=True,
         )
         self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}", self.name, current_ids={}
+            f"{DOMAIN_SENSOR}.{{}}", READING_DLI, current_ids={}
         )
         self._unit_of_measurement = UNIT_DLI
 


### PR DESCRIPTION
## Summary

Fix entity name translations not working because `_attr_name` takes precedence over `_attr_translation_key`.

## Problem

When both `_attr_name` and `_attr_translation_key` are set on an entity, Home Assistant uses `_attr_name` for the display name and ignores the translation. This meant entity names were always showing in English regardless of the user's language setting.

## Solution

- Remove `_attr_name` from all sensor and number entities that have `_attr_translation_key`
- Add `_entity_id_key` class attribute to preserve existing entity IDs (using the original `READING_*` constants)
- Entity IDs remain unchanged to avoid breaking existing dashboards and automations

## Changes

- `sensor.py`: Remove `_attr_name`, add `_entity_id_key` to all `PlantCurrentStatus` subclasses
- `number.py`: Remove `_attr_name`, add `_entity_id_key` to all `PlantMinMax` subclasses

## Test plan

- [x] All 174 tests pass
- [x] Code formatting passes (`black --check`)
- [ ] Manual testing: Verify entity names display correctly in non-English languages

🤖 Generated with [Claude Code](https://claude.ai/code)