### PR TITLE
Release 2026.1.1 (stable)

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.1.1-beta1"
+  "version": "2026.1.1"
 }


### PR DESCRIPTION
## Summary
- Bump version from 2026.1.1-beta1 to 2026.1.1 (stable release)
- No negative feedback received from beta testing

Merging will trigger the automated release workflow.