### PR TITLE
feat: add Replace Sensors to options flow

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -89,6 +89,37 @@ from .plant_helpers import PlantHelper
 
 _LOGGER = logging.getLogger(__name__)
 
+SENSOR_SCHEMA_FIELDS = [
+    (FLOW_SENSOR_TEMPERATURE, SensorDeviceClass.TEMPERATURE),
+    (FLOW_SENSOR_MOISTURE, SensorDeviceClass.MOISTURE),
+    (FLOW_SENSOR_CONDUCTIVITY, SensorDeviceClass.CONDUCTIVITY),
+    (FLOW_SENSOR_ILLUMINANCE, SensorDeviceClass.ILLUMINANCE),
+    (FLOW_SENSOR_HUMIDITY, SensorDeviceClass.HUMIDITY),
+    (FLOW_SENSOR_CO2, SensorDeviceClass.CO2),
+    (FLOW_SENSOR_SOIL_TEMPERATURE, SensorDeviceClass.TEMPERATURE),
+]
+
+
+def _build_sensor_schema(defaults: dict[str, Any] | None = None) -> dict:
+    """Build sensor selection schema, optionally pre-filled with current values."""
+    defaults = defaults or {}
+    schema = {}
+    for key, device_class in SENSOR_SCHEMA_FIELDS:
+        current = defaults.get(key)
+        if current:
+            vol_key = vol.Optional(key, description={"suggested_value": current})
+        else:
+            vol_key = vol.Optional(key)
+        schema[vol_key] = selector(
+            {
+                ATTR_ENTITY: {
+                    ATTR_DEVICE_CLASS: device_class,
+                    ATTR_DOMAIN: DOMAIN_SENSOR,
+                }
+            }
+        )
+    return schema
+
 
 class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Plants."""
@@ -227,67 +258,9 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("Plant_info: %s", self.plant_info)
             return await self.async_step_limits()
 
-        data_schema = {}
-        data_schema[FLOW_SENSOR_TEMPERATURE] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-        data_schema[FLOW_SENSOR_MOISTURE] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.MOISTURE,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-        data_schema[FLOW_SENSOR_CONDUCTIVITY] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.CONDUCTIVITY,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-        data_schema[FLOW_SENSOR_ILLUMINANCE] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.ILLUMINANCE,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-        data_schema[FLOW_SENSOR_HUMIDITY] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.HUMIDITY,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-        data_schema[FLOW_SENSOR_CO2] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.CO2,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-        data_schema[FLOW_SENSOR_SOIL_TEMPERATURE] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: SensorDeviceClass.TEMPERATURE,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
-
         return self.async_show_form(
             step_id="sensors",
-            data_schema=vol.Schema(data_schema),
+            data_schema=vol.Schema(_build_sensor_schema()),
         )
 
     async def async_step_limits(
@@ -563,6 +536,17 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return True
 
 
+_SENSOR_ATTR_MAP = {
+    FLOW_SENSOR_TEMPERATURE: "sensor_temperature",
+    FLOW_SENSOR_MOISTURE: "sensor_moisture",
+    FLOW_SENSOR_CONDUCTIVITY: "sensor_conductivity",
+    FLOW_SENSOR_ILLUMINANCE: "sensor_illuminance",
+    FLOW_SENSOR_HUMIDITY: "sensor_humidity",
+    FLOW_SENSOR_CO2: "sensor_co2",
+    FLOW_SENSOR_SOIL_TEMPERATURE: "sensor_soil_temperature",
+}
+
+
 class OptionsFlowHandler(config_entries.OptionsFlow):
     """Handling options for plant."""
 
@@ -571,6 +555,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self.plant = None
 
     async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Show menu to choose between plant properties and sensor replacement."""
