### PR TITLE
release: 2026.5.0-beta1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.4.0-beta9"
+  "version": "2026.5.0-beta1"
 }


### PR DESCRIPTION
First beta of the **2026.5** minor cycle.

I read your "2025.5" as a typo for **2026.5** — current version is `2026.4.0-beta9` and today is May 2026. If you actually meant something else (e.g., starting fresh major numbering), let me know before merging.

## Included since 2026.4.0-beta9
- #413 — fix: skip RestoreState for brand-new threshold entities. A delete + re-add of a same-named plant no longer restores the deleted entity's stale value over the fresh OPB-fetched default. The auto-derived `entity_id` collision via HA's RestoreState (~7-day retention) was a third independent thread of #392, distinct from the force-refresh and entity-domain bugs already shipped in beta8/beta9.
- #426 — chore: declare `pytest-freezer` as a test dependency (was a transitive dep that happened to be present in CI and dev environments).

## Test plan
- [x] `ruff check .`
- [x] `black --check .`
- [x] `pytest tests/` — 250 passed
- [ ] Manual: delete a plant whose thresholds you've edited, change the species data in OpenPlantbook, re-add the plant with the same name within 7 days. Confirm the thresholds show the fresh OPB values, not the deleted entity's last state.