### PR TITLE
fix: edge-trigger force-refresh + publish state immediately (refs #392)

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -778,16 +778,23 @@ async def update_plant_options(
         return
 
     plant = hass.data[DOMAIN][entry.entry_id]["plant"]
+    _LOGGER.debug(
+        "update_plant_options begin for %s Options: %s",
+        entry.entry_id,
+        dict(entry.options),
+    )
     entity_picture = entry.options.get(ATTR_ENTITY_PICTURE)
 
     if entity_picture is not None:
         if entity_picture == "":
             plant.add_image(entity_picture)
         elif entity_picture.startswith(URL_SCHEME_MEDIA_SOURCE):
+            _LOGGER.debug("Using media-source URL: %s", entity_picture)
             plant.add_image(entity_picture)
         elif entity_picture.startswith(("http://", "https://")):
             try:
                 cv.url(entity_picture)
+                _LOGGER.debug("Using HTTP URL: %s", entity_picture)
                 plant.add_image(entity_picture)
             except vol.Invalid as exc:
                 _LOGGER.warning("Not a valid URL: %s", entity_picture)
@@ -795,6 +802,7 @@ async def update_plant_options(
         elif entity_picture.startswith("/"):
             try:
                 cv.path(entity_picture)
+                _LOGGER.debug("Using local path: %s", entity_picture)
                 plant.add_image(entity_picture)
             except vol.Invalid as exc:
                 _LOGGER.warning("Not a valid path: %s", entity_picture)
@@ -819,6 +827,12 @@ async def update_plant_options(
 
     new_species = entry.options.get(ATTR_SPECIES)
     if new_species is not None and new_species != plant.species:
+        _LOGGER.debug(
+            "Species changed from '%s' to '%s' (no OPB sync — that's "
+            "handled by the form handler when applicable)",
+            plant.species,
+            new_species,
+        )
         plant.species = new_species
 
     plant.update_registry()
@@ -826,6 +840,7 @@ async def update_plant_options(
     # state machine immediately. Without this the UI would only see the
     # update on the next 30 s poll.
     plant.async_write_ha_state()
+    _LOGGER.debug("update_plant_options done for %s", entry.entry_id)
 
 
 async def refresh_plant_from_openplantbook(
@@ -843,11 +858,21 @@ async def refresh_plant_from_openplantbook(
     applied, False if OPB had nothing for this species.
     """
     _LOGGER.debug(
-        "Refreshing %s from OpenPlantbook for species '%s'",
+        "refresh_plant_from_openplantbook CALLED for %s, species='%s'",
         entry.entry_id,
         new_species,
     )
     plant_helper = PlantHelper(hass=hass)
+    if not plant_helper.has_openplantbook:
+        _LOGGER.debug(
+            "OpenPlantbook integration not available; recording species "
+            "without sync for %s",
+            entry.entry_id,
+        )
+        plant.species = new_species
+        plant.async_write_ha_state()
+        return False
+
     plant_config = await plant_helper.generate_configentry(
         config={
             ATTR_SPECIES: new_species,
@@ -857,8 +882,17 @@ async def refresh_plant_from_openplantbook(
             FLOW_FORCE_SPECIES_UPDATE: True,
         }
     )
+    _LOGGER.debug(
+        "generate_configentry returned: data_source=%s, limits=%s",
+        plant_config[DATA_SOURCE],
+        plant_config.get(FLOW_PLANT_INFO, {}).get(FLOW_PLANT_LIMITS),
+    )
 
     if plant_config[DATA_SOURCE] != DATA_SOURCE_PLANTBOOK:
+        _LOGGER.debug(
+            "OpenPlantbook had no data for '%s'; recording species without " "sync",
+            new_species,
+        )
         plant.species = new_species
         plant.async_write_ha_state()
         return False
@@ -875,7 +909,9 @@ async def refresh_plant_from_openplantbook(
         opb_display_raw[0].upper() + opb_display_raw[1:] if opb_display_raw else ""
     )
 
-    for key, value in plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].items():
+    limits = plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
+    _LOGGER.debug("Updating %d threshold entities from OPB data", len(limits))
+    for key, value in limits.items():
         set_entity = getattr(plant, key, None)
         if set_entity is None:
             _LOGGER.warning(
@@ -884,6 +920,13 @@ async def refresh_plant_from_openplantbook(
                 plant.name,
             )
             continue
+        _LOGGER.debug(
+            "Setting %s (entity_id=%s) from %s to %s",
+            key,
+            set_entity.entity_id,
+            set_entity.native_value,
+            value,
+        )
         await set_entity.async_set_native_value(float(value))
 
     # Single atomic update of entry.data (limits) + entry.options
@@ -891,15 +934,15 @@ async def refresh_plant_from_openplantbook(
     # entry state that already matches the in-memory plant attrs.
     data = dict(entry.data)
     plant_info = dict(data.get(FLOW_PLANT_INFO, {}))
-    plant_info[FLOW_PLANT_LIMITS] = dict(
-        plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
-    )
+    plant_info[FLOW_PLANT_LIMITS] = dict(limits)
     data[FLOW_PLANT_INFO] = plant_info
     options = dict(entry.options)
     options[OPB_DISPLAY_PID] = plant.display_species
     options[ATTR_ENTITY_PICTURE] = plant.entity_picture
+    _LOGGER.debug("Persisting refreshed limits and OPB metadata for %s", entry.entry_id)
     hass.config_entries.async_update_entry(entry, data=data, options=options)
 
     plant.update_registry()
     plant.async_write_ha_state()
+    _LOGGER.debug("refresh_plant_from_openplantbook done for %s", entry.entry_id)
     return True

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -615,6 +615,30 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             ):
                 user_input[OPB_DISPLAY_PID] = ""
 
+            # FLOW_FORCE_SPECIES_UPDATE is an edge-triggered "do this now"
+            # signal, not durable state. Pop it before storing so it never
+            # persists to entry.options where a stale True from a prior
+            # failed attempt would collide with a future identical
+            # submission and silently break force-refresh.
+            force_refresh = user_input.pop(FLOW_FORCE_SPECIES_UPDATE, False)
+            new_species = user_input.get(ATTR_SPECIES, "")
+
+            # Trigger OPB sync directly when species changed or the user
+            # clicked "Force refresh". The update listener is unreliable
+            # for this — HA short-circuits it when submitted options equal
+            # current options, which is exactly the force-refresh case
+            # when nothing else changed.
+            if new_species and (force_refresh or new_species != self.plant.species):
+                opb_succeeded = await refresh_plant_from_openplantbook(
+                    self.hass, self.config_entry, self.plant, new_species
+                )
+                if opb_succeeded:
+                    # Reflect OPB-fetched values in user_input so the
+                    # framework's subsequent async_update_entry doesn't
+                    # overwrite them with the form's prefilled values.
+                    user_input[OPB_DISPLAY_PID] = self.plant.display_species
+                    user_input[ATTR_ENTITY_PICTURE] = self.plant.entity_picture
+
             _LOGGER.debug(
                 "Options flow creating entry with data: %s (previous options: %s)",
                 user_input,
@@ -741,50 +765,41 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 async def update_plant_options(
     hass: HomeAssistant, entry: config_entries.ConfigEntry
 ) -> None:
-    """Handle options update."""
+    """Apply non-OPB options changes to the plant entity.
+
+    Fired by HA whenever entry.options changes. Note that HA short-circuits
+    this when the new options dict equals the current one — so anything that
+    must run on every form submission (e.g. force-refreshing OPB) is invoked
+    directly from OptionsFlowHandler.async_step_plant_properties, not here.
+    """
     _LOGGER.debug("update_plant_options CALLED for entry %s", entry.entry_id)
-    # Guard against being called after entry is unloaded
     if entry.entry_id not in hass.data.get(DOMAIN, {}):
         _LOGGER.debug("Ignoring update for unloaded entry %s", entry.entry_id)
         return
 
     plant = hass.data[DOMAIN][entry.entry_id]["plant"]
-
-    _LOGGER.debug(
-        "update_plant_options begin for %s Options: %s Data: %s",
-        entry.entry_id,
-        dict(entry.options),
-        dict(entry.data),
-    )
     entity_picture = entry.options.get(ATTR_ENTITY_PICTURE)
 
     if entity_picture is not None:
         if entity_picture == "":
             plant.add_image(entity_picture)
         elif entity_picture.startswith(URL_SCHEME_MEDIA_SOURCE):
-            # Media-source URL - pass through for frontend/card to resolve
-            _LOGGER.debug("Using media-source URL: %s", entity_picture)
             plant.add_image(entity_picture)
         elif entity_picture.startswith(("http://", "https://")):
-            # Full HTTP URL - validate
             try:
                 cv.url(entity_picture)
-                _LOGGER.debug("Using HTTP URL: %s", entity_picture)
                 plant.add_image(entity_picture)
             except vol.Invalid as exc:
                 _LOGGER.warning("Not a valid URL: %s", entity_picture)
                 raise vol.Invalid(f"Invalid URL: {entity_picture}") from exc
         elif entity_picture.startswith("/"):
-            # Relative path (like /local/...) - validate as path
             try:
                 cv.path(entity_picture)
-                _LOGGER.debug("Using local path: %s", entity_picture)
                 plant.add_image(entity_picture)
             except vol.Invalid as exc:
                 _LOGGER.warning("Not a valid path: %s", entity_picture)
                 raise vol.Invalid(f"Invalid path: {entity_picture}") from exc
         else:
-            # Unknown format
             _LOGGER.warning(
                 "Unknown image format: %s. Use a full URL or /local/ path.",
                 entity_picture,
@@ -796,7 +811,6 @@ async def update_plant_options(
 
     new_display_species = entry.options.get(OPB_DISPLAY_PID)
     if new_display_species is not None:
-        # Capitalize first letter for proper binomial nomenclature
         plant.display_species = (
             new_display_species[0].upper() + new_display_species[1:]
             if new_display_species
@@ -804,86 +818,88 @@ async def update_plant_options(
         )
 
     new_species = entry.options.get(ATTR_SPECIES)
-    force_new_species = entry.options.get(FLOW_FORCE_SPECIES_UPDATE)
-    _LOGGER.debug(
-        "Force refresh check: new_species=%s, plant.species=%s, "
-        "force_new_species=%s, species_changed=%s",
-        new_species,
-        plant.species,
-        force_new_species,
-        new_species != plant.species if new_species is not None else "N/A",
-    )
-    if new_species is not None and (
-        new_species != plant.species or force_new_species is True
-    ):
-        _LOGGER.debug("Species changed from '%s' to '%s'", plant.species, new_species)
-        plant_helper = PlantHelper(hass=hass)
-        plant_config = await plant_helper.generate_configentry(
-            config={
-                ATTR_SPECIES: new_species,
-                ATTR_ENTITY_PICTURE: entity_picture,
-                OPB_DISPLAY_PID: new_display_species,
-                FLOW_FORCE_SPECIES_UPDATE: force_new_species,
-            }
-        )
-        _LOGGER.debug(
-            "generate_configentry returned: data_source=%s, limits=%s",
-            plant_config[DATA_SOURCE],
-            plant_config.get(FLOW_PLANT_INFO, {}).get(FLOW_PLANT_LIMITS),
-        )
-        if plant_config[DATA_SOURCE] == DATA_SOURCE_PLANTBOOK:
-            plant.species = new_species
-            plant.add_image(plant_config[FLOW_PLANT_INFO][ATTR_ENTITY_PICTURE])
-            # Capitalize first letter for proper binomial nomenclature
-            opb_display = plant_config[FLOW_PLANT_INFO][OPB_DISPLAY_PID]
-            plant.display_species = (
-                opb_display[0].upper() + opb_display[1:] if opb_display else ""
-            )
-            _LOGGER.debug(
-                "Updating %d threshold entities from OPB data",
-                len(plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]),
-            )
-            for key, value in plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].items():
-                set_entity = getattr(plant, key)
-                if set_entity is None:
-                    _LOGGER.warning(
-                        "Threshold entity for '%s' is None on plant %s, skipping",
-                        key,
-                        plant.name,
-                    )
-                    continue
-                _LOGGER.debug(
-                    "Setting %s (entity_id=%s) from %s to %s",
-                    key,
-                    set_entity.entity_id,
-                    set_entity.native_value,
-                    value,
-                )
-                await set_entity.async_set_native_value(float(value))
+    if new_species is not None and new_species != plant.species:
+        plant.species = new_species
 
-        else:
-            plant.species = new_species
-
-        # We need to reset the force_update option back to False, or else
-        # this will only be run once (unchanged options are will not trigger the flow)
-        options = dict(entry.options)
-        data = dict(entry.data)
-        # Persist refreshed OPB limits to config entry so they survive restarts
-        if plant_config[DATA_SOURCE] == DATA_SOURCE_PLANTBOOK:
-            plant_info = dict(data.get(FLOW_PLANT_INFO, {}))
-            plant_info[FLOW_PLANT_LIMITS] = dict(
-                plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
-            )
-            data[FLOW_PLANT_INFO] = plant_info
-        options[FLOW_FORCE_SPECIES_UPDATE] = False
-        options[OPB_DISPLAY_PID] = plant.display_species
-        options[ATTR_ENTITY_PICTURE] = plant.entity_picture
-        _LOGGER.debug(
-            "Doing a refresh to update values: Data: %s Options: %s",
-            data,
-            options,
-        )
-
-        hass.config_entries.async_update_entry(entry, data=data, options=options)
-    _LOGGER.debug("Update plant options done for %s", entry.entry_id)
     plant.update_registry()
+    # Push attribute changes (display_species, entity_picture) into the
+    # state machine immediately. Without this the UI would only see the
+    # update on the next 30 s poll.
+    plant.async_write_ha_state()
+
+
+async def refresh_plant_from_openplantbook(
+    hass: HomeAssistant,
+    entry: config_entries.ConfigEntry,
+    plant,
+    new_species: str,
+) -> bool:
+    """Fetch fresh species data from OpenPlantbook and apply to the plant.
+
+    Called directly from OptionsFlowHandler when the user changes species
+    or clicks "Force refresh" — *not* from the update listener, because HA
+    silently skips listener invocation when submitted options happen to
+    equal current options. Returns True if OPB returned data and was
+    applied, False if OPB had nothing for this species.
+    """
+    _LOGGER.debug(
+        "Refreshing %s from OpenPlantbook for species '%s'",
+        entry.entry_id,
+        new_species,
+    )
+    plant_helper = PlantHelper(hass=hass)
+    plant_config = await plant_helper.generate_configentry(
+        config={
+            ATTR_SPECIES: new_species,
+            ATTR_ENTITY_PICTURE: plant.entity_picture,
+            OPB_DISPLAY_PID: plant.display_species,
+            # Always bypass any OPB-side cache for an explicit refresh.
+            FLOW_FORCE_SPECIES_UPDATE: True,
+        }
+    )
+
+    if plant_config[DATA_SOURCE] != DATA_SOURCE_PLANTBOOK:
+        plant.species = new_species
+        plant.async_write_ha_state()
+        return False
+
+    # Apply all plant-side mutations *before* any operation that fires the
+    # entry update listener, so the listener never sees a half-updated
+    # plant. _attr_entity_picture is set directly (rather than via
+    # add_image) so we can defer the entry write to a single atomic update
+    # at the end of this function.
+    plant.species = new_species
+    plant._attr_entity_picture = plant_config[FLOW_PLANT_INFO][ATTR_ENTITY_PICTURE]
+    opb_display_raw = plant_config[FLOW_PLANT_INFO][OPB_DISPLAY_PID]
+    plant.display_species = (
+        opb_display_raw[0].upper() + opb_display_raw[1:] if opb_display_raw else ""
+    )
+
+    for key, value in plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].items():
+        set_entity = getattr(plant, key, None)
+        if set_entity is None:
+            _LOGGER.warning(
+                "Threshold entity for '%s' is None on plant %s, skipping",
+                key,
+                plant.name,
+            )
+            continue
+        await set_entity.async_set_native_value(float(value))
+
+    # Single atomic update of entry.data (limits) + entry.options
+    # (display_pid, image). The resulting listener invocation, if any, sees
+    # entry state that already matches the in-memory plant attrs.
+    data = dict(entry.data)
+    plant_info = dict(data.get(FLOW_PLANT_INFO, {}))
+    plant_info[FLOW_PLANT_LIMITS] = dict(
+        plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
+    )
+    data[FLOW_PLANT_INFO] = plant_info
+    options = dict(entry.options)
+    options[OPB_DISPLAY_PID] = plant.display_species
+    options[ATTR_ENTITY_PICTURE] = plant.entity_picture
+    hass.config_entries.async_update_entry(entry, data=data, options=options)
+
+    plant.update_registry()
+    plant.async_write_ha_state()
+    return True

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -26,6 +26,7 @@ from custom_components.plant.const import (
     CONF_MIN_TEMPERATURE,
     CONF_MIN_VPD,
     DOMAIN,
+    FLOW_FORCE_SPECIES_UPDATE,
     FLOW_PLANT_INFO,
     FLOW_PLANT_LIMITS,
     FLOW_RIGHT_PLANT,
@@ -1206,3 +1207,144 @@ class TestOptionsFlow:
         )
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert init_integration.options.get(FLOW_MOISTURE_GRACE_PERIOD) == 86400
+
+    async def test_force_refresh_works_when_options_unchanged(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_services,
+    ) -> None:
+        """Force refresh must trigger an OPB sync even when the resulting
+        options dict is identical to the current options dict.
+
+        Regression for the Mars2020-Github case in #392: a previous
+        force-refresh attempt failed before it could reset force_update,
+        leaving force_update=True permanently in entry.options. The next
+        force-refresh attempt then submits the same options dict, HA's
+        async_update_entry detects no change, the update_listener never
+        fires, and OPB sync is silently skipped.
+        """
+        entry = init_integration
+        plant = hass.data[DOMAIN][entry.entry_id]["plant"]
+
+        # Simulate the stale state: every option the form would submit is
+        # already in entry.options at the same value, including a stale
+        # force_update=True from a prior failed attempt. We bypass update
+        # listeners while seeding this state so the listener doesn't reset
+        # force_update to False the way a successful run normally would.
+        identical_options = {
+            ATTR_SPECIES: "monstera deliciosa",
+            FLOW_FORCE_SPECIES_UPDATE: True,
+            OPB_DISPLAY_PID: "Monstera deliciosa",
+            ATTR_ENTITY_PICTURE: "https://example.com/stale.jpg",
+            "illuminance_trigger": True,
+            "dli_trigger": True,
+            "humidity_trigger": True,
+            "temperature_trigger": True,
+            "moisture_trigger": True,
+            "moisture_grace_period": 0,
+            "conductivity_trigger": True,
+            "co2_trigger": True,
+            "soil_temperature_trigger": True,
+            "vpd_trigger": False,
+        }
+        saved_listeners = list(entry.update_listeners)
+        entry.update_listeners.clear()
+        try:
+            hass.config_entries.async_update_entry(entry, options=identical_options)
+            await hass.async_block_till_done()
+        finally:
+            entry.update_listeners.extend(saved_listeners)
+
+        # Sanity check the precondition: stale force_update=True is in
+        # entry.options now, with no listener invocation having reset it.
+        assert entry.options.get(FLOW_FORCE_SPECIES_UPDATE) is True
+
+        # User opens the options form and submits the form prefilled with
+        # those same values — bit-identical to current entry.options.
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {"next_step_id": "plant_properties"},
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], dict(identical_options)
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        # OPB sync must have run: the plant should now show the OPB-fetched
+        # image (not the stale form-prefilled value).
+        assert plant.entity_picture == GET_RESULT_MONSTERA_DELICIOSA["image_url"]
+
+    async def test_options_flow_publishes_state_immediately(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_no_openplantbook,
+    ) -> None:
+        """After a successful options-flow submission, the plant entity's
+        published state must reflect the new attributes immediately, not
+        after the next 30-second poll. Without an explicit
+        async_write_ha_state call, mutating instance attributes
+        (display_species, entity_picture) leaves hass.states stale until
+        polling fires.
+        """
+        entry = init_integration
+        plant = hass.data[DOMAIN][entry.entry_id]["plant"]
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "plant_properties"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SPECIES: "rebranded species",
+                OPB_DISPLAY_PID: "Rebranded Display",
+                ATTR_ENTITY_PICTURE: "https://example.com/rebranded.jpg",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        # No sleep, no poll — read state immediately.
+        state = hass.states.get(plant.entity_id)
+        assert state is not None
+        assert state.attributes.get(ATTR_SPECIES) == "Rebranded Display"
+        assert (
+            state.attributes.get("entity_picture")
+            == "https://example.com/rebranded.jpg"
+        )
+
+    async def test_force_update_not_persisted_to_options(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_services,
+    ) -> None:
+        """force_update is an edge-triggered signal ('do this now'), not
+        durable state. After processing, it must not remain in
+        entry.options where it could collide with a future identical
+        submission and silently break force-refresh.
+        """
+        entry = init_integration
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "plant_properties"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SPECIES: "monstera deliciosa",
+                FLOW_FORCE_SPECIES_UPDATE: True,
+                OPB_DISPLAY_PID: "Monstera deliciosa",
+                ATTR_ENTITY_PICTURE: "https://example.com/whatever.jpg",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        assert FLOW_FORCE_SPECIES_UPDATE not in entry.options


### PR DESCRIPTION
## Summary
Two related fixes for the OpenPlantbook force-refresh path:

1. **Force-refresh is now reliable even when no field changes value.** `FLOW_FORCE_SPECIES_UPDATE` was being stored in `entry.options`, and HA's `_async_update_entry` short-circuits update listeners when the new options dict equals the current one. A previous force-refresh that failed before resetting the flag left `force_update=True` permanently in `entry.options` — every subsequent force-refresh attempt then collided with that stale True, the listener never fired, and OPB sync silently never ran (the Mars2020-Github case in #392 — confirmed by the `update_plant_options CALLED` debug line being absent in his beta7 log).

   `force_update` is reframed as the edge-triggered \"do this now\" signal it always was: `OptionsFlowHandler` pops it from `user_input` (so it never persists) and invokes the OPB sync directly. The new `refresh_plant_from_openplantbook` function bypasses the update-listener path entirely, so HA's dedupe-on-equal can no longer short-circuit it.

2. **Plant entity attributes update immediately, not after the next 30 s poll.** `update_plant_options` mutated `PlantDevice` instance attributes (`species`, `display_species`, `_attr_entity_picture`) but never called `plant.async_write_ha_state()`. `hass.states` stayed stale until the periodic `update()` poll wrote state, which is why \"submit, look at the device, see old data, submit again, see new data\" — the second submit was a coincident bystander; you'd see the same fix by just waiting 30 seconds. Both `update_plant_options` and the new refresh function now publish state explicitly.

## Architectural cleanup
- OPB-sync code extracted out of `update_plant_options` into a standalone async function. The listener no longer carries OPB logic — it just applies entry.options changes (image, display, species, triggers) to the plant and publishes state.
- The new function performs all plant-side mutations before any listener-firing operation, then commits a single atomic `async_update_entry` of both data (limits) and options (display_pid, image). The listener invocation, if any, sees consistent state instead of racing with the refresh mid-update.

## Tests
- `test_force_refresh_works_when_options_unchanged` — sets up entry.options identical to what the form will submit (with stale `force_update=True`) by clearing update_listeners during seed, then verifies OPB sync still runs. Reproduces the Mars2020-Github case directly.
- `test_options_flow_publishes_state_immediately` — submits species change, asserts `hass.states.get(plant.entity_id).attributes` reflects the new species/picture *immediately* (no `await asyncio.sleep`, no polling).
- `test_force_update_not_persisted_to_options` — asserts `FLOW_FORCE_SPECIES_UPDATE` is absent from `entry.options` after submission.

## Test plan
- [x] All 248 unit tests pass
- [x] `ruff check .` clean
- [x] `black --check .` clean
- [ ] Manual: trigger force-refresh on a real install (HA 2026.5) and confirm both species/image update immediately on the device card and that re-clicking force-refresh works repeatably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)