### PR TITLE
Release v2026.2.0

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.2.0-beta4"
+  "version": "2026.2.0"
 }


### PR DESCRIPTION
## Summary
- Bump version from 2026.2.0-beta4 to stable 2026.2.0

Release workflow will automatically create the GitHub Release and tag after merge.