### PR TITLE
fix: add VPD sensor name to en.json translations

### DIFF
--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24h rolling)"
+      },
+      "vpd": {
+        "name": "Vapour pressure deficit"
       }
     },
     "number": {


### PR DESCRIPTION
The VPD sensor entry was missing from `translations/en.json` — only the threshold entities (max/min VPD) were added. Without this, HA has no display name for the VPD sensor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)