### PR TITLE
fix: websocket API reports zero sensor values as unavailable

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -685,7 +685,9 @@ class PlantDevice(Entity):
             return {
                 ATTR_MAX: max_entity.state,
                 ATTR_MIN: min_entity.state,
-                ATTR_CURRENT: sensor.state or STATE_UNAVAILABLE,
+                ATTR_CURRENT: (
+                    sensor.state if sensor.state is not None else STATE_UNAVAILABLE
+                ),
                 ATTR_ICON: self._get_entity_icon(sensor),
                 ATTR_UNIT_OF_MEASUREMENT: sensor.unit_of_measurement,
                 ATTR_SENSOR: sensor.entity_id,


### PR DESCRIPTION
## Summary
- Fixes #386 (the actual root cause, which the #383 fix missed)
- `SensorEntity.state` returns the raw numeric value (e.g., `0.0` float), not a string
- The expression `sensor.state or STATE_UNAVAILABLE` in the websocket API treats `0`/`0.0` as falsy in Python, replacing valid zero readings with "unavailable"
- The flower card uses this websocket API, so it displayed "Unavailable" for any sensor at exactly zero
- The prior fix (#383) only addressed the `__init__` constructor check but missed this websocket code path

## Change
```python
# Before
ATTR_CURRENT: sensor.state or STATE_UNAVAILABLE,

# After  
ATTR_CURRENT: sensor.state if sensor.state is not None else STATE_UNAVAILABLE,
```

## Test plan
- [ ] Set an external moisture sensor to 0%
- [ ] Verify the flower card shows "0" instead of "Unavailable"
- [ ] Verify sensors with actual unavailable state still show "Unavailable"
- [ ] Verify non-zero sensor values display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)