+        self.plant = self.hass.data[DOMAIN][self.config_entry.entry_id]["plant"]
+        return self.async_show_menu(
+            step_id="init",
+            menu_options=["plant_properties", "replace_sensor"],
+            description_placeholders={"plant_name": self.plant.name},
+        )
+
+    async def async_step_plant_properties(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Manage the options."""
@@ -590,7 +585,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
             return self.async_create_entry(title="", data=user_input)
 
-        self.plant = self.hass.data[DOMAIN][self.config_entry.entry_id]["plant"]
         plant_helper = PlantHelper(hass=self.hass)
         data_schema = {}
         data_schema[
@@ -652,8 +646,33 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         ] = cv.boolean
 
         return self.async_show_form(
-            step_id="init",
+            step_id="plant_properties",
             data_schema=vol.Schema(data_schema),
+            description_placeholders={"plant_name": self.plant.name},
+        )
+
+    async def async_step_replace_sensor(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle sensor replacement."""
+        if user_input is not None:
+            plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
+            for key, attr_name in _SENSOR_ATTR_MAP.items():
+                new_val = user_input.get(key)
+                old_val = plant_info.get(key)
+                if new_val != old_val:
+                    sensor = getattr(self.plant, attr_name, None)
+                    if sensor:
+                        sensor.replace_external_sensor(new_val)
+            # Preserve existing options (triggers, image, species, etc.)
+            return self.async_create_entry(
+                title="", data=dict(self.config_entry.options)
+            )
+
+        plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
+        return self.async_show_form(
+            step_id="replace_sensor",
+            data_schema=vol.Schema(_build_sensor_schema(defaults=plant_info)),
             description_placeholders={"plant_name": self.plant.name},
         )
 

--- a/custom_components/plant/strings.json
+++ b/custom_components/plant/strings.json
@@ -130,24 +130,42 @@
     "step": {
       "init": {
         "title": "Options",
-        "description": "",
+        "description": "Configure options for **{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Plant properties",
+          "replace_sensor": "Replace sensors"
+        }
+      },
+      "plant_properties": {
+        "title": "Plant properties",
+        "description": "Configure options for **{plant_name}**",
         "data": {
           "check_days": "Illuminance check days",
           "species": "Species",
           "force_update": "Force refresh data from OpenPlantbook",
           "display_pid": "Plant species to display",
-          "temperature_sensor": "Temperature sensor",
-          "moisture_sensor": "Soil moisture sensor",
-          "conductivity_sensor": "Conductivity sensor",
-          "illuminance_sensor": "Illuminance sensor",
-          "humidity_sensor": "Air humidity sensor",
           "entity_picture": "Image (URL, /local/ path, or media-source:// URL)",
           "illuminance_trigger": "Use illuminance as problem trigger",
           "dli_trigger": "Use daily light integral (dli) as problem trigger",
           "humidity_trigger": "Use air humidity as problem trigger",
           "conductivity_trigger": "Use conductivity as problem trigger",
           "moisture_trigger": "Use soil moisture as problem trigger",
-          "temperature_trigger": "Use temperature as problem trigger"
+          "temperature_trigger": "Use temperature as problem trigger",
+          "co2_trigger": "Use CO2 as problem trigger",
+          "soil_temperature_trigger": "Use soil temperature as problem trigger"
+        }
+      },
+      "replace_sensor": {
+        "title": "Replace sensors",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Temperature sensor",
+          "moisture_sensor": "Soil moisture sensor",
+          "conductivity_sensor": "Conductivity sensor",
+          "illuminance_sensor": "Illuminance sensor",
+          "humidity_sensor": "Air humidity sensor",
+          "co2_sensor": "CO2 sensor",
+          "soil_temperature_sensor": "Soil temperature sensor"
         }
       }
     }

--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Optionen",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Pflanzeneigenschaften",
+          "replace_sensor": "Sensoren ersetzen"
+        }
+      },
+      "plant_properties": {
+        "title": "Pflanzeneigenschaften",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Beleuchtungsstärke-Kontrolltage",
           "species": "Art",
           "force_update": "Aktualisierung der Daten aus OpenPlantbook erzwingen",
           "display_pid": "Anzuzeigende Pflanzenart",
-          "temperature_sensor": "Temperatursensor",
-          "moisture_sensor": "Bodenfeuchtesensor",
-          "conductivity_sensor": "Leitfähigkeitssensor",
-          "illuminance_sensor": "Beleuchtungsstärkesensor",
-          "humidity_sensor": "Luftfeuchtigkeitssensor",
           "entity_picture": "Bild-URL. Wird automatisch aktualisiert, wenn die Art in OpenPlantbook gefunden wird",
           "illuminance_trigger": "Beleuchtungsstärke als Problemauslöser verwenden",
           "dli_trigger": "Tägliches Lichtintegral (DLI) als Problemauslöser verwenden",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Temperatur als Problemauslöser verwenden",
           "co2_trigger": "CO2 als Problemauslöser verwenden",
           "soil_temperature_trigger": "Bodentemperatur als Problemauslöser verwenden"
+        }
+      },
+      "replace_sensor": {
+        "title": "Sensoren ersetzen",
+        "description": "Externe Sensoren für **{plant_name}** ersetzen. Feld leeren, um den Sensor zu entfernen.",
+        "data": {
+          "temperature_sensor": "Temperatursensor",
+          "moisture_sensor": "Bodenfeuchtesensor",
+          "conductivity_sensor": "Leitfähigkeitssensor",
+          "illuminance_sensor": "Beleuchtungsstärkesensor",
+          "humidity_sensor": "Luftfeuchtigkeitssensor",
+          "co2_sensor": "CO2-Sensor",
+          "soil_temperature_sensor": "Bodentemperatursensor"
         }
       }
     }

