### PR TITLE
Codex/homeassistant plant soil con

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+# AGENTS.md
+
+Guidance for Codex when working with this repository.
+
+## Project Overview
+
+Custom Home Assistant integration for plant monitoring. Replaces the built-in `plant` component with an enhanced version that treats plants as devices with multiple entities.
+
+**Domain:** `plant`
+**Minimum HA Version:** 2025.8.0
+
+## Related Repositories
+
+This integration is part of a plant monitoring ecosystem:
+
+- **[home-assistant-openplantbook](https://github.com/Olen/home-assistant-openplantbook)** - OpenPlantbook API integration that provides species data and thresholds
+- **[lovelace-flower-card](https://github.com/Olen/lovelace-flower-card)** - Lovelace card for displaying plant data (uses the websocket API)
+
+## Quick Commands
+
+```bash
+# Format check (CI uses this)
+.venv/bin/black . --check --fast --diff
+
+# Format code
+.venv/bin/black .
+
+# Run tests
+.venv/bin/pytest tests/ -v
+
+# Run tests with coverage
+.venv/bin/pytest tests/ --cov=custom_components/plant --cov-report=term-missing
+```
+
+See DEVELOPMENT.md for full setup instructions.
+
+## Architecture
+
+### Core Files
+
+| File | Purpose |
+|------|---------|
+| `__init__.py` | Integration setup, `PlantDevice` entity, `plant.replace_sensor` service |
+| `config_flow.py` | Multi-step config flow + `OptionsFlowHandler` for editing plants |
+| `sensor.py` | Sensor entities: current values, PPFD, TLI, DLI |
+| `number.py` | Threshold entities (min/max) using `RestoreNumber` |
+| `plant_helpers.py` | `PlantHelper` class for OpenPlantbook API calls |
+| `const.py` | Constants, defaults, `CONF_PLANTBOOK_MAPPING` |
+
+### Entity Structure per Plant
+
+- 1 `PlantDevice` (main state: ok/problem/unknown)
+- 8 sensor entities (moisture, temperature, conductivity, illuminance, humidity, CO2, soil_temperature + PPFD, TLI, DLI)
+- 16 number entities (min/max thresholds for 8 measurement types)
+
+### Config Flow Steps
+
+1. `user` - Name, species, sensor selection
+2. `select_species` - OpenPlantbook search results (skipped if no OPB)
+3. `limits` - Threshold values and image
+4. `limits_done` - Entry creation
+
+### Websocket API
+
+`plant/get_info` - Returns plant data for Lovelace cards (used by lovelace-flower-card)
+
+## Key Patterns
+
+- Plants are HA devices with identifiers `{(DOMAIN, unique_id)}`
+- External sensors are tracked; values copied to plant-owned sensors
+- Service `plant.replace_sensor` changes the external sensor for any measurement
+- Temperature thresholds respect HA's configured unit system
+- DLI calculated from illuminance: `lux * lux_to_ppfd_factor / 1000000`
+
+## Git Workflow
+
+**Always use feature branches for code changes.** Do not commit directly to master.
+
+```bash
+# Create a branch for your work
+git checkout -b feature-name
+
+# After changes, push and create PR
+git push -u origin feature-name
+gh pr create --fill
+```
+
+The master branch is protected - all changes must go through pull requests.
+
+## Releases
+
+Releases are automated via GitHub Actions. The workflow triggers when `manifest.json` version changes.
+
+**To create a new release:**
+
+1. Update the version in `custom_components/plant/manifest.json`
+2. Commit and push to main (or merge PR)
+3. The CI workflow runs tests, then the release workflow creates a GitHub release
+
+**Version format:**
+- Stable: `YYYY.M.P` (e.g., `2026.1.0`)
+- Beta: `YYYY.M.P-betaN` (e.g., `2026.1.0-beta5`)
+
+**Do NOT manually create tags** - the release workflow handles this automatically based on the manifest version.
+
+## Translations
+
+Translation files in `custom_components/plant/translations/`:
+- Use abbreviated forms (Max/Min) for entity names due to GUI space constraints
+- Each language uses appropriate abbreviations (Maks./Min., Maxi./Mini., etc.)
+- Services section should be present in all translation files

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_PICTURE,
     ATTR_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
@@ -89,15 +90,22 @@ from .plant_helpers import PlantHelper
 
 _LOGGER = logging.getLogger(__name__)
 
-CONDUCTIVITY_DEVICE_CLASSES = [
+CONDUCTIVITY_ALLOWED_DEVICE_CLASSES = {
     SensorDeviceClass.CONDUCTIVITY,
     "soil_fertility",
-]
+}
+CONDUCTIVITY_ALLOWED_UNIT_SUFFIXES = {
+    "us/cm",
+    "µs/cm",
+    "μs/cm",
+    "ms/cm",
+    "s/cm",
+}
 
 SENSOR_SCHEMA_FIELDS = [
     (FLOW_SENSOR_TEMPERATURE, SensorDeviceClass.TEMPERATURE),
     (FLOW_SENSOR_MOISTURE, SensorDeviceClass.MOISTURE),
-    (FLOW_SENSOR_CONDUCTIVITY, CONDUCTIVITY_DEVICE_CLASSES),
+    (FLOW_SENSOR_CONDUCTIVITY, None),
     (FLOW_SENSOR_ILLUMINANCE, SensorDeviceClass.ILLUMINANCE),
     (FLOW_SENSOR_HUMIDITY, SensorDeviceClass.HUMIDITY),
     (FLOW_SENSOR_CO2, SensorDeviceClass.CO2),
@@ -115,15 +123,38 @@ def _build_sensor_schema(defaults: dict[str, Any] | None = None) -> dict:
             vol_key = vol.Optional(key, description={"suggested_value": current})
         else:
             vol_key = vol.Optional(key)
-        schema[vol_key] = selector(
-            {
-                ATTR_ENTITY: {
-                    ATTR_DEVICE_CLASS: device_class,
-                    ATTR_DOMAIN: DOMAIN_SENSOR,
-                }
-            }
-        )
+        entity_selector = {ATTR_DOMAIN: DOMAIN_SENSOR}
+        if device_class is not None:
+            entity_selector[ATTR_DEVICE_CLASS] = device_class
+        schema[vol_key] = selector({ATTR_ENTITY: entity_selector})
     return schema
+
+
+def _normalize_unit(unit: str | None) -> str:
+    """Normalize unit strings for conductivity compatibility checks."""
+    if not unit:
+        return ""
+    return unit.strip().replace(" ", "").lower()
+
+
+def _is_valid_conductivity_sensor(hass: HomeAssistant, entity_id: str | None) -> bool:
+    """Check whether an entity can be used as conductivity/fertility sensor."""
+    if not entity_id:
+        return True
+
+    state = hass.states.get(entity_id)
+    if state is None:
+        return False
+
+    device_class = state.attributes.get(ATTR_DEVICE_CLASS)
+    if device_class in CONDUCTIVITY_ALLOWED_DEVICE_CLASSES:
+        return True
+
+    unit = _normalize_unit(state.attributes.get(ATTR_UNIT_OF_MEASUREMENT))
+    if unit in CONDUCTIVITY_ALLOWED_UNIT_SUFFIXES:
+        return True
+
+    return "soil_fertility" in entity_id or "conductivity" in entity_id
 
 
 class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -247,25 +278,31 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle sensor selection step."""
+        errors = {}
         if user_input is not None:
             _LOGGER.debug("User Input (sensors) %s", user_input)
-            # Store sensor selections in plant_info
-            for key in (
-                FLOW_SENSOR_TEMPERATURE,
-                FLOW_SENSOR_MOISTURE,
-                FLOW_SENSOR_CONDUCTIVITY,
-                FLOW_SENSOR_ILLUMINANCE,
-                FLOW_SENSOR_HUMIDITY,
-                FLOW_SENSOR_CO2,
-                FLOW_SENSOR_SOIL_TEMPERATURE,
-            ):
-                self.plant_info[key] = user_input.get(key)
-            _LOGGER.debug("Plant_info: %s", self.plant_info)
-            return await self.async_step_limits()
+            conductivity_sensor = user_input.get(FLOW_SENSOR_CONDUCTIVITY)
+            if not _is_valid_conductivity_sensor(self.hass, conductivity_sensor):
+                errors[FLOW_SENSOR_CONDUCTIVITY] = "invalid_conductivity_sensor"
+            else:
+                # Store sensor selections in plant_info
+                for key in (
+                    FLOW_SENSOR_TEMPERATURE,
+                    FLOW_SENSOR_MOISTURE,
+                    FLOW_SENSOR_CONDUCTIVITY,
+                    FLOW_SENSOR_ILLUMINANCE,
+                    FLOW_SENSOR_HUMIDITY,
+                    FLOW_SENSOR_CO2,
+                    FLOW_SENSOR_SOIL_TEMPERATURE,
+                ):
+                    self.plant_info[key] = user_input.get(key)
+                _LOGGER.debug("Plant_info: %s", self.plant_info)
+                return await self.async_step_limits()
 
         return self.async_show_form(
             step_id="sensors",
             data_schema=vol.Schema(_build_sensor_schema()),
+            errors=errors,
         )
 
     async def async_step_limits(
@@ -660,35 +697,41 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle sensor replacement."""
+        errors = {}
         if user_input is not None:
-            plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
-            for key, attr_name in _SENSOR_ATTR_MAP.items():
-                new_val = user_input.get(key)
-                old_val = plant_info.get(key)
-                if new_val != old_val:
-                    sensor = getattr(self.plant, attr_name, None)
-                    if sensor and sensor.hass is not None:
-                        sensor.replace_external_sensor(new_val)
-                    else:
-                        # Sensor entity is disabled (not added to HA).
-                        # Update config_entry.data directly; the entity
-                        # will pick up the new sensor when enabled.
-                        new_data = dict(self.config_entry.data)
-                        new_plant_info = dict(new_data.get(FLOW_PLANT_INFO, {}))
-                        new_plant_info[key] = new_val
-                        new_data[FLOW_PLANT_INFO] = new_plant_info
-                        self.hass.config_entries.async_update_entry(
-                            self.config_entry, data=new_data
-                        )
-            # Preserve existing options (triggers, image, species, etc.)
-            return self.async_create_entry(
-                title="", data=dict(self.config_entry.options)
-            )
+            conductivity_sensor = user_input.get(FLOW_SENSOR_CONDUCTIVITY)
+            if not _is_valid_conductivity_sensor(self.hass, conductivity_sensor):
+                errors[FLOW_SENSOR_CONDUCTIVITY] = "invalid_conductivity_sensor"
+            else:
+                plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
+                for key, attr_name in _SENSOR_ATTR_MAP.items():
+                    new_val = user_input.get(key)
+                    old_val = plant_info.get(key)
+                    if new_val != old_val:
+                        sensor = getattr(self.plant, attr_name, None)
+                        if sensor and sensor.hass is not None:
+                            sensor.replace_external_sensor(new_val)
+                        else:
+                            # Sensor entity is disabled (not added to HA).
+                            # Update config_entry.data directly; the entity
+                            # will pick up the new sensor when enabled.
+                            new_data = dict(self.config_entry.data)
+                            new_plant_info = dict(new_data.get(FLOW_PLANT_INFO, {}))
+                            new_plant_info[key] = new_val
+                            new_data[FLOW_PLANT_INFO] = new_plant_info
+                            self.hass.config_entries.async_update_entry(
+                                self.config_entry, data=new_data
+                            )
+                # Preserve existing options (triggers, image, species, etc.)
+                return self.async_create_entry(
+                    title="", data=dict(self.config_entry.options)
+                )
 
         plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
         return self.async_show_form(
             step_id="replace_sensor",
             data_schema=vol.Schema(_build_sensor_schema(defaults=plant_info)),
+            errors=errors,
             description_placeholders={"plant_name": self.plant.name},
         )
 

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -89,10 +89,15 @@ from .plant_helpers import PlantHelper
 
 _LOGGER = logging.getLogger(__name__)
 
+CONDUCTIVITY_DEVICE_CLASSES = [
+    SensorDeviceClass.CONDUCTIVITY,
+    "soil_fertility",
+]
+
 SENSOR_SCHEMA_FIELDS = [
     (FLOW_SENSOR_TEMPERATURE, SensorDeviceClass.TEMPERATURE),
     (FLOW_SENSOR_MOISTURE, SensorDeviceClass.MOISTURE),
-    (FLOW_SENSOR_CONDUCTIVITY, SensorDeviceClass.CONDUCTIVITY),
+    (FLOW_SENSOR_CONDUCTIVITY, CONDUCTIVITY_DEVICE_CLASSES),
     (FLOW_SENSOR_ILLUMINANCE, SensorDeviceClass.ILLUMINANCE),
     (FLOW_SENSOR_HUMIDITY, SensorDeviceClass.HUMIDITY),
     (FLOW_SENSOR_CO2, SensorDeviceClass.CO2),

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -105,7 +105,6 @@ CONDUCTIVITY_ALLOWED_UNIT_SUFFIXES = {
 SENSOR_SCHEMA_FIELDS = [
     (FLOW_SENSOR_TEMPERATURE, SensorDeviceClass.TEMPERATURE),
     (FLOW_SENSOR_MOISTURE, SensorDeviceClass.MOISTURE),
-    (FLOW_SENSOR_CONDUCTIVITY, None),
     (FLOW_SENSOR_ILLUMINANCE, SensorDeviceClass.ILLUMINANCE),
     (FLOW_SENSOR_HUMIDITY, SensorDeviceClass.HUMIDITY),
     (FLOW_SENSOR_CO2, SensorDeviceClass.CO2),
@@ -113,7 +112,23 @@ SENSOR_SCHEMA_FIELDS = [
 ]
 
 
-def _build_sensor_schema(defaults: dict[str, Any] | None = None) -> dict:
+def _get_compatible_conductivity_entities(
+    hass: HomeAssistant, current: str | None = None
+) -> list[str]:
+    """Return sensor entity IDs that look compatible with conductivity input."""
+    entity_ids = [
+        entity_id
+        for entity_id in hass.states.async_entity_ids(DOMAIN_SENSOR)
+        if _is_valid_conductivity_sensor(hass, entity_id)
+    ]
+    if current and current.startswith(f"{DOMAIN_SENSOR}.") and current not in entity_ids:
+        entity_ids.append(current)
+    return sorted(entity_ids)
+
+
+def _build_sensor_schema(
+    hass: HomeAssistant, defaults: dict[str, Any] | None = None
+) -> dict:
     """Build sensor selection schema, optionally pre-filled with current values."""
     defaults = defaults or {}
     schema = {}
@@ -127,6 +142,22 @@ def _build_sensor_schema(defaults: dict[str, Any] | None = None) -> dict:
         if device_class is not None:
             entity_selector[ATTR_DEVICE_CLASS] = device_class
         schema[vol_key] = selector({ATTR_ENTITY: entity_selector})
+
+    current = defaults.get(FLOW_SENSOR_CONDUCTIVITY)
+    conductivity_key = (
+        vol.Optional(FLOW_SENSOR_CONDUCTIVITY, description={"suggested_value": current})
+        if current
+        else vol.Optional(FLOW_SENSOR_CONDUCTIVITY)
+    )
+    schema[conductivity_key] = selector(
+        {
+            ATTR_ENTITY: {
+                "include_entities": _get_compatible_conductivity_entities(
+                    hass, current
+                ),
+            }
+        }
+    )
     return schema
 
 
@@ -301,7 +332,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="sensors",
-            data_schema=vol.Schema(_build_sensor_schema()),
+            data_schema=vol.Schema(_build_sensor_schema(self.hass)),
             errors=errors,
         )
 
@@ -730,7 +761,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
         return self.async_show_form(
             step_id="replace_sensor",
-            data_schema=vol.Schema(_build_sensor_schema(defaults=plant_info)),
+            data_schema=vol.Schema(_build_sensor_schema(self.hass, defaults=plant_info)),
             errors=errors,
             description_placeholders={"plant_name": self.plant.name},
         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -282,7 +282,7 @@ class TestConfigFlowSensorsStep:
         hass.states.async_set(
             "sensor.soil_fertility",
             "750",
-            {"device_class": "soil_fertility"},
+            {"unit_of_measurement": "µS/cm"},
         )
 
         result = await hass.config_entries.flow.async_init(
@@ -564,7 +564,7 @@ class TestOptionsFlowReplaceSensor:
         hass.states.async_set(
             "sensor.soil_fertility",
             "850",
-            {"device_class": "soil_fertility"},
+            {"unit_of_measurement": "µS/cm"},
         )
 
         result = await hass.config_entries.options.async_init(init_integration.entry_id)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -28,6 +28,7 @@ from custom_components.plant.const import (
     FLOW_PLANT_LIMITS,
     FLOW_RIGHT_PLANT,
     FLOW_SENSOR_CO2,
+    FLOW_SENSOR_CONDUCTIVITY,
     FLOW_SENSOR_ILLUMINANCE,
     FLOW_SENSOR_MOISTURE,
     FLOW_SENSOR_TEMPERATURE,
@@ -266,6 +267,42 @@ class TestConfigFlowSensorsStep:
             {
                 FLOW_SENSOR_TEMPERATURE: "sensor.temp",
                 FLOW_SENSOR_MOISTURE: "sensor.moisture",
+            },
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "limits"
+
+    async def test_sensors_step_accepts_soil_fertility_sensor_for_conductivity(
+        self,
+        hass: HomeAssistant,
+        mock_no_openplantbook,
+    ) -> None:
+        """Test that soil_fertility sensors can be selected as conductivity input."""
+        hass.states.async_set(
+            "sensor.soil_fertility",
+            "750",
+            {"device_class": "soil_fertility"},
+        )
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                ATTR_NAME: "My Plant",
+                ATTR_SPECIES: "ficus",
+            },
+        )
+
+        assert result["step_id"] == "sensors"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                FLOW_SENSOR_CONDUCTIVITY: "sensor.soil_fertility",
             },
         )
 
@@ -513,6 +550,39 @@ class TestConfigFlowLimitsStep:
         assert CONF_MIN_TEMPERATURE not in schema_keys
         # Conductivity thresholds should NOT be present
         assert CONF_MAX_CONDUCTIVITY not in schema_keys
+
+
+class TestOptionsFlowReplaceSensor:
+    """Tests for the replace sensor options step."""
+
+    async def test_replace_sensor_accepts_soil_fertility_sensor(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test replacing conductivity sensor with a soil_fertility sensor."""
+        hass.states.async_set(
+            "sensor.soil_fertility",
+            "850",
+            {"device_class": "soil_fertility"},
+        )
+
+        result = await hass.config_entries.options.async_init(init_integration.entry_id)
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {"next_step_id": "replace_sensor"},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "replace_sensor"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {FLOW_SENSOR_CONDUCTIVITY: "sensor.soil_fertility"},
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
 
     async def test_conditional_limits_illuminance_includes_dli(
         self,


### PR DESCRIPTION
## Summary

Accept `soil_fertility` entities in the conductivity sensor selector.

## Why

Some plant sensors expose fertility as `soil_fertility` instead of `conductivity`, which currently forces users to create template sensors before they can assign them in this integration.

## Changes

- allow both `conductivity` and `soil_fertility` in the conductivity selector
- add config flow coverage for setup and replace-sensor flows
