### PR TITLE
Bump version to 2026.2.0-beta1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.1.1"
+  "version": "2026.2.0-beta1"
 }


### PR DESCRIPTION
## Summary
- Bump version to 2026.2.0-beta1 for pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)