--- a/custom_components/plant/translations/dk.json
+++ b/custom_components/plant/translations/dk.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Indstillinger",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Planteegenskaber",
+          "replace_sensor": "Erstat sensorer"
+        }
+      },
+      "plant_properties": {
+        "title": "Planteegenskaber",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Dage til kontrol af lysstyrke",
           "species": "Art",
           "force_update": "Gennemtving opdatering af data fra OpenPlantbook",
           "display_pid": "Planteart der skal vises",
-          "temperature_sensor": "Temperatursensor",
-          "moisture_sensor": "Jordfugtighedssensor",
-          "conductivity_sensor": "Ledningsevnesensor",
-          "illuminance_sensor": "Lysstyrkesensor",
-          "humidity_sensor": "Luftfugtighedssensor",
           "entity_picture": "Billed-URL. Opdateres automatisk, hvis arten findes i OpenPlantbook",
           "illuminance_trigger": "Brug lysstyrke som problemudløser",
           "dli_trigger": "Brug dagligt lysintegral (DLI) som problemudløser",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Brug temperatur som problemudløser",
           "co2_trigger": "Brug CO2 som problemudløser",
           "soil_temperature_trigger": "Brug jordtemperatur som problemudløser"
+        }
+      },
+      "replace_sensor": {
+        "title": "Erstat sensorer",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Temperatursensor",
+          "moisture_sensor": "Jordfugtighedssensor",
+          "conductivity_sensor": "Ledningsevnesensor",
+          "illuminance_sensor": "Lysstyrkesensor",
+          "humidity_sensor": "Luftfugtighedssensor",
+          "co2_sensor": "CO2-sensor",
+          "soil_temperature_sensor": "Jordtemperatursensor"
         }
       }
     }

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Options",
         "description": "Configure options for **{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Plant properties",
