### PR TITLE
fix: persist refreshed OpenPlantbook limits to config entry

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -798,6 +798,13 @@ async def update_plant_options(
         # this will only be run once (unchanged options are will not trigger the flow)
         options = dict(entry.options)
         data = dict(entry.data)
+        # Persist refreshed OPB limits to config entry so they survive restarts
+        if plant_config[DATA_SOURCE] == DATA_SOURCE_PLANTBOOK:
+            plant_info = dict(data.get(FLOW_PLANT_INFO, {}))
+            plant_info[FLOW_PLANT_LIMITS] = dict(
+                plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
+            )
+            data[FLOW_PLANT_INFO] = plant_info
         options[FLOW_FORCE_SPECIES_UPDATE] = False
         options[OPB_DISPLAY_PID] = plant.display_species
         options[ATTR_ENTITY_PICTURE] = plant.entity_picture


### PR DESCRIPTION
## Summary
- Fixes #392
- When "Force refresh data from OpenPlantbook" was used, the refreshed threshold values were applied to the HA state registry (`hass.states.async_set`) but never saved to the config entry data
- On HA restart, the old pre-refresh values were restored since the config entry still had the original limits
- Now merges refreshed limits into `entry.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]` before calling `async_update_entry()` so they persist across restarts

## Test plan
- [ ] Configure a plant with OpenPlantbook species data
- [ ] Change threshold values in OpenPlantbook for that species
- [ ] Use "Force refresh data from OpenPlantbook" in the plant's options
- [ ] Verify the new values appear immediately
- [ ] Restart Home Assistant
- [ ] Verify the refreshed values are still present after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)