### PR TITLE
fix: allow entity auto-rename when device is renamed

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.entity import (
     async_generate_entity_id,
 )
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_registry import async_get as er_async_get
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util.unit_conversion import TemperatureConverter
 
@@ -203,11 +204,16 @@ class PlantMinMax(RestoreNumber):
         self._config = config
         self.hass = hass
         self._plant = plantdevice
-        self.entity_id = async_generate_entity_id(
-            f"{DOMAIN}.{{}}",
-            f"{self._plant.name} {self._entity_id_key}",
-            current_ids={},
-        )
+        # Only force entity_id for existing entities (backwards compat).
+        # New entities let has_entity_name derive the entity_id automatically,
+        # which enables auto-rename when the device is renamed.
+        ent_reg = er_async_get(hass)
+        if ent_reg.async_get_entity_id("number", DOMAIN, self._attr_unique_id):
+            self.entity_id = async_generate_entity_id(
+                f"{DOMAIN}.{{}}",
+                f"{self._plant.name} {self._entity_id_key}",
+                current_ids={},
+            )
         # pylint: disable=no-member
         if (
             not hasattr(self, "_attr_native_value")
@@ -221,6 +227,7 @@ class PlantMinMax(RestoreNumber):
         """Device info for devices"""
         return DeviceInfo(
             identifiers={(DOMAIN, self._plant.unique_id)},
+            name=self._plant.name,
         )
 
     async def async_set_native_value(self, value: float) -> None:

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -43,6 +43,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import (
     EVENT_ENTITY_REGISTRY_UPDATED,
     EventEntityRegistryUpdatedData,
+    async_get as er_async_get,
 )
 from homeassistant.helpers.event import (
     async_track_state_change_event,
@@ -198,11 +199,15 @@ class PlantCurrentStatus(RestoreSensor):
         self._plant = plantdevice
         self._tracker = []
         self._follow_external = True
-        self.entity_id = async_generate_entity_id(
-            f"{DOMAIN}.{{}}",
-            f"{self._plant.name} {self._entity_id_key}",
-            current_ids={},
-        )
+        # Only force entity_id for existing entities (backwards compat).
+        # New entities let has_entity_name derive the entity_id automatically.
+        ent_reg = er_async_get(hass)
+        if ent_reg.async_get_entity_id(DOMAIN_SENSOR, DOMAIN, self._attr_unique_id):
+            self.entity_id = async_generate_entity_id(
+                f"{DOMAIN}.{{}}",
+                f"{self._plant.name} {self._entity_id_key}",
+                current_ids={},
+            )
         if (
             not self._attr_native_value
             or self._attr_native_value == STATE_UNKNOWN
@@ -220,6 +225,7 @@ class PlantCurrentStatus(RestoreSensor):
         """Device info for devices"""
         return DeviceInfo(
             identifiers={(DOMAIN, self._plant.unique_id)},
+            name=self._plant.name,
         )
 
     @property
@@ -622,11 +628,13 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         self._source_is_ppfd = False  # Track if source already provides PPFD
         super().__init__(hass, config, plantdevice)
         self._follow_unit = False
-        self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}",
-            f"{self._plant.name} {self._entity_id_key}",
-            current_ids={},
-        )
+        ent_reg = er_async_get(hass)
+        if ent_reg.async_get_entity_id(DOMAIN_SENSOR, DOMAIN, self._attr_unique_id):
+            self.entity_id = async_generate_entity_id(
+                f"{DOMAIN_SENSOR}.{{}}",
+                f"{self._plant.name} {self._entity_id_key}",
+                current_ids={},
+            )
 
     def _is_ppfd_source(self) -> bool:
         """Check if the external sensor provides PPFD directly (not lux).
@@ -765,17 +773,22 @@ class PlantTotalLightIntegral(IntegrationSensor):
             unit_time=UnitOfTime.SECONDS,
             max_sub_interval=None,
         )
-        self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}",
-            f"{self._plant.name} Total {READING_PPFD} Integral",
-            current_ids={},
-        )
+        ent_reg = er_async_get(hass)
+        if ent_reg.async_get_entity_id(
+            DOMAIN_SENSOR, DOMAIN, f"{config.entry_id}-ppfd-integral"
+        ):
+            self.entity_id = async_generate_entity_id(
+                f"{DOMAIN_SENSOR}.{{}}",
+                f"{self._plant.name} Total {READING_PPFD} Integral",
+                current_ids={},
+            )
 
     @property
     def device_info(self) -> DeviceInfo:
         """Device info for devices"""
         return DeviceInfo(
             identifiers={(DOMAIN, self._plant.unique_id)},
+            name=self._plant.name,
         )
 
     def _calculate_unit(self, source_unit: str) -> str:
@@ -874,11 +887,13 @@ class PlantDailyLightIntegral(UtilityMeterSensor):
             suggested_entity_id=None,
             periodically_resetting=True,
         )
-        self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}",
-            f"{self._plant.name} {READING_DLI}",
-            current_ids={},
-        )
+        ent_reg = er_async_get(hass)
+        if ent_reg.async_get_entity_id(DOMAIN_SENSOR, DOMAIN, f"{config.entry_id}-dli"):
+            self.entity_id = async_generate_entity_id(
+                f"{DOMAIN_SENSOR}.{{}}",
+                f"{self._plant.name} {READING_DLI}",
+                current_ids={},
+            )
 
     @property
     def native_unit_of_measurement(self) -> str:
@@ -896,6 +911,7 @@ class PlantDailyLightIntegral(UtilityMeterSensor):
         """Device info for devices"""
         return DeviceInfo(
             identifiers={(DOMAIN, self._plant.unique_id)},
+            name=self._plant.name,
         )
 
     async def async_added_to_hass(self) -> None:
@@ -983,11 +999,15 @@ class PlantDailyLightIntegral24h(StatisticsSensor):
             precision=2,
             percentile=50,  # Not used for "change" characteristic
         )
-        self.entity_id = async_generate_entity_id(
-            f"{DOMAIN_SENSOR}.{{}}",
-            f"{self._plant.name} {READING_DLI}_24h",
-            current_ids={},
-        )
+        ent_reg = er_async_get(hass)
+        if ent_reg.async_get_entity_id(
+            DOMAIN_SENSOR, DOMAIN, f"{config.entry_id}-dli-24h"
+        ):
+            self.entity_id = async_generate_entity_id(
+                f"{DOMAIN_SENSOR}.{{}}",
+                f"{self._plant.name} {READING_DLI}_24h",
+                current_ids={},
+            )
 
     @property
     def native_unit_of_measurement(self) -> str:
@@ -1002,6 +1022,7 @@ class PlantDailyLightIntegral24h(StatisticsSensor):
         """Device info for devices."""
         return DeviceInfo(
             identifiers={(DOMAIN, self._plant.unique_id)},
+            name=self._plant.name,
         )
 
 

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -43,6 +43,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.entity_registry import (
     EVENT_ENTITY_REGISTRY_UPDATED,
     EventEntityRegistryUpdatedData,
+)
+from homeassistant.helpers.entity_registry import (
     async_get as er_async_get,
 )
 from homeassistant.helpers.event import (


### PR DESCRIPTION
## Summary

Fixes #379

- **Existing entities** (already in the entity registry) keep their current `entity_id` for backwards compatibility
- **New entities** skip the manual `entity_id` assignment, letting `has_entity_name=True` derive the `entity_id` from the device name — this enables auto-rename when the device is renamed in the UI
- Child entity `device_info` now includes the device `name`, ensuring the device registry has the correct name even when child entities (numbers, sensors) are registered before the main `PlantDevice` entity

## Root cause

The setup order in `__init__.py` forwards entry setup to platforms (creating number/sensor entities) *before* adding the `PlantDevice` entity. Child entities' `device_info` only provided `identifiers` without a `name`, so when HA created the device from a child entity, the device name was `None`. Adding `name=self._plant.name` to all child `device_info` properties fixes this.

## Test plan

- [x] All 232 existing tests pass
- [x] Entity naming tests verify plant name appears in entity IDs
- [x] Multi-plant tests verify no entity ID collisions
- [ ] Manual test: rename a plant device in the UI and verify child entities follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)