+          "replace_sensor": "Replace sensors"
+        }
+      },
+      "plant_properties": {
+        "title": "Plant properties",
+        "description": "Configure options for **{plant_name}**",
         "data": {
           "check_days": "Illuminance check days",
           "species": "Species",
           "force_update": "Force refresh data from OpenPlantbook",
           "display_pid": "Plant species to display",
-          "temperature_sensor": "Temperature sensor",
-          "moisture_sensor": "Soil moisture sensor",
-          "conductivity_sensor": "Conductivity sensor",
-          "illuminance_sensor": "Illuminance sensor",
-          "humidity_sensor": "Air humidity sensor",
           "entity_picture": "Image URL. Will be automatically updated if species is found in OpenPlantbook",
           "illuminance_trigger": "Use illuminance as problem trigger",
           "dli_trigger": "Use daily light integral (DLI) as problem trigger",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Use temperature as problem trigger",
           "co2_trigger": "Use CO2 as problem trigger",
           "soil_temperature_trigger": "Use soil temperature as problem trigger"
+        }
+      },
+      "replace_sensor": {
+        "title": "Replace sensors",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Temperature sensor",
+          "moisture_sensor": "Soil moisture sensor",
+          "conductivity_sensor": "Conductivity sensor",
+          "illuminance_sensor": "Illuminance sensor",
+          "humidity_sensor": "Air humidity sensor",
+          "co2_sensor": "CO2 sensor",
+          "soil_temperature_sensor": "Soil temperature sensor"
         }
       }
     }

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Opciones",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Propiedades de la planta",
+          "replace_sensor": "Reemplazar sensores"
+        }
+      },
+      "plant_properties": {
+        "title": "Propiedades de la planta",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Días de control de iluminación",
           "species": "Especie",
           "force_update": "Forzar actualización de datos de OpenPlantbook",
           "display_pid": "Especie de planta a mostrar",
-          "temperature_sensor": "Sensor de temperatura",
-          "moisture_sensor": "Sensor de humedad del suelo",
-          "conductivity_sensor": "Sensor de conductividad",
-          "illuminance_sensor": "Sensor de iluminación",
-          "humidity_sensor": "Sensor de humedad del aire",
           "entity_picture": "URL de la imagen. Se actualizará automáticamente si la especie se encuentra en OpenPlantbook",
           "illuminance_trigger": "Usar iluminación como desencadenante de problema",
           "dli_trigger": "Usar integral de luz diaria (DLI) como desencadenante de problema",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Usar temperatura como desencadenante de problema",
           "co2_trigger": "Usar CO2 como desencadenante de problema",
           "soil_temperature_trigger": "Usar temperatura del suelo como desencadenante de problema"
+        }
+      },
+      "replace_sensor": {
+        "title": "Reemplazar sensores",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Sensor de temperatura",
+          "moisture_sensor": "Sensor de humedad del suelo",
+          "conductivity_sensor": "Sensor de conductividad",
+          "illuminance_sensor": "Sensor de iluminación",
+          "humidity_sensor": "Sensor de humedad del aire",
+          "co2_sensor": "Sensor de CO2",
+          "soil_temperature_sensor": "Sensor de temperatura del suelo"
         }
       }
     }

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Options",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Propriétés de la plante",
+          "replace_sensor": "Remplacer les capteurs"
+        }
+      },
+      "plant_properties": {
+        "title": "Propriétés de la plante",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Jours de contrôle de luminosité",
           "species": "Espèce",
           "force_update": "Forcer la mise à jour des données depuis OpenPlantbook",
           "display_pid": "Espèce de plante à afficher",
-          "temperature_sensor": "Capteur de température",
-          "moisture_sensor": "Capteur d'humidité du sol",
-          "conductivity_sensor": "Capteur de conductivité",
-          "illuminance_sensor": "Capteur de luminosité",
-          "humidity_sensor": "Capteur d'humidité de l'air",
           "entity_picture": "URL de l'image. Sera automatiquement mise à jour si l'espèce est trouvée dans OpenPlantbook",
           "illuminance_trigger": "Utiliser la luminosité comme déclencheur de problème",
           "dli_trigger": "Utiliser l'intégrale quotidienne de lumière (DLI) comme déclencheur de problème",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Utiliser la température comme déclencheur de problème",
           "co2_trigger": "Utiliser le CO2 comme déclencheur de problème",
           "soil_temperature_trigger": "Utiliser la température du sol comme déclencheur de problème"
+        }
+      },
+      "replace_sensor": {
+        "title": "Remplacer les capteurs",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Capteur de température",
+          "moisture_sensor": "Capteur d'humidité du sol",
+          "conductivity_sensor": "Capteur de conductivité",
+          "illuminance_sensor": "Capteur de luminosité",
+          "humidity_sensor": "Capteur d'humidité de l'air",
+          "co2_sensor": "Capteur de CO2",
+          "soil_temperature_sensor": "Capteur de température du sol"
         }
       }
     }

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Beállítások",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Növény tulajdonságai",
+          "replace_sensor": "Érzékelők cseréje"
+        }
+      },
+      "plant_properties": {
+        "title": "Növény tulajdonságai",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Megvilágítás ellenőrzési napok",
           "species": "Faj",
           "force_update": "OpenPlantbook adatok frissítésének kényszerítése",
           "display_pid": "Megjelenítendő növényfaj",
-          "temperature_sensor": "Hőmérséklet-érzékelő",
-          "moisture_sensor": "Talajnedvesség-érzékelő",
-          "conductivity_sensor": "Vezetőképesség-érzékelő",
-          "illuminance_sensor": "Fényérzékelő",
-          "humidity_sensor": "Páratartalom-érzékelő",
           "entity_picture": "Kép URL. Automatikusan frissül, ha a faj megtalálható az OpenPlantbook-ban",
           "illuminance_trigger": "Megvilágítás használata problémajelzőként",
           "dli_trigger": "Napi fényintegrál (DLI) használata problémajelzőként",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Hőmérséklet használata problémajelzőként",
           "co2_trigger": "CO2 használata problémajelzőként",
           "soil_temperature_trigger": "Talajhőmérséklet használata problémajelzőként"
+        }
+      },
+      "replace_sensor": {
+        "title": "Érzékelők cseréje",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Hőmérséklet-érzékelő",
+          "moisture_sensor": "Talajnedvesség-érzékelő",
+          "conductivity_sensor": "Vezetőképesség-érzékelő",
+          "illuminance_sensor": "Fényérzékelő",
+          "humidity_sensor": "Páratartalom-érzékelő",
+          "co2_sensor": "CO2-érzékelő",
+          "soil_temperature_sensor": "Talajhőmérséklet-érzékelő"
         }
       }
     }

