### PR TITLE
Release v2026.4.0-beta5

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.4.0-beta4"
+  "version": "2026.4.0-beta5"
 }


### PR DESCRIPTION
## Summary
- Bump version to 2026.4.0-beta5
- Includes #406 — fix VPD sensor naming (was showing as "Atmospheric pressure" with wrong unit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)