### PR TITLE
feat: restructure config flow UX (#129)

### DIFF
--- a/custom_components/plant/strings.json
+++ b/custom_components/plant/strings.json
@@ -70,15 +70,10 @@
     "step": {
       "user": {
         "title": "Configure a plant",
-        "description": "If you can't find the correct sensors in the dropdown menus, sensors can be added after the plant is set up",
+        "description": "Enter a name for your plant. Optionally enter a species to search OpenPlantbook.",
         "data": {
           "name": "Plant name",
-          "species": "Species",
-          "temperature_sensor": "Temperature sensor",
-          "moisture_sensor": "Soil moisture sensor",
-          "conductivity_sensor": "Conductivity sensor",
-          "illuminance_sensor": "Illuminance sensor",
-          "humidity_sensor": "Air humidity sensor"
+          "species": "Species"
         },
         "data_description": {
           "species": "Will be used for searching OpenPlantbook"
@@ -88,10 +83,24 @@
         "title": "Select species from OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Search for a different species",
           "species": "Species"
         },
         "menu_options": {
           "user": "Go back"
+        }
+      },
+      "sensors": {
+        "title": "Select sensors",
+        "description": "All sensors are optional. Sensors can also be added or changed later.",
+        "data": {
+          "temperature_sensor": "Temperature sensor",
+          "moisture_sensor": "Soil moisture sensor",
+          "conductivity_sensor": "Conductivity sensor",
+          "illuminance_sensor": "Illuminance sensor",
+          "humidity_sensor": "Air humidity sensor",
+          "co2_sensor": "CO2 sensor",
+          "soil_temperature_sensor": "Soil temperature sensor"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Eine Pflanze konfigurieren",
-        "description": "Wenn Sie in den Dropdown-Menüs nicht die richtigen Sensoren finden, können Sie die Sensoren nach Abschluss der Installation hinzufügen",
+        "description": "Geben Sie einen Namen für Ihre Pflanze ein. Optional können Sie eine Art eingeben, um in OpenPlantbook zu suchen.",
         "data": {
           "name": "Pflanzenname",
-          "species": "Art",
-          "temperature_sensor": "Temperatursensor",
-          "moisture_sensor": "Bodenfeuchtesensor",
-          "conductivity_sensor": "Leitfähigkeitssensor",
-          "illuminance_sensor": "Beleuchtungsstärkesensor",
-          "humidity_sensor": "Luftfeuchtigkeitssensor",
-          "co2_sensor": "CO2-Sensor",
-          "soil_temperature_sensor": "Bodentemperatursensor"
+          "species": "Art"
         },
         "data_description": {
           "species": "Wird für die Suche in OpenPlantbook verwendet"
@@ -114,10 +107,24 @@
         "title": "Art aus OpenPlantbook auswählen",
         "description": "{desc}",
         "data": {
+          "search_for": "Nach einer anderen Art suchen",
           "species": "Art"
         },
         "menu_options": {
           "user": "Zurück"
+        }
+      },
+      "sensors": {
+        "title": "Sensoren auswählen",
+        "description": "Alle Sensoren sind optional. Sensoren können auch später hinzugefügt oder geändert werden.",
+        "data": {
+          "temperature_sensor": "Temperatursensor",
+          "moisture_sensor": "Bodenfeuchtesensor",
+          "conductivity_sensor": "Leitfähigkeitssensor",
+          "illuminance_sensor": "Beleuchtungsstärkesensor",
+          "humidity_sensor": "Luftfeuchtigkeitssensor",
+          "co2_sensor": "CO2-Sensor",
+          "soil_temperature_sensor": "Bodentemperatursensor"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/dk.json
+++ b/custom_components/plant/translations/dk.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Konfigurer en plante",
-        "description": "Hvis du ikke finder de rigtige sensorer i rullemenuerne, kan du tilføje dem efter installationen er fuldført",
+        "description": "Indtast et navn til din plante. Indtast eventuelt en art for at søge i OpenPlantbook.",
         "data": {
           "name": "Plantenavn",
-          "species": "Art",
-          "temperature_sensor": "Temperatursensor",
-          "moisture_sensor": "Jordfugtighedssensor",
-          "conductivity_sensor": "Ledningsevnesensor",
-          "illuminance_sensor": "Lysstyrkesensor",
-          "humidity_sensor": "Luftfugtighedssensor",
-          "co2_sensor": "CO2-sensor",
-          "soil_temperature_sensor": "Jordtemperatursensor"
+          "species": "Art"
         },
         "data_description": {
           "species": "Bruges til søgning i OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Vælg art fra OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Søg efter en anden art",
           "species": "Art"
         },
         "menu_options": {
           "user": "Tilbage"
+        }
+      },
+      "sensors": {
+        "title": "Vælg sensorer",
+        "description": "Alle sensorer er valgfrie. Sensorer kan også tilføjes eller ændres senere.",
+        "data": {
+          "temperature_sensor": "Temperatursensor",
+          "moisture_sensor": "Jordfugtighedssensor",
+          "conductivity_sensor": "Ledningsevnesensor",
+          "illuminance_sensor": "Lysstyrkesensor",
+          "humidity_sensor": "Luftfugtighedssensor",
+          "co2_sensor": "CO2-sensor",
+          "soil_temperature_sensor": "Jordtemperatursensor"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Configure a plant",
-        "description": "If you can't find the correct sensors in the dropdown menus, sensors can be added after the plant is set up",
+        "description": "Enter a name for your plant. Optionally enter a species to search OpenPlantbook.",
         "data": {
           "name": "Plant name",
-          "species": "Species",
-          "temperature_sensor": "Temperature sensor",
-          "moisture_sensor": "Soil moisture sensor",
-          "conductivity_sensor": "Conductivity sensor",
-          "illuminance_sensor": "Illuminance sensor",
-          "humidity_sensor": "Air humidity sensor",
-          "co2_sensor": "CO2 sensor",
-          "soil_temperature_sensor": "Soil temperature sensor"
+          "species": "Species"
         },
         "data_description": {
           "species": "Will be used for searching OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Select species from OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Search for a different species",
           "species": "Species"
         },
         "menu_options": {
           "user": "Go back"
+        }
+      },
+      "sensors": {
+        "title": "Select sensors",
+        "description": "All sensors are optional. Sensors can also be added or changed later.",
+        "data": {
+          "temperature_sensor": "Temperature sensor",
+          "moisture_sensor": "Soil moisture sensor",
+          "conductivity_sensor": "Conductivity sensor",
+          "illuminance_sensor": "Illuminance sensor",
+          "humidity_sensor": "Air humidity sensor",
+          "co2_sensor": "CO2 sensor",
+          "soil_temperature_sensor": "Soil temperature sensor"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Configurar una planta",
-        "description": "Si no puede encontrar los sensores correctos en los menús desplegables, los sensores se pueden añadir después de configurar la planta",
+        "description": "Introduzca un nombre para su planta. Opcionalmente introduzca una especie para buscar en OpenPlantbook.",
         "data": {
           "name": "Nombre de la planta",
-          "species": "Especie",
-          "temperature_sensor": "Sensor de temperatura",
-          "moisture_sensor": "Sensor de humedad del suelo",
-          "conductivity_sensor": "Sensor de conductividad",
-          "illuminance_sensor": "Sensor de iluminación",
-          "humidity_sensor": "Sensor de humedad del aire",
-          "co2_sensor": "Sensor de CO2",
-          "soil_temperature_sensor": "Sensor de temperatura del suelo"
+          "species": "Especie"
         },
         "data_description": {
           "species": "Se usará para buscar en OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Seleccionar especie en OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Buscar una especie diferente",
           "species": "Especie"
         },
         "menu_options": {
           "user": "Volver atrás"
+        }
+      },
+      "sensors": {
+        "title": "Seleccionar sensores",
+        "description": "Todos los sensores son opcionales. Los sensores también se pueden añadir o cambiar más tarde.",
+        "data": {
+          "temperature_sensor": "Sensor de temperatura",
+          "moisture_sensor": "Sensor de humedad del suelo",
+          "conductivity_sensor": "Sensor de conductividad",
+          "illuminance_sensor": "Sensor de iluminación",
+          "humidity_sensor": "Sensor de humedad del aire",
+          "co2_sensor": "Sensor de CO2",
+          "soil_temperature_sensor": "Sensor de temperatura del suelo"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Configurer une plante",
-        "description": "Si vous ne trouvez pas les capteurs appropriés dans les menus déroulants, les capteurs peuvent être ajoutés après la configuration de la plante",
+        "description": "Entrez un nom pour votre plante. Vous pouvez optionnellement entrer une espèce pour rechercher dans OpenPlantbook.",
         "data": {
           "name": "Nom de la plante",
-          "species": "Espèce",
-          "temperature_sensor": "Capteur de température",
-          "moisture_sensor": "Capteur d'humidité du sol",
-          "conductivity_sensor": "Capteur de conductivité",
-          "illuminance_sensor": "Capteur de luminosité",
-          "humidity_sensor": "Capteur d'humidité de l'air",
-          "co2_sensor": "Capteur de CO2",
-          "soil_temperature_sensor": "Capteur de température du sol"
+          "species": "Espèce"
         },
         "data_description": {
           "species": "Sera utilisé pour la recherche dans OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Sélectionner une espèce dans OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Rechercher une autre espèce",
           "species": "Espèce"
         },
         "menu_options": {
           "user": "Revenir en arrière"
+        }
+      },
+      "sensors": {
+        "title": "Sélectionner les capteurs",
+        "description": "Tous les capteurs sont optionnels. Les capteurs peuvent également être ajoutés ou modifiés ultérieurement.",
+        "data": {
+          "temperature_sensor": "Capteur de température",
+          "moisture_sensor": "Capteur d'humidité du sol",
+          "conductivity_sensor": "Capteur de conductivité",
+          "illuminance_sensor": "Capteur de luminosité",
+          "humidity_sensor": "Capteur d'humidité de l'air",
+          "co2_sensor": "Capteur de CO2",
+          "soil_temperature_sensor": "Capteur de température du sol"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Növény konfigurálása",
-        "description": "Ha nem találja a megfelelő érzékelőket a legördülő menüben, az érzékelőket a növény beállítása után is hozzáadhatja",
+        "description": "Adjon meg egy nevet a növényének. Opcionálisan adjon meg egy fajt az OpenPlantbook-ban való kereséshez.",
         "data": {
           "name": "Növény neve",
-          "species": "Faj",
-          "temperature_sensor": "Hőmérséklet-érzékelő",
-          "moisture_sensor": "Talajnedvesség-érzékelő",
-          "conductivity_sensor": "Vezetőképesség-érzékelő",
-          "illuminance_sensor": "Fényérzékelő",
-          "humidity_sensor": "Páratartalom-érzékelő",
-          "co2_sensor": "CO2-érzékelő",
-          "soil_temperature_sensor": "Talajhőmérséklet-érzékelő"
+          "species": "Faj"
         },
         "data_description": {
           "species": "OpenPlantbook keresésére lesz felhasználva"
@@ -114,10 +107,24 @@
         "title": "Faj kiválasztása az OpenPlantbook-ból",
         "description": "{desc}",
         "data": {
+          "search_for": "Másik faj keresése",
           "species": "Faj"
         },
         "menu_options": {
           "user": "Vissza"
+        }
+      },
+      "sensors": {
+        "title": "Érzékelők kiválasztása",
+        "description": "Minden érzékelő opcionális. Az érzékelők később is hozzáadhatók vagy módosíthatók.",
+        "data": {
+          "temperature_sensor": "Hőmérséklet-érzékelő",
+          "moisture_sensor": "Talajnedvesség-érzékelő",
+          "conductivity_sensor": "Vezetőképesség-érzékelő",
+          "illuminance_sensor": "Fényérzékelő",
+          "humidity_sensor": "Páratartalom-érzékelő",
+          "co2_sensor": "CO2-érzékelő",
+          "soil_temperature_sensor": "Talajhőmérséklet-érzékelő"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/nb.json
+++ b/custom_components/plant/translations/nb.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Konfigurer en plante",
-        "description": "Hvis du ikke finner de riktige sensorene i nedtrekksmenyene, kan du legge til sensorene etter at planten er satt opp",
+        "description": "Skriv inn et navn for planten din. Du kan eventuelt skrive inn en art for å søke i OpenPlantbook.",
         "data": {
           "name": "Plantenavn",
-          "species": "Art",
-          "temperature_sensor": "Temperatursensor",
-          "moisture_sensor": "Jordfuktighetssensor",
-          "conductivity_sensor": "Ledningsevnesensor",
-          "illuminance_sensor": "Lyssensor",
-          "humidity_sensor": "Luftfuktighetssensor",
-          "co2_sensor": "CO2-sensor",
-          "soil_temperature_sensor": "Jordtemperatursensor"
+          "species": "Art"
         },
         "data_description": {
           "species": "Brukes for å søke i OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Velg art fra OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Søk etter en annen art",
           "species": "Art"
         },
         "menu_options": {
           "user": "Tilbake"
+        }
+      },
+      "sensors": {
+        "title": "Velg sensorer",
+        "description": "Alle sensorer er valgfrie. Sensorer kan også legges til eller endres senere.",
+        "data": {
+          "temperature_sensor": "Temperatursensor",
+          "moisture_sensor": "Jordfuktighetssensor",
+          "conductivity_sensor": "Ledningsevnesensor",
+          "illuminance_sensor": "Lyssensor",
+          "humidity_sensor": "Luftfuktighetssensor",
+          "co2_sensor": "CO2-sensor",
+          "soil_temperature_sensor": "Jordtemperatursensor"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Stel een plant in",
-        "description": "Als je de juiste sensoren niet kunt vinden in de dropdown menu's, dan kunnen de sensoren toegevoegd worden nadat de installatie voltooid is",
+        "description": "Voer een naam in voor uw plant. Voer optioneel een soort in om te zoeken in OpenPlantbook.",
         "data": {
           "name": "Plantnaam",
-          "species": "Soort",
-          "temperature_sensor": "Temperatuursensor",
-          "moisture_sensor": "Bodemvochtsensor",
-          "conductivity_sensor": "Geleidbaarheidssensor",
-          "illuminance_sensor": "Lichtsensor",
-          "humidity_sensor": "Luchtvochtigheidssensor",
-          "co2_sensor": "CO2-sensor",
-          "soil_temperature_sensor": "Bodemtemperatuursensor"
+          "species": "Soort"
         },
         "data_description": {
           "species": "Wordt gebruikt voor het zoeken in OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Selecteer soort uit OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Zoek naar een andere soort",
           "species": "Soort"
         },
         "menu_options": {
           "user": "Terug"
+        }
+      },
+      "sensors": {
+        "title": "Selecteer sensoren",
+        "description": "Alle sensoren zijn optioneel. Sensoren kunnen ook later worden toegevoegd of gewijzigd.",
+        "data": {
+          "temperature_sensor": "Temperatuursensor",
+          "moisture_sensor": "Bodemvochtsensor",
+          "conductivity_sensor": "Geleidbaarheidssensor",
+          "illuminance_sensor": "Lichtsensor",
+          "humidity_sensor": "Luchtvochtigheidssensor",
+          "co2_sensor": "CO2-sensor",
+          "soil_temperature_sensor": "Bodemtemperatuursensor"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "Configurar uma planta",
-        "description": "Caso não consiga encontrar o sensor correto no dropdown, pode personalizar posteriormente",
+        "description": "Introduza um nome para a sua planta. Opcionalmente introduza uma espécie para pesquisar no OpenPlantbook.",
         "data": {
           "name": "Nome da planta",
-          "species": "Espécie",
-          "temperature_sensor": "Sensor de temperatura",
-          "moisture_sensor": "Sensor de humidade do solo",
-          "conductivity_sensor": "Sensor de condutividade",
-          "illuminance_sensor": "Sensor de iluminação",
-          "humidity_sensor": "Sensor de humidade do ar",
-          "co2_sensor": "Sensor de CO2",
-          "soil_temperature_sensor": "Sensor de temperatura do solo"
+          "species": "Espécie"
         },
         "data_description": {
           "species": "Será usado para pesquisar no OpenPlantbook"
@@ -114,10 +107,24 @@
         "title": "Selecionar espécie do OpenPlantbook",
         "description": "{desc}",
         "data": {
+          "search_for": "Pesquisar uma espécie diferente",
           "species": "Espécie"
         },
         "menu_options": {
           "user": "Voltar"
+        }
+      },
+      "sensors": {
+        "title": "Selecionar sensores",
+        "description": "Todos os sensores são opcionais. Os sensores também podem ser adicionados ou alterados mais tarde.",
+        "data": {
+          "temperature_sensor": "Sensor de temperatura",
+          "moisture_sensor": "Sensor de humidade do solo",
+          "conductivity_sensor": "Sensor de condutividade",
+          "illuminance_sensor": "Sensor de iluminação",
+          "humidity_sensor": "Sensor de humidade do ar",
+          "co2_sensor": "Sensor de CO2",
+          "soil_temperature_sensor": "Sensor de temperatura do solo"
         }
       },
       "limits": {

--- a/custom_components/plant/translations/zh-Hans.json
+++ b/custom_components/plant/translations/zh-Hans.json
@@ -94,17 +94,10 @@
     "step": {
       "user": {
         "title": "配置植物",
-        "description": "如果在下拉菜单中找不到正确的传感器，可以在植物设置完成后添加传感器",
+        "description": "输入植物名称。可选择输入种类以在OpenPlantbook中搜索。",
         "data": {
           "name": "植物名称",
-          "species": "植物种类",
-          "temperature_sensor": "温度传感器",
-          "moisture_sensor": "土壤湿度传感器",
-          "conductivity_sensor": "电导率传感器",
-          "illuminance_sensor": "光照传感器",
-          "humidity_sensor": "空气湿度传感器",
-          "co2_sensor": "二氧化碳传感器",
-          "soil_temperature_sensor": "土壤温度传感器"
+          "species": "植物种类"
         },
         "data_description": {
           "species": "将用于在OpenPlantbook中搜索"
@@ -114,10 +107,24 @@
         "title": "从OpenPlantbook选择种类",
         "description": "{desc}",
         "data": {
+          "search_for": "搜索其他种类",
           "species": "植物种类"
         },
         "menu_options": {
           "user": "返回"
+        }
+      },
+      "sensors": {
+        "title": "选择传感器",
+        "description": "所有传感器都是可选的。传感器也可以在之后添加或更改。",
+        "data": {
+          "temperature_sensor": "温度传感器",
+          "moisture_sensor": "土壤湿度传感器",
+          "conductivity_sensor": "电导率传感器",
+          "illuminance_sensor": "光照传感器",
+          "humidity_sensor": "空气湿度传感器",
+          "co2_sensor": "二氧化碳传感器",
+          "soil_temperature_sensor": "土壤温度传感器"
         }
       },
       "limits": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -572,16 +572,10 @@ class TestSensorEntityIdRename:
         # Verify the integral sensor is tracking the PPFD sensor
         assert integral_sensor._source_entity == old_entity_id
 
-        # Fire entity registry update event (simulating a rename)
-        hass.bus.async_fire(
-            EVENT_ENTITY_REGISTRY_UPDATED,
-            {
-                "action": "update",
-                "entity_id": new_entity_id,
-                "old_entity_id": old_entity_id,
-                "changes": {"entity_id": new_entity_id},
-            },
-        )
+        # Rename the entity via the entity registry so HA's internal handlers
+        # can find the registry entry (avoids AssertionError in teardown)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_update_entity(old_entity_id, new_entity_id=new_entity_id)
         await hass.async_block_till_done()
 
         # Verify the integral sensor updated its source reference
@@ -604,16 +598,10 @@ class TestSensorEntityIdRename:
         # Verify the DLI sensor is tracking the integral sensor
         assert dli_sensor._sensor_source_id == old_entity_id
 
-        # Fire entity registry update event (simulating a rename)
-        hass.bus.async_fire(
-            EVENT_ENTITY_REGISTRY_UPDATED,
-            {
-                "action": "update",
-                "entity_id": new_entity_id,
-                "old_entity_id": old_entity_id,
-                "changes": {"entity_id": new_entity_id},
-            },
-        )
+        # Rename the entity via the entity registry so HA's internal handlers
+        # can find the registry entry (avoids AssertionError in teardown)
+        ent_reg = er.async_get(hass)
+        ent_reg.async_update_entity(old_entity_id, new_entity_id=new_entity_id)
         await hass.async_block_till_done()
 
         # Verify the DLI sensor updated its source reference


### PR DESCRIPTION
## Summary

- Restructures the plant setup config flow to separate species search from sensor selection, improving UX as requested in #129
- New flow: **Name/Species → OPB species selection → Sensor selection → Threshold limits**
- Species selection now includes a re-search field so users can search for a different species without going back
- Sensor selection is a dedicated step where all 7 sensors are optional
- Threshold limits are now conditional — only shows thresholds for sensor types selected in the previous step (shows all if none selected)
- Updated all 10 translation files (de, dk, en, es, fr, hu, nb, nl, pt, zh-Hans) plus strings.json
- Fixed flaky test teardown error in entity rename tests by using the entity registry API instead of raw bus events

## Test plan

- [x] All 207 tests pass (0 errors)
- [x] ruff check passes
- [x] black formatting passes
- [ ] Manual test: full flow with OpenPlantbook (name → species search → select species → sensors → limits → done)
- [ ] Manual test: full flow without OpenPlantbook (name → sensors → limits → done)
- [ ] Manual test: empty species bypasses OPB step
- [ ] Manual test: re-search in species selection step
- [ ] Manual test: "wrong plant" checkbox loops back to species selection
- [ ] Manual test: conditional limits only show thresholds for selected sensors
- [ ] Manual test: verify translations display correctly for non-English locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)