### PR TITLE
docs: update documentation for Replace Sensors UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ The sensor dropdowns filter by `device_class`. Some integrations don't set the c
 
 **Solutions:**
 1. Report the issue to the physical sensor's integration maintainer
-2. Add the plant without that sensor, then use **Configure** → **Replace sensors** or the `plant.replace_sensor` action (its checks are more relaxed)
+2. Add the plant without that sensor, then use the `plant.replace_sensor` action (it doesn't filter by `device_class`)
 3. Create a template sensor with the correct device class:
 
 ```yaml

--- a/TIPS.md
+++ b/TIPS.md
@@ -54,10 +54,10 @@ template:
 
 ### Option 3: Use `replace_sensor` After Setup
 
-Sensor replacement has **more relaxed** validation than the initial setup. You can:
+The `plant.replace_sensor` action has **more relaxed** validation than the setup flow and the **Configure** → **Replace sensors** UI — it does not filter by `device_class`, so it accepts any `sensor.*` entity. You can:
 
 1. Set up the plant **without** the problematic sensor
-2. Use **Configure** → **Replace sensors** to assign it from the UI, or use **Developer Tools** → **Actions** → `plant.replace_sensor`
+2. Use **Developer Tools** → **Actions** → `plant.replace_sensor` to assign it
 
 ```yaml
 action: plant.replace_sensor


### PR DESCRIPTION
## Summary

Updates README.md and TIPS.md to document the new "Replace sensors" option in the Configuration menu (#359, #360).

**Changes:**
- **Replacing Sensors** section: adds UI method as recommended approach, keeps service call as alternative
- **Problem Reports**: updates navigation path to include "Plant properties" menu step
- **OpenPlantbook / Changing Species**: same navigation path update
- **FAQ entries**: mention UI option alongside service call
- **TIPS.md**: updates Option 3 to mention UI, adjusts comparison table
- Adds `<!-- TODO -->` placeholders for 3 screenshots (options menu, replace sensor form, plant properties triggers)

## Test plan

- [x] All links and anchors verified
- [ ] Add screenshots after manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)