### PR TITLE
Document configurable Lux to PPFD conversion factor

### DIFF
--- a/DLI.md
+++ b/DLI.md
@@ -38,14 +38,32 @@ This produces PPFD in mol/m²/s.
 
 #### Conversion Factor
 
-The conversion factor of `0.0185` is an approximation that works well for natural sunlight. The actual conversion varies by light source:
+The default conversion factor of `0.0185` is an approximation that works well for natural sunlight. The actual conversion varies by light source:
 
 | Light Source | Conversion Factor (μmol/m²/s per lux) |
 |--------------|---------------------------------------|
 | Sunlight     | ~0.0185                               |
 | Metal Halide | ~0.014                                |
+| HPS          | ~0.013                                |
 | Fluorescent  | ~0.013-0.014                          |
-| LED          | Varies by spectrum                    |
+| LED          | ~0.014-0.020 (varies by spectrum)     |
+
+#### Configuring the Conversion Factor
+
+Since the conversion factor varies significantly depending on your light source, you can adjust it per plant using the **Lux to PPFD factor** entity. This is particularly useful for:
+
+- Indoor plants under grow lights
+- Plants in greenhouses with artificial supplemental lighting
+- Any situation where the default sunlight factor doesn't match your light source
+
+To adjust the factor:
+1. Go to your plant's device page
+2. Find the "Lux to PPFD factor" number entity under Configuration
+3. Adjust the value based on your light source (see table above)
+
+The factor can be set between 0.001 and 0.1, with a default of 0.0185.
+
+**Example:** If you're using LED grow lights with a conversion factor of 0.017, set the "Lux to PPFD factor" to `0.017` for more accurate DLI readings.
 
 References:
 - https://www.apogeeinstruments.com/conversion-ppfd-to-lux/
@@ -126,7 +144,7 @@ This value (33.3 mol/m²/d) represents a bright sunny day, which is appropriate 
 
 ## Limitations
 
-1. **Light Source Dependency:** The conversion factor is optimized for sunlight. Indoor plants under artificial lighting may have less accurate DLI readings depending on the light spectrum.
+1. **Light Source Dependency:** The default conversion factor is optimized for sunlight. Indoor plants under artificial lighting may have less accurate DLI readings depending on the light spectrum. You can adjust the "Lux to PPFD factor" per plant to compensate for different light sources (see [Configuring the Conversion Factor](#configuring-the-conversion-factor)).
 
 2. **Sensor Accuracy:** The accuracy of the DLI calculation depends on the accuracy of the illuminance sensor being used.
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ These updates are immediately reflected in HA without restarting anything.
 
 See https://en.wikipedia.org/wiki/Daily_light_integral for what DLI means.
 
+#### Configurable Lux to PPFD Conversion
+
+The DLI calculation converts illuminance (lux) to PPFD using a conversion factor. The default factor (0.0185) is optimized for sunlight, but different light sources have different conversion factors. You can now adjust this per plant using the **"Lux to PPFD factor"** configuration entity.
+
+This is useful for:
+- Indoor plants under LED grow lights
+- Greenhouses with supplemental lighting
+- Any situation where the default sunlight factor doesn't match your light source
+
 For technical details on how DLI is calculated in this integration, see [DLI.md](DLI.md).
 
 ### More flexible lovelace card


### PR DESCRIPTION
## Summary

Add documentation for the "Lux to PPFD factor" configuration entity that was added in PR #311.

## Changes

### README.md
- Added section under "Daily Light Integral" explaining the configurable conversion factor
- Explains use cases (LED grow lights, greenhouses, etc.)

### DLI.md
- Updated conversion factor table with HPS and more detailed LED info
- Added new "Configuring the Conversion Factor" section with step-by-step instructions
- Updated Limitations section to reference the configurable factor

## Test plan

- [x] Documentation renders correctly in GitHub preview
- [x] Links to anchors work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)