### PR TITLE
fix: write initial state for new number entities (#375)

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -251,7 +251,13 @@ class PlantMinMax(RestoreNumber):
             new_state,
             self._attr_native_value,
         )
-        self._attr_native_value = new_state
+        if new_state is not None:
+            try:
+                self._attr_native_value = float(new_state)
+            except (ValueError, TypeError):
+                self._attr_native_value = new_state
+        else:
+            self._attr_native_value = new_state
 
     def state_attributes_changed(
         self, old_attributes: dict[str, Any], new_attributes: dict[str, Any]
@@ -279,6 +285,12 @@ class PlantMinMax(RestoreNumber):
                 "No restore data for %s, keeping default %s",
                 self.entity_id,
                 self._default_value,
+            )
+            self.async_write_ha_state()
+            async_track_state_change_event(
+                self.hass,
+                [self.entity_id],
+                self._state_changed_event,
             )
             return
         _LOGGER.debug(

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -378,7 +378,7 @@ class TestThresholdStateChanges:
 
         # Simulate state change
         threshold.state_changed(old_state="60", new_state="70")
-        assert threshold.native_value == "70"
+        assert threshold.native_value == 70.0
 
 
 class TestTemperatureUnitConversion:


### PR DESCRIPTION
## Summary

- New plant limit entities stayed "unavailable" because `async_added_to_hass()` returned early without calling `async_write_ha_state()` when no restore data existed
- The default value was correctly set in `__init__()` but never pushed to HA's state machine, leaving the entity unavailable until disable/re-enable
- Also fixes `state_changed()` to convert string states to float, keeping `_attr_native_value` consistent with `NumberEntity` expectations

Fixes #375

## Test plan

- [x] All 232 tests pass
- [ ] Create a new plant and verify limit entities have numeric default values (not "unavailable")
- [ ] Verify existing plants with restore data still restore correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)