### PR TITLE
release: 2026.4.0-beta9

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.4.0-beta8"
+  "version": "2026.4.0-beta9"
 }


### PR DESCRIPTION
Bumps version to **2026.4.0-beta9** to ship the OpenPlantbook force-refresh fix and the 30 s-delay fix from #423.

## Included since 2026.4.0-beta8
- #423 — fix: edge-trigger force-refresh + publish state immediately
  - `force_update` is no longer stored in `entry.options`. Instead, `OptionsFlowHandler` pops it and invokes the OPB sync directly, bypassing HA's listener-on-change short-circuit. (Refs #392 — Mars2020-Github case where stale `force_update=True` made the listener silently never fire.)
  - The OPB-sync logic is extracted into `refresh_plant_from_openplantbook`, guarded by `PlantHelper.has_openplantbook`, and performs all plant-side mutations before any listener-firing operation.
  - `update_plant_options` (and the new refresh function) now call `plant.async_write_ha_state()` so the entity's published attributes update immediately on submit, not after the next 30 s poll.
  - PR #414's diagnostic logging restored / extended for both paths.

## Test plan
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest tests/` — 248 passed
- [ ] Manual on HA 2026.5: change species (with OPB available) → device card updates immediately. Click "Force refresh" twice → second click still triggers OPB call.