### PR TITLE
fix: use custom device class for VPD sensor

### DIFF
--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -59,6 +59,7 @@ from .const import (
     ATTR_MOISTURE,
     ATTR_PLANT,
     ATTR_SENSORS,
+    ATTR_VPD,
     DATA_UPDATED,
     DEFAULT_LUX_TO_PPFD,
     DOMAIN,
@@ -665,7 +666,7 @@ class PlantCurrentVpd(RestoreSensor):
 
     _attr_has_entity_name = True
     _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_device_class = SensorDeviceClass.ATMOSPHERIC_PRESSURE
+    _attr_device_class = ATTR_VPD
     _attr_icon = ICON_VPD
     _attr_native_unit_of_measurement = UNIT_VPD
     _attr_suggested_display_precision = 2


### PR DESCRIPTION
## Summary
Fixes the VPD sensor showing as "Atmospheric pressure" with hPa unit conversion.

Using `SensorDeviceClass.ATMOSPHERIC_PRESSURE` caused HA to override the entity name and convert the unit from kPa to hPa. Now uses a custom device class string (`ATTR_VPD`) like moisture and conductivity do, so the translation key ("Vapour pressure deficit") and native kPa unit work correctly.

## Test plan
- [x] All 245 tests pass
- [x] Ruff passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)