### PR TITLE
feat: prefer pre-computed DLI from openplantbook integration

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -252,4 +252,6 @@ CONF_PLANTBOOK_MAPPING = {
     CONF_MAX_HUMIDITY: "max_env_humid",
     CONF_MIN_MMOL: "min_light_mmol",
     CONF_MAX_MMOL: "max_light_mmol",
+    CONF_MIN_DLI: "min_dli",
+    CONF_MAX_DLI: "max_dli",
 }

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -356,7 +356,7 @@ class PlantHelper:
             )
             # Prefer pre-computed DLI from openplantbook integration (includes
             # ratio-based detection). Fall back to mmol × PPFD_DLI_FACTOR.
-            opb_max_dli = opb_plant.get("max_dli")
+            opb_max_dli = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_DLI])
             if opb_max_dli is not None:
                 max_dli = round(float(opb_max_dli))
             else:
@@ -365,7 +365,7 @@ class PlantHelper:
                     max_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR)
                 else:
                     max_dli = DEFAULT_MAX_DLI
-            opb_min_dli = opb_plant.get("min_dli")
+            opb_min_dli = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_DLI])
             if opb_min_dli is not None:
                 min_dli = round(float(opb_min_dli))
             else:

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -354,16 +354,26 @@ class PlantHelper:
                 UnitOfTemperature.CELSIUS,
                 0,
             )
-            opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_MMOL])
-            if opb_mmol:
-                max_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR)
+            # Prefer pre-computed DLI from openplantbook integration (includes
+            # ratio-based detection). Fall back to mmol × PPFD_DLI_FACTOR.
+            opb_max_dli = opb_plant.get("max_dli")
+            if opb_max_dli is not None:
+                max_dli = round(float(opb_max_dli))
             else:
-                max_dli = DEFAULT_MAX_DLI
-            opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_MMOL])
-            if opb_mmol:
-                min_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR)
+                opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_MMOL])
+                if opb_mmol:
+                    max_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR)
+                else:
+                    max_dli = DEFAULT_MAX_DLI
+            opb_min_dli = opb_plant.get("min_dli")
+            if opb_min_dli is not None:
+                min_dli = round(float(opb_min_dli))
             else:
-                min_dli = DEFAULT_MIN_DLI
+                opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_MMOL])
+                if opb_mmol:
+                    min_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR)
+                else:
+                    min_dli = DEFAULT_MIN_DLI
             max_conductivity = _to_int(
                 opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_CONDUCTIVITY]),
                 DEFAULT_MAX_CONDUCTIVITY,

--- a/tests/fixtures/openplantbook_responses.py
+++ b/tests/fixtures/openplantbook_responses.py
@@ -54,6 +54,28 @@ GET_RESULT_FICUS_LYRATA = {
     "image_url": "https://opb-img.plantbook.io/ficus_lyrata.jpg",
 }
 
+# Get result with pre-computed DLI from openplantbook integration
+GET_RESULT_WITH_DLI = {
+    "pid": "capsicum annuum",
+    "display_pid": "Capsicum annuum",
+    "alias": "Pepper",
+    "max_light_mmol": 12000,
+    "min_light_mmol": 3500,
+    "max_light_lux": 95000,
+    "min_light_lux": 6000,
+    "max_dli": 43.2,
+    "min_dli": 12.6,
+    "max_temp": 35,
+    "min_temp": 10,
+    "max_env_humid": 80,
+    "min_env_humid": 40,
+    "max_soil_moist": 65,
+    "min_soil_moist": 20,
+    "max_soil_ec": 2500,
+    "min_soil_ec": 350,
+    "image_url": "https://opb-img.plantbook.io/capsicum_annuum.jpg",
+}
+
 # Empty search result
 SEARCH_RESULT_EMPTY = {}
 

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -326,6 +326,30 @@ class TestPlantHelperGenerateConfigentry:
         # expected_min_dli = round(1500 * 0.0036) = 5
         assert limits[CONF_MIN_DLI] == 5
 
+    async def test_generate_configentry_dli_from_opb_precomputed(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_with_dli,
+    ) -> None:
+        """Test that pre-computed DLI from openplantbook is used when available."""
+        helper = PlantHelper(hass)
+        config = {
+            ATTR_NAME: "My Pepper",
+            ATTR_SPECIES: "capsicum annuum",
+            ATTR_SENSORS: {},
+        }
+
+        result = await helper.generate_configentry(config)
+
+        limits = result[FLOW_PLANT_INFO][ATTR_LIMITS]
+
+        # Should use pre-computed DLI values from openplantbook (rounded)
+        # max_dli = 43.2 → round = 43
+        assert limits[CONF_MAX_DLI] == 43
+
+        # min_dli = 12.6 → round = 13
+        assert limits[CONF_MIN_DLI] == 13
+
 
 class TestPlantHelperEdgeCases:
     """Tests for edge cases in PlantHelper."""


### PR DESCRIPTION
## Summary

- When the openplantbook integration provides `max_dli`/`min_dli` attributes (from [Olen/home-assistant-openplantbook#65](https://github.com/Olen/home-assistant-openplantbook/pull/65)), use those directly
- Falls back to the existing `mmol × PPFD_DLI_FACTOR` conversion when DLI attributes are not present (backwards compatible)
- The openplantbook integration uses a mmol/lux ratio heuristic to auto-detect whether mmol values encode PPFD×photoperiod (× 0.0036) or daily integrals (/ 1000)

Relates to #52 and Olen/home-assistant-openplantbook#57.

## Test plan

- [x] New test: `test_generate_configentry_dli_from_opb_precomputed` — verifies pre-computed DLI values from OPB are used
- [x] Existing test: `test_generate_configentry_dli_from_mmol` — verifies fallback still works
- [x] All 232 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)