### PR TITLE
fix: force refresh now actually updates threshold entities

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -790,18 +790,16 @@ async def update_plant_options(
             for key, value in plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].items():
                 set_entity = getattr(plant, key)
                 _LOGGER.debug("Entity: %s To: %s", set_entity, value)
-                set_entity_id = set_entity.entity_id
                 _LOGGER.debug(
                     "Setting %s to %s",
-                    set_entity_id,
+                    set_entity.entity_id,
                     value,
                 )
-
-                hass.states.async_set(
-                    set_entity_id,
-                    new_state=value,
-                    attributes=hass.states.get(set_entity_id).attributes,
-                )
+                # Use async_set_native_value to update the entity's internal
+                # state. hass.states.async_set() only updates the state
+                # machine but leaves _attr_native_value unchanged, so the
+                # old value reappears on next write or restart.
+                await set_entity.async_set_native_value(float(value))
 
         else:
             plant.species = new_species


### PR DESCRIPTION
## Summary
Fixes #392 — "Force refresh data from OpenPlantbook" fetches correct values but threshold entities revert to old values.

## Root cause
`update_plant_options()` was using `hass.states.async_set()` to write the refreshed threshold values. This updates the **HA state machine** (what the GUI reads) but does **not** update the entity's internal `_attr_native_value`. Since `RestoreNumber` entities persist via `_attr_native_value`, the old value would reappear on the next `async_write_ha_state()` call or after a restart.

This explains the user's observation: the config flow form showed the correct values (read from the fresh OPB data), but the actual entity values didn't change.

## Fix
Replace `hass.states.async_set()` with `await set_entity.async_set_native_value(float(value))`, which properly updates the entity's internal state and triggers `async_write_ha_state()`.

## Test plan
- [x] All 245 tests pass
- [x] Ruff passes
- [ ] Manual: modify plant thresholds in OPB, force refresh, verify entity values update and persist after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)