### PR TITLE
Capitalize first letter of species name for binomial nomenclature

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -413,11 +413,17 @@ class PlantDevice(Entity):
             ATTR_SPECIES, self._config.data[FLOW_PLANT_INFO].get(ATTR_SPECIES)
         )
         # Get display_species from options or from initial config
-        self.display_species = (
+        # Capitalize first letter for proper binomial nomenclature (genus capitalized)
+        raw_display_species = (
             self._config.options.get(
                 OPB_DISPLAY_PID, self._config.data[FLOW_PLANT_INFO].get(OPB_DISPLAY_PID)
             )
             or self.species
+        )
+        self.display_species = (
+            raw_display_species[0].upper() + raw_display_species[1:]
+            if raw_display_species
+            else ""
         )
         self._attr_unique_id = self._config.entry_id
 

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -591,7 +591,12 @@ async def update_plant_options(
 
     new_display_species = entry.options.get(OPB_DISPLAY_PID)
     if new_display_species is not None:
-        plant.display_species = new_display_species
+        # Capitalize first letter for proper binomial nomenclature
+        plant.display_species = (
+            new_display_species[0].upper() + new_display_species[1:]
+            if new_display_species
+            else ""
+        )
 
     new_species = entry.options.get(ATTR_SPECIES)
     force_new_species = entry.options.get(FLOW_FORCE_SPECIES_UPDATE)
@@ -611,7 +616,11 @@ async def update_plant_options(
         if plant_config[DATA_SOURCE] == DATA_SOURCE_PLANTBOOK:
             plant.species = new_species
             plant.add_image(plant_config[FLOW_PLANT_INFO][ATTR_ENTITY_PICTURE])
-            plant.display_species = plant_config[FLOW_PLANT_INFO][OPB_DISPLAY_PID]
+            # Capitalize first letter for proper binomial nomenclature
+            opb_display = plant_config[FLOW_PLANT_INFO][OPB_DISPLAY_PID]
+            plant.display_species = (
+                opb_display[0].upper() + opb_display[1:] if opb_display else ""
+            )
             for key, value in plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].items():
                 set_entity = getattr(plant, key)
                 _LOGGER.debug("Entity: %s To: %s", set_entity, value)


### PR DESCRIPTION
## Summary

Ensure species names follow proper binomial nomenclature by capitalizing the first letter (genus name).

## Problem

Species names like "monstera deliciosa" should display as "Monstera deliciosa" (genus capitalized, species epithet lowercase).

## Changes

- `__init__.py`: Capitalize first letter when setting `display_species`
- `config_flow.py`: Capitalize first letter when updating `display_species` via options flow
- Added 2 tests to verify capitalization behavior

## Fixes

Fixes Olen/lovelace-flower-card#173

## Test plan

- [x] All 176 tests pass (2 new tests added)
- [x] Code formatting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)