### PR TITLE
Use correct unit for Total Light Integral sensor

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -131,6 +131,7 @@ DATA_UPDATED = "plant_data_updated"
 
 UNIT_PPFD = "mol/s⋅m²"
 UNIT_MICRO_PPFD = "µmol/s⋅m²"
+UNIT_TOTAL_LIGHT_INTEGRAL = "mol/m²"
 UNIT_DLI = "mol/d⋅m²"
 UNIT_MICRO_DLI = "µmol/d⋅m²"
 # Note: For conductivity, use UnitOfConductivity.MICROSIEMENS_PER_CM from homeassistant.const

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -96,6 +96,7 @@ from .const import (
     TRANSLATION_KEY_TOTAL_LIGHT_INTEGRAL,
     UNIT_DLI,
     UNIT_PPFD,
+    UNIT_TOTAL_LIGHT_INTEGRAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -685,13 +686,14 @@ class PlantTotalLightIntegral(IntegrationSensor):
         )
 
     def _calculate_unit(self, source_unit: str) -> str:
-        """Override unit calculation to always return DLI unit.
+        """Override unit calculation to return the correct integrated unit.
 
         The parent IntegrationSensor tries to derive the unit by appending
         the time unit to the source unit (e.g., "mol/s⋅m²" + "s" = "mol/s⋅m²s").
-        We override this to always return the correct DLI unit.
+        We override this to return mol/m² (the seconds cancel out when
+        integrating mol/s⋅m² over time).
         """
-        return UNIT_DLI
+        return UNIT_TOTAL_LIGHT_INTEGRAL
 
     async def async_added_to_hass(self) -> None:
         """Handle entity which will be added."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -18,6 +18,7 @@ from custom_components.plant.const import (
     DOMAIN,
     UNIT_DLI,
     UNIT_PPFD,
+    UNIT_TOTAL_LIGHT_INTEGRAL,
 )
 
 from .common import set_sensor_state
@@ -415,8 +416,8 @@ class TestTotalLightIntegralSensor:
         """Test total integral sensor has unit calculation override.
 
         The IntegrationSensor parent class calculates units by appending time
-        unit to source unit. We override _calculate_unit to always return
-        the correct DLI unit.
+        unit to source unit. We override _calculate_unit to return mol/m²
+        (the seconds cancel out when integrating mol/s⋅m² over time).
         """
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
@@ -426,8 +427,11 @@ class TestTotalLightIntegralSensor:
         # Verify the class has the _calculate_unit method override
         assert hasattr(plant.total_integral, "_calculate_unit")
         assert callable(plant.total_integral._calculate_unit)
-        # Verify it returns the correct DLI unit regardless of input
-        assert plant.total_integral._calculate_unit("mol/s⋅m²") == UNIT_DLI
+        # Verify it returns the correct unit (mol/m², not mol/d⋅m² which is for DLI)
+        assert (
+            plant.total_integral._calculate_unit("mol/s⋅m²")
+            == UNIT_TOTAL_LIGHT_INTEGRAL
+        )
 
 
 class TestSensorDeviceInfo:


### PR DESCRIPTION
## Summary

Differentiates the units between Total Light Integral and DLI sensors:

- **Total Light Integral**: `mol/m²` - cumulative total that never resets
- **DLI**: `mol/d⋅m²` - daily total that resets each day

Previously both used `mol/d⋅m²` which was technically incorrect for the Total Light Integral since it's a running total with no time reference (the seconds cancel out when integrating `mol/s⋅m²` over time).

## Test plan

- [x] All existing tests pass
- [x] Updated unit tests verify the correct units
- [ ] Manual testing: verify Total Light Integral shows `mol/m²` and DLI shows `mol/d⋅m²`

🤖 Generated with [Claude Code](https://claude.ai/code)