--- a/custom_components/plant/translations/nb.json
+++ b/custom_components/plant/translations/nb.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Innstillinger",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Planteegenskaper",
+          "replace_sensor": "Erstatt sensorer"
+        }
+      },
+      "plant_properties": {
+        "title": "Planteegenskaper",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Dager for lysstyrkekontroll",
           "species": "Art",
           "force_update": "Tving oppdatering av data fra OpenPlantbook",
           "display_pid": "Planteart som skal vises",
-          "temperature_sensor": "Temperatursensor",
-          "moisture_sensor": "Jordfuktighetssensor",
-          "conductivity_sensor": "Ledningsevnesensor",
-          "illuminance_sensor": "Lyssensor",
-          "humidity_sensor": "Luftfuktighetssensor",
           "entity_picture": "Bilde-URL. Oppdateres automatisk hvis arten finnes i OpenPlantbook",
           "illuminance_trigger": "Bruk lysstyrke som problemutløser",
           "dli_trigger": "Bruk daglig lysintegral (DLI) som problemutløser",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Bruk temperatur som problemutløser",
           "co2_trigger": "Bruk CO2 som problemutløser",
           "soil_temperature_trigger": "Bruk jordtemperatur som problemutløser"
+        }
+      },
+      "replace_sensor": {
+        "title": "Erstatt sensorer",
+        "description": "Erstatt eksterne sensorer for **{plant_name}**. Tøm et felt for å fjerne sensoren.",
+        "data": {
+          "temperature_sensor": "Temperatursensor",
+          "moisture_sensor": "Jordfuktighetssensor",
+          "conductivity_sensor": "Ledningsevnesensor",
+          "illuminance_sensor": "Lyssensor",
+          "humidity_sensor": "Luftfuktighetssensor",
+          "co2_sensor": "CO2-sensor",
+          "soil_temperature_sensor": "Jordtemperatursensor"
         }
       }
     }

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Opties",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Planteigenschappen",
+          "replace_sensor": "Sensoren vervangen"
+        }
+      },
+      "plant_properties": {
+        "title": "Planteigenschappen",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Lichtsterktecontroledagen",
           "species": "Soort",
           "force_update": "Forceer ophalen data van OpenPlantbook",
           "display_pid": "Te tonen plantsoort",
-          "temperature_sensor": "Temperatuursensor",
-          "moisture_sensor": "Bodemvochtsensor",
-          "conductivity_sensor": "Geleidbaarheidssensor",
-          "illuminance_sensor": "Lichtsensor",
-          "humidity_sensor": "Luchtvochtigheidssensor",
           "entity_picture": "Afbeeldings-URL. Wordt automatisch ingevuld als soort is gevonden in OpenPlantbook",
           "illuminance_trigger": "Gebruik lichtsterkte als trigger voor probleem",
           "dli_trigger": "Gebruik dagelijkse lichtintegraal (DLI) als trigger voor probleem",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Gebruik temperatuur als trigger voor probleem",
           "co2_trigger": "Gebruik CO2 als trigger voor probleem",
           "soil_temperature_trigger": "Gebruik bodemtemperatuur als trigger voor probleem"
+        }
+      },
+      "replace_sensor": {
+        "title": "Sensoren vervangen",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Temperatuursensor",
+          "moisture_sensor": "Bodemvochtsensor",
+          "conductivity_sensor": "Geleidbaarheidssensor",
+          "illuminance_sensor": "Lichtsensor",
+          "humidity_sensor": "Luchtvochtigheidssensor",
+          "co2_sensor": "CO2-sensor",
+          "soil_temperature_sensor": "Bodemtemperatuursensor"
         }
       }
     }

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "Opções",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "Propriedades da planta",
+          "replace_sensor": "Substituir sensores"
+        }
+      },
+      "plant_properties": {
+        "title": "Propriedades da planta",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "Dias de verificação de iluminação",
           "species": "Espécie",
           "force_update": "Forçar atualização do OpenPlantbook",
           "display_pid": "Espécie de planta a mostrar",
-          "temperature_sensor": "Sensor de temperatura",
-          "moisture_sensor": "Sensor de humidade do solo",
-          "conductivity_sensor": "Sensor de condutividade",
-          "illuminance_sensor": "Sensor de iluminação",
-          "humidity_sensor": "Sensor de humidade do ar",
           "entity_picture": "URL da imagem. Será automaticamente atualizada se a espécie for encontrada no OpenPlantbook",
           "illuminance_trigger": "Usar iluminação como gatilho de problema",
           "dli_trigger": "Usar integral de luz diária (DLI) como gatilho de problema",
@@ -174,6 +177,19 @@
           "temperature_trigger": "Usar temperatura como gatilho de problema",
           "co2_trigger": "Usar CO2 como gatilho de problema",
           "soil_temperature_trigger": "Usar temperatura do solo como gatilho de problema"
+        }
+      },
+      "replace_sensor": {
+        "title": "Substituir sensores",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "Sensor de temperatura",
+          "moisture_sensor": "Sensor de humidade do solo",
+          "conductivity_sensor": "Sensor de condutividade",
+          "illuminance_sensor": "Sensor de iluminação",
+          "humidity_sensor": "Sensor de humidade do ar",
+          "co2_sensor": "Sensor de CO2",
+          "soil_temperature_sensor": "Sensor de temperatura do solo"
         }
       }
     }

