### PR TITLE
fix: downgrade log spam to debug, stable release 2026.2.1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.2.1-beta10"
+  "version": "2026.2.1"
 }

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -275,7 +275,18 @@ class PlantMinMax(RestoreNumber):
         await super().async_added_to_hass()
         state = await self.async_get_last_number_data()
         if not state:
+            _LOGGER.debug(
+                "No restore data for %s, keeping default %s",
+                self.entity_id,
+                self._default_value,
+            )
             return
+        _LOGGER.debug(
+            "Restoring %s: native_value=%r, unit=%s",
+            self.entity_id,
+            state.native_value,
+            state.native_unit_of_measurement,
+        )
         if state.native_value is not None:
             try:
                 float(state.native_value)
@@ -394,7 +405,7 @@ class PlantMaxTemperature(PlantMinMax):
         try:
             current_value = float(self.state)
         except (ValueError, TypeError):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Cannot convert temperature for %s: state is %s",
                 self.entity_id,
                 self.state,
@@ -477,7 +488,7 @@ class PlantMinTemperature(PlantMinMax):
         try:
             current_value = float(self.state)
         except (ValueError, TypeError):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Cannot convert temperature for %s: state is %s",
                 self.entity_id,
                 self.state,
@@ -790,7 +801,7 @@ class PlantMaxSoilTemperature(PlantMinMax):
         try:
             current_value = float(self.state)
         except (ValueError, TypeError):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Cannot convert temperature for %s: state is %s",
                 self.entity_id,
                 self.state,
@@ -866,7 +877,7 @@ class PlantMinSoilTemperature(PlantMinMax):
         try:
             current_value = float(self.state)
         except (ValueError, TypeError):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "Cannot convert temperature for %s: state is %s",
                 self.entity_id,
                 self.state,

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -303,7 +303,25 @@ class PlantCurrentStatus(RestoreSensor):
         self._attr_native_value = None
         if state:
             if "external_sensor" in state.attributes:
+                _LOGGER.debug(
+                    "Restoring %s external sensor from state: %s",
+                    self.entity_id,
+                    state.attributes["external_sensor"],
+                )
                 self.replace_external_sensor(state.attributes["external_sensor"])
+            else:
+                _LOGGER.debug(
+                    "No external_sensor in restored state for %s",
+                    self.entity_id,
+                )
+        else:
+            _LOGGER.debug("No restore data for %s", self.entity_id)
+        _LOGGER.debug(
+            "Sensor %s setup complete: external_sensor=%s, enabled=%s",
+            self.entity_id,
+            self.external_sensor,
+            self.enabled,
+        )
         self.async_track_entity(self.entity_id)
         if self.external_sensor:
             self.async_track_entity(self.external_sensor)
@@ -645,7 +663,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         try:
             numeric_value = float(value)
         except (ValueError, TypeError):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "PPFD source %s has non-numeric value: %s",
                 self.external_sensor,
                 value,
@@ -667,7 +685,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
             try:
                 lux_to_ppfd = float(self._plant.lux_to_ppfd.native_value)
             except (ValueError, TypeError):
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "Lux-to-PPFD factor has non-numeric value: %s, using default %s",
                     self._plant.lux_to_ppfd.native_value,
                     DEFAULT_LUX_TO_PPFD,


### PR DESCRIPTION
## Summary

- **Fixes #371**: Downgrade frequent non-numeric value warnings to `debug` level — eliminates the "logging too frequently" rate-limiter and log spam for users with unconfigured sensor types
- **Add diagnostic debug logging** throughout the update flow for future troubleshooting (only visible with debug logging enabled)
- **Stable release 2026.2.1** — all beta fixes are validated, ready for general use

### Log level changes

| Location | Before | After | Reason |
|----------|--------|-------|--------|
| `_safe_float()` sensor values | warning | debug | Fires every update cycle for unconfigured sensors |
| DLI `last_period` | warning | debug | Transient during startup |
| PPFD/lux-to-PPFD conversion | warning | debug | Transient sensor states |
| Temperature unit conversion | warning | debug | Transient during entity setup |
| Threshold non-numeric state | warning | **warning** | Genuine problem, infrequent |
| Number entity restore failures | warning | **warning** | Startup-only, actionable |
| Entity not found in registry | warning | **warning** | Actionable, infrequent |

### New debug logging
- Plant state transitions (`ok` → `problem`, etc.)
- Threshold check status changes with value and range details
- Number entity restore flow
- Sensor entity setup completion (external sensor, enabled state)

## Test plan
- [x] All 231 tests pass
- [x] Zero warnings in test output (was ~30 before)
- [ ] Verify no log spam with default logging level
- [ ] Verify debug messages appear with `custom_components.plant: debug` in logger config

🤖 Generated with [Claude Code](https://claude.com/claude-code)