### PR TITLE
Add missing dependency on pytest-freezer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ test = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
+    "pytest-freezer>=0.4.9",
     "pytest-timeout>=2.2.0",
     "pytest-homeassistant-custom-component>=0.13.0",
     "syrupy>=4.6.0",


### PR DESCRIPTION
Required since #390 to run the tests