### PR TITLE
chore: bump version to 2026.2.1-beta5

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.2.1-beta4"
+  "version": "2026.2.1-beta5"
 }


### PR DESCRIPTION
## Summary

- Bump version to `2026.2.1-beta5` to trigger auto-release with the new "Replace sensors" options flow feature (#359, #360)

🤖 Generated with [Claude Code](https://claude.com/claude-code)