--- a/custom_components/plant/translations/zh-Hans.json
+++ b/custom_components/plant/translations/zh-Hans.json
@@ -155,16 +155,19 @@
       "init": {
         "title": "选项",
         "description": "**{plant_name}**",
+        "menu_options": {
+          "plant_properties": "植物属性",
+          "replace_sensor": "替换传感器"
+        }
+      },
+      "plant_properties": {
+        "title": "植物属性",
+        "description": "**{plant_name}**",
         "data": {
           "check_days": "光照检查天数",
           "species": "植物种类",
           "force_update": "强制从OpenPlantbook刷新数据",
           "display_pid": "要显示的植物种类",
-          "temperature_sensor": "温度传感器",
-          "moisture_sensor": "土壤湿度传感器",
-          "conductivity_sensor": "电导率传感器",
-          "illuminance_sensor": "光照传感器",
-          "humidity_sensor": "空气湿度传感器",
           "entity_picture": "图片URL。如果在OpenPlantbook中找到种类，将自动更新",
           "illuminance_trigger": "使用光照作为问题触发器",
           "dli_trigger": "使用每日光照积分(DLI)作为问题触发器",
@@ -174,6 +177,19 @@
           "temperature_trigger": "使用温度作为问题触发器",
           "co2_trigger": "使用二氧化碳作为问题触发器",
           "soil_temperature_trigger": "使用土壤温度作为问题触发器"
+        }
+      },
+      "replace_sensor": {
+        "title": "替换传感器",
+        "description": "Replace external sensors for **{plant_name}**. Clear a field to remove that sensor.",
+        "data": {
+          "temperature_sensor": "温度传感器",
+          "moisture_sensor": "土壤湿度传感器",
+          "conductivity_sensor": "电导率传感器",
+          "illuminance_sensor": "光照传感器",
+          "humidity_sensor": "空气湿度传感器",
+          "co2_sensor": "CO2传感器",
+          "soil_temperature_sensor": "土壤温度传感器"
         }
       }
     }


### PR DESCRIPTION
## Summary

Closes #359

- Adds a **menu** to the options flow with two choices: "Plant properties" (existing behavior) and "Replace sensors" (new)
- The "Replace sensors" step shows entity selectors pre-filled with current sensor assignments, allowing users to change sensors from the Configuration UI instead of Developer Tools
- Extracts shared sensor schema builder (`_build_sensor_schema`) to eliminate code duplication between setup flow and options flow
- Fixes a critical bug where returning from a sensor replacement step would wipe all trigger settings by preserving existing `config_entry.options`
- Updates all 10 translation files with localized menu labels and step titles

## Test plan

- [x] All 228 existing tests pass with no regressions
- [x] 3 new tests added: replace sensor, preserve options, no-change scenario
- [x] Existing 6 options flow tests updated for menu navigation
- [x] Ruff lint and format checks pass
- [ ] Manual test: open plant Configuration → verify menu appears → test both menu paths
- [ ] Manual test: replace a sensor → verify entity updates correctly
- [ ] Manual test: replace sensor → verify trigger settings are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)