### PR TITLE
release: 2026.4.0-beta8

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.4.0-beta7"
+  "version": "2026.4.0-beta8"
 }


### PR DESCRIPTION
Bumps version to **2026.4.0-beta8** to ship the fix for #417 (entity_id wrong-domain warnings in HA 2026.5).

## Included since 2026.4.0-beta7
- #421 — fix: use platform domain (sensor/number) for entity_id, not integration domain. Stops the `Detected that custom integration 'plant' sets an entity ID with wrong domain` warnings on every threshold and current-value entity. (Fixes #417)
- #421 — refactor: drop `DOMAIN_SENSOR`/`ENTITY_ID_PREFIX_SENSOR` indirection in `const.py`; each platform file now imports its own `DOMAIN as <NAME>_DOMAIN` directly from HA. Enables ruff `combine-as-imports`.

## Test plan
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest tests/` — 245 passed
- [ ] Manual: load on HA 2026.5 and confirm no `wrong domain` warnings during setup