### PR TITLE
docs: document hysteresis behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,21 @@ Configure via **Settings** → **Devices & Services** → **Plant Monitor** → 
 
 ![Problem trigger options](https://user-images.githubusercontent.com/203184/184301674-0461813a-a665-4e93-b5a8-7c9575fe4782.png)
 
+### Hysteresis
+
+All threshold checks include a **hysteresis band** equal to 5% of the min–max range. This prevents rapid flapping between OK and PROBLEM when a sensor value hovers near a threshold.
+
+A plant enters PROBLEM when a value crosses its threshold, but does not return to OK until the value clears the threshold by the band amount. For example, with moisture min=20 and max=60 (range 40, band 2.0):
+
+- Moisture drops below 20% — enters PROBLEM
+- Moisture rises to 21% — **stays in PROBLEM** (below min + band = 22%)
+- Moisture rises to 23% — clears to OK
+
+The band scales proportionally with your configured thresholds. No configuration is needed — hysteresis is always active.
+
+> [!NOTE]
+> When a sensor becomes unavailable, the hysteresis state resets. The next valid reading is evaluated fresh against the thresholds.
+
 ---
 
 ## 🔄 Replacing Sensors

--- a/TIPS.md
+++ b/TIPS.md
@@ -131,6 +131,9 @@ automation:
 
 ## 🚨 Problem Notification Automation
 
+> [!TIP]
+> The integration includes built-in [hysteresis](README.md#hysteresis) on all thresholds, so plants won't flap between OK and PROBLEM when a sensor value hovers near a boundary. This significantly reduces duplicate notifications without any extra configuration.
+
 Get notified when any plant has a problem:
 
 ```yaml


### PR DESCRIPTION
## Summary

Documents the hysteresis feature added in #354.

- **README.md**: Added "Hysteresis" subsection under "Problem Reports" explaining the 5% band, with a concrete moisture example and the unavailability reset behavior
- **TIPS.md**: Added a tip in the "Problem Notification Automation" section linking to the hysteresis docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)