### PR TITLE
Release v2026.4.0-beta6

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.4.0-beta5"
+  "version": "2026.4.0-beta6"
 }


### PR DESCRIPTION
- Bump version to 2026.4.0-beta6
- Includes #408 — add missing VPD sensor name to en.json translations

🤖 Generated with [Claude Code](https://claude.com/claude-code)