### PR TITLE
fix: skip restore state for brand-new threshold entities

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -263,7 +263,16 @@ class PlantMinMax(RestoreNumber):
         # New entities let has_entity_name derive the entity_id automatically,
         # which enables auto-rename when the device is renamed.
         ent_reg = er_async_get(hass)
-        if ent_reg.async_get_entity_id(NUMBER_DOMAIN, DOMAIN, self._attr_unique_id):
+        existing_entity_id = ent_reg.async_get_entity_id(
+            NUMBER_DOMAIN, DOMAIN, self._attr_unique_id
+        )
+        # Track whether this is a brand-new config entry. HA's RestoreState
+        # keyed by entity_id preserves deleted entities' last state for ~7
+        # days, so a delete + re-add with the same plant name would restore
+        # stale values over the fresh ones from OpenPlantbook. Skip restore
+        # when the unique_id is new.
+        self._is_new_entity = existing_entity_id is None
+        if existing_entity_id:
             self.entity_id = async_generate_entity_id(
                 f"{NUMBER_DOMAIN}.{{}}",
                 f"{self._plant.name} {self._entity_id_key}",
@@ -341,6 +350,19 @@ class PlantMinMax(RestoreNumber):
     async def async_added_to_hass(self) -> None:
         """Restore state of thresholds on startup."""
         await super().async_added_to_hass()
+        if self._is_new_entity:
+            _LOGGER.debug(
+                "New entity %s, using default %s (skipping restore)",
+                self.entity_id,
+                self._default_value,
+            )
+            self.async_write_ha_state()
+            async_track_state_change_event(
+                self.hass,
+                [self.entity_id],
+                self._state_changed_event,
+            )
+            return
         state = await self.async_get_last_number_data()
         if not state:
             _LOGGER.debug(

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -263,16 +263,16 @@ class PlantMinMax(RestoreNumber):
         # New entities let has_entity_name derive the entity_id automatically,
         # which enables auto-rename when the device is renamed.
         ent_reg = er_async_get(hass)
-        existing_entity_id = ent_reg.async_get_entity_id(
-            NUMBER_DOMAIN, DOMAIN, self._attr_unique_id
-        )
         # Track whether this is a brand-new config entry. HA's RestoreState
         # keyed by entity_id preserves deleted entities' last state for ~7
         # days, so a delete + re-add with the same plant name would restore
         # stale values over the fresh ones from OpenPlantbook. Skip restore
         # when the unique_id is new.
-        self._is_new_entity = existing_entity_id is None
-        if existing_entity_id:
+        self._is_new_entity = (
+            ent_reg.async_get_entity_id(NUMBER_DOMAIN, DOMAIN, self._attr_unique_id)
+            is None
+        )
+        if not self._is_new_entity:
             self.entity_id = async_generate_entity_id(
                 f"{NUMBER_DOMAIN}.{{}}",
                 f"{self._plant.name} {self._entity_id_key}",

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 from homeassistant.components.number import NumberMode
 from homeassistant.const import LIGHT_LUX, PERCENTAGE, UnitOfConductivity
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache_with_extra_data,
+)
 
 from custom_components.plant.const import (
     ATTR_PLANT,
@@ -15,6 +18,8 @@ from custom_components.plant.const import (
     DOMAIN,
     UNIT_DLI,
 )
+
+from .conftest import TEST_PLANT_NAME
 
 
 class TestThresholdEntitiesCreation:
@@ -610,3 +615,118 @@ class TestLuxToPpfdEntity:
         await hass.async_block_till_done()
 
         assert lux_to_ppfd.native_value == 0.014
+
+
+# Pre-built NumberExtraStoredData payload for max_moisture (0-100 %, step 1).
+def _moisture_extra(value: float) -> dict:
+    return {
+        "native_max_value": 100,
+        "native_min_value": 0,
+        "native_step": 1,
+        "native_unit_of_measurement": PERCENTAGE,
+        "native_value": value,
+    }
+
+
+class TestThresholdRestoreState:
+    """Tests for RestoreState behavior of threshold entities.
+
+    HA's RestoreState is keyed by entity_id and retains values for ~7 days
+    after entity removal. A delete + re-add of a plant with the same name
+    produces a colliding auto-derived entity_id, which without a guard
+    would restore the deleted entity's stale value over the fresh
+    OPB-fetched default. These tests cover both halves of the contract:
+
+    - Brand-new config entries skip restore and use defaults.
+    - Existing entries (already in the entity registry) still restore,
+      so user edits survive normal restarts and reloads.
+    """
+
+    async def test_new_entity_skips_stale_restore_state(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """A brand-new config entry must use the default value from
+        FLOW_PLANT_LIMITS, not stale RestoreState left behind by a
+        previously-deleted entity that happened to share the same
+        auto-derived entity_id.
+
+        Reproduces the delete + re-add scenario from #392: the
+        deleted plant left max_moisture=99 % in RestoreState; a fresh
+        re-add with the same name must show the configured 60 %.
+        """
+        mock_restore_cache_with_extra_data(
+            hass,
+            [
+                (
+                    State("number.test_plant_max_soil_moisture", "99"),
+                    _moisture_extra(99),
+                ),
+            ],
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id="brand_new_entry_id",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        # plant_config_data sets max_moisture=60. Without the skip-restore
+        # guard, the stale 99 from RestoreState would win.
+        assert plant.max_moisture.native_value == 60
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_existing_entity_restores_user_edited_value(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Existing entries (already present in the entity registry from
+        a prior setup) must continue to restore their previous value.
+        Only brand-new entries skip restore.
+        """
+        entry_id = "existing_entry_id"
+        unique_id = f"{entry_id}-max-moisture"
+
+        # Pre-register the entity so the integration sees it as existing.
+        ent_reg = er.async_get(hass)
+        registry_entry = ent_reg.async_get_or_create(
+            domain="number",
+            platform=DOMAIN,
+            unique_id=unique_id,
+        )
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [(State(registry_entry.entity_id, "85"), _moisture_extra(85))],
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        # The user previously edited max_moisture to 85; that must win
+        # over the config default of 60.
+        assert plant.max_moisture.native_value == 85
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Summary
- Home Assistant's `RestoreState` is keyed by `entity_id` and retains state for removed entities for ~7 days.
- When a plant was deleted and re-added with the same name, the auto-derived `entity_id` collided with the previous entity. `async_get_last_number_data()` then returned the stale value, overwriting the fresh `_default_value` just loaded from OpenPlantbook.
- Detect a brand-new config entry via the entity-registry lookup already performed in `__init__` (unique_id includes `entry_id`, so a new entry never has a registry match). When new, skip restore and keep the default.
- Existing entries restore as before, so user edits still survive restarts and reloads.

Refs #392. Holding off on merging until the reporter confirms which scenario they actually hit.

## Test plan
- [ ] Existing plant: edit a threshold in UI, restart HA — user's value is restored.
- [ ] Delete a plant, change species data in OpenPlantbook, re-add the plant with the same name — thresholds show the fresh OPB values, not the deleted entity's last state.
- [ ] Force refresh on an existing plant — thresholds update to the fresh OPB values (should be unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)