### PR TITLE
docs: add battery monitoring tips and HA template tutorial links

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ The card supports both °C and °F:
 
 ## 💡 Tips & Tricks
 
-For practical tips, template examples, and workarounds — including fixing sensors with wrong `device_class`, auto-watering automations, and problem notifications — see **[TIPS.md](TIPS.md)**.
+For practical tips, template examples, and workarounds — including fixing sensors with wrong `device_class`, auto-watering automations, problem notifications, and battery/stuck sensor monitoring — see **[TIPS.md](TIPS.md)**.
 
 ---
 
@@ -329,6 +329,12 @@ Local images must be in your HA `www` folder, referenced with the `/local/` pref
 | `file:///config/www/images/plants/my-plant.jpg` (file URI) | ❌ |
 
 You can also use `media-source://` URLs. See [Plant Images](#️-plant-images).
+</details>
+
+<details>
+<summary><strong>Can the integration monitor sensor battery levels or detect dead sensors?</strong></summary>
+
+The integration monitors plant *readings*, not sensor hardware. For battery monitoring, see Home Assistant's official tutorial: [Get notified when a device needs a new battery](https://www.home-assistant.io/docs/templating/tutorial-battery-alerts/). For detecting stuck sensors (no value change in 24+ hours), see the [Battery Monitoring & Stuck Sensors](TIPS.md#-battery-monitoring--stuck-sensors) section in TIPS.md.
 </details>
 
 <details>

--- a/TIPS.md
+++ b/TIPS.md
@@ -12,6 +12,7 @@ Practical tips, template examples, and workarounds for common situations with th
   - [🚨 Problem Notification Automation](#-problem-notification-automation)
   - [🌤️ Weather Forecast Warnings for Outdoor Plants](#️-weather-forecast-warnings-for-outdoor-plants)
   - [🌡️ Combining Multiple Temperature Sources](#️-combining-multiple-temperature-sources)
+  - [🔋 Battery Monitoring & Stuck Sensors](#-battery-monitoring--stuck-sensors)
   - [📊 Export Plant Config as YAML](#-export-plant-config-as-yaml)
 
 ---
@@ -300,6 +301,9 @@ This picks up new plants automatically when they're added to the area.
 
 ## 🌡️ Combining Multiple Temperature Sources
 
+> [!TIP]
+> Home Assistant has an official tutorial on averaging sensor values: [Show the average home temperature on your dashboard](https://www.home-assistant.io/docs/templating/tutorial-average-temperature/). The same approach works for averaging moisture, conductivity, or any other numeric sensor across your plants.
+
 If you have multiple temperature sensors near a plant and want to use the average:
 
 ```yaml
@@ -318,6 +322,54 @@ template:
           {% set valid = sensors | select('greaterthan', -40) | list %}
           {{ (valid | sum / valid | count) | round(1) if valid else 'unavailable' }}
 ```
+
+---
+
+## 🔋 Battery Monitoring & Stuck Sensors
+
+Plant sensors (especially BLE and Zigbee) are battery-powered and will eventually stop updating when the battery dies. This integration does not monitor battery levels directly — it monitors the *readings* from your sensors. A dead battery typically shows up as a sensor stuck on its last value or going unavailable.
+
+Home Assistant has an official tutorial that walks you through building a daily low-battery notification: **[Get notified when a device needs a new battery](https://www.home-assistant.io/docs/templating/tutorial-battery-alerts/)**. This covers all your HA devices, including plant sensors.
+
+If you want to detect **stuck sensors** (battery not yet reported as low, but readings stopped changing), you can use a `last_changed` check:
+
+```yaml
+automation:
+  - alias: "Plant sensor stuck warning"
+    description: >
+      Warns when a plant sensor hasn't changed value in 24 hours,
+      which may indicate a dead battery or connectivity issue.
+    trigger:
+      - platform: time
+        at: "09:00:00"
+    action:
+      - variables:
+          stale_sensors: >
+            {% set ns = namespace(items=[]) %}
+            {% for state in states.sensor %}
+              {% if 'external_sensor' in state.attributes
+                 and (now() - state.last_changed).total_seconds() > 86400 %}
+                {% set ns.items = ns.items + [
+                  state.attributes.friendly_name ~ ' (last changed '
+                  ~ relative_time(state.last_changed) ~ ' ago)'
+                ] %}
+              {% endif %}
+            {% endfor %}
+            {{ ns.items }}
+      - condition: template
+        value_template: "{{ stale_sensors | length > 0 }}"
+      - action: notify.mobile_app
+        data:
+          title: "Plant sensor may be stuck"
+          message: >
+            These plant sensors haven't updated in 24 hours:
+            {% for s in stale_sensors %}
+            - {{ s }}
+            {% endfor %}
+```
+
+> [!NOTE]
+> The `external_sensor` attribute is present on plant-owned sensor entities, so this filters specifically for plant sensors rather than all sensors in your system.
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds a new "Battery Monitoring & Stuck Sensors" section to TIPS.md with:
  - Link to HA's official [battery alerts tutorial](https://www.home-assistant.io/docs/templating/tutorial-battery-alerts/)
  - A ready-to-use automation for detecting plant sensors stuck for 24+ hours (dead battery / connectivity issue)
- Adds a tip to the "Combining Multiple Temperature Sources" section linking to HA's [average temperature tutorial](https://www.home-assistant.io/docs/templating/tutorial-average-temperature/), noting it works for moisture/conductivity too
- Adds an FAQ entry in README.md for the common "can it monitor batteries?" question
- Updates the README Tips & Tricks description to mention the new topics

Addresses recurring user questions about battery monitoring and stuck sensors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)