### PR TITLE
fix: websocket API sends NaN for unavailable threshold values

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -698,9 +698,11 @@ class PlantDevice(Entity):
             _LOGGER.debug("Skipping %s: sensor %s not available", attr_name, sensor)
             return None
         try:
+            max_val = self._safe_float(max_entity.state, max_entity.entity_id)
+            min_val = self._safe_float(min_entity.state, min_entity.entity_id)
             return {
-                ATTR_MAX: max_entity.state,
-                ATTR_MIN: min_entity.state,
+                ATTR_MAX: max_val if max_val is not None else max_entity._default_value,
+                ATTR_MIN: min_val if min_val is not None else min_entity._default_value,
                 ATTR_CURRENT: (
                     sensor.state if sensor.state is not None else STATE_UNAVAILABLE
                 ),


### PR DESCRIPTION
## Summary
- When threshold number entities haven't loaded yet or have non-numeric state (e.g. "unknown"/"unavailable"), the websocket API passed through the raw string which the flower card rendered as NaN
- Now validates threshold values with `_safe_float` and falls back to the entity's `_default_value` when non-numeric
- Reported in the last comment on #376

## Test plan
- [ ] Verify flower card shows correct threshold values under normal operation
- [ ] Verify thresholds fall back to defaults during startup before entities fully load

🤖 Generated with [Claude Code](https://claude.com/claude-code)