### PR TITLE
fix: fall back to default VPD thresholds when OPB omits them

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -481,20 +481,18 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if show_all or (
             selected_sensors["temperature"] and selected_sensors["humidity"]
         ):
+            max_vpd = plant_config[FLOW_PLANT_INFO][ATTR_LIMITS].get(CONF_MAX_VPD)
+            min_vpd = plant_config[FLOW_PLANT_INFO][ATTR_LIMITS].get(CONF_MIN_VPD)
             data_schema[
                 vol.Required(
                     CONF_MAX_VPD,
-                    default=plant_config[FLOW_PLANT_INFO][ATTR_LIMITS].get(
-                        CONF_MAX_VPD
-                    ),
+                    default=max_vpd if max_vpd is not None else DEFAULT_MAX_VPD,
                 )
             ] = float
             data_schema[
                 vol.Required(
                     CONF_MIN_VPD,
-                    default=plant_config[FLOW_PLANT_INFO][ATTR_LIMITS].get(
-                        CONF_MIN_VPD
-                    ),
+                    default=min_vpd if min_vpd is not None else DEFAULT_MIN_VPD,
                 )
             ] = float
 


### PR DESCRIPTION
## Summary
- When OpenPlantbook doesn't return `min_vpd` / `max_vpd` for a species, the config flow passed `None` as the default to `vol.Required`, causing an error when adding a new plant (reported in #392).
- Fall back to `DEFAULT_MIN_VPD` / `DEFAULT_MAX_VPD` when values are missing or `None`.

## Test plan
- [ ] Add a new plant whose OPB species has no VPD data — form should load with default VPD values instead of erroring.
- [ ] Add a plant whose OPB species does provide VPD — values should still be used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)