### PR TITLE
fix: tie plant entity to config entry for proper cleanup

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -207,9 +207,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     await component.async_add_entities(plant_entities)
 
-    # Add the entities to device registry together with plant
+    # Add the entities to device registry and tie to config entry
     device_id = plant.device_id
-    await _plant_add_to_device_registry(hass, plant_entities, device_id)
+    await _plant_add_to_device_registry(hass, plant_entities, device_id, entry)
 
     # Set up utility sensor
     hass.data.setdefault(DATA_UTILITY, {})
@@ -317,9 +317,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def _plant_add_to_device_registry(
-    hass: HomeAssistant, plant_entities: list[Entity], device_id: str
+    hass: HomeAssistant,
+    plant_entities: list[Entity],
+    device_id: str,
+    entry: ConfigEntry,
 ) -> None:
-    """Add all related entities to the correct device_id"""
+    """Add all related entities to the correct device and config entry."""
 
     # There must be a better way to do this, but I just can't find a way to set the
     # device_id when adding the entities.
@@ -329,7 +332,11 @@ async def _plant_add_to_device_registry(
             raise ConfigEntryNotReady(
                 f"Entity {entity.entity_id} not yet registered, retrying setup"
             )
-        erreg.async_update_entity(entity.registry_entry.entity_id, device_id=device_id)
+        erreg.async_update_entity(
+            entity.registry_entry.entity_id,
+            device_id=device_id,
+            config_entry_id=entry.entry_id,
+        )
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.2.1-beta2"
+  "version": "2026.2.1-beta3"
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -104,6 +104,12 @@ class TestIntegrationSetup:
         assert len(entities_before) > 0
         assert device_before is not None
 
+        # Verify the main plant entity is tied to the config entry
+        plant_entity_id = entity_registry.async_get_entity_id(DOMAIN, DOMAIN, entry_id)
+        assert plant_entity_id is not None
+        plant_entry = entity_registry.async_get(plant_entity_id)
+        assert plant_entry.config_entry_id == entry_id
+
         # Remove the config entry (this calls async_remove_entry)
         await hass.config_entries.async_remove(entry_id)
         await hass.async_block_till_done()
@@ -111,6 +117,9 @@ class TestIntegrationSetup:
         # Verify entities are removed from registry
         entities_after = er.async_entries_for_config_entry(entity_registry, entry_id)
         assert len(entities_after) == 0
+
+        # Verify the main plant entity is also removed
+        assert entity_registry.async_get(plant_entity_id) is None
 
         # Verify device is removed from registry
         device_after = device_registry.async_get_device(


### PR DESCRIPTION
## Summary
- Associates the main `plant.xxx` entity with its config entry by passing `config_entry_id` to `async_update_entity` in `_plant_add_to_device_registry`
- This ensures `async_entries_for_config_entry` finds the entity during removal, preventing orphaned plant entities from lingering in the entity registry and UI dropdowns
- Runs on every startup, so existing setups are fixed automatically

Fixes #291

## Test plan
- [x] Existing tests pass (52/52)
- [x] Updated `test_remove_entry` to verify plant entity has `config_entry_id` set and is properly removed
- [ ] Manual: remove a plant via UI, verify it disappears from entity registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)