### PR TITLE
fix: skip disabled thresholds in OPB refresh + drop thread-unsafe poll call

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1393,7 +1393,12 @@ class PlantDevice(Entity):
                 new_state,
             )
         self._attr_state = new_state
-        self.update_registry()
+        # Note: do NOT call self.update_registry() here. update() runs in
+        # an executor thread (HA's polling), and device_registry.async_get_or_create
+        # raises in HA 2026.5+ when called off the event loop. Device-registry
+        # updates are handled by the async paths (async_added_to_hass,
+        # update_plant_options, refresh_plant_from_openplantbook), which fire
+        # whenever model/manufacturer can actually change.
 
     @property
     def data_source(self) -> str | None:

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -920,6 +920,17 @@ async def refresh_plant_from_openplantbook(
                 plant.name,
             )
             continue
+        # Disabled threshold entities (e.g. CO2 thresholds when no CO2
+        # sensor is configured) get aborted by HA's EntityPlatform with
+        # entity.hass set back to None. The instance is still referenced
+        # from plant.add_thresholds, but it cannot publish state — skip.
+        if set_entity.hass is None:
+            _LOGGER.debug(
+                "Threshold entity for '%s' is disabled on plant %s, skipping",
+                key,
+                plant.name,
+            )
+            continue
         _LOGGER.debug(
             "Setting %s (entity_id=%s) from %s to %s",
             key,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -37,6 +37,7 @@ from custom_components.plant.const import (
     OPB_DISPLAY_PID,
 )
 
+from .conftest import create_plant_config_data
 from .fixtures.openplantbook_responses import (
     GET_RESULT_MONSTERA_DELICIOSA,
 )
@@ -1317,6 +1318,76 @@ class TestOptionsFlow:
             state.attributes.get("entity_picture")
             == "https://example.com/rebranded.jpg"
         )
+
+    async def test_force_refresh_skips_disabled_threshold_entities(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+    ) -> None:
+        """Force refresh must not crash when threshold entities are
+        disabled (which happens when the user hasn't configured the
+        corresponding sensor — e.g., no CO2 sensor → CO2 thresholds
+        default-disabled).
+
+        HA's EntityPlatform calls entity.add_to_platform_abort() for
+        disabled entities, which sets entity.hass = None. The disabled
+        entity is still referenced from plant.add_thresholds, so the
+        OPB refresh loop hits it and previously crashed with
+        "Attribute hass is None for <entity unknown.unknown=unknown>".
+        """
+        # Plant with no CO2 / soil_temperature / illuminance sensors —
+        # those threshold entities will be default-disabled. moisture +
+        # temperature + humidity remain enabled.
+        config_data = create_plant_config_data(
+            co2_sensor=None,
+            soil_temperature_sensor=None,
+            illuminance_sensor=None,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_disabled_thresholds",
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id]["plant"]
+
+        # Sanity-check the precondition: at least one threshold has
+        # hass=None because the platform aborted the add for it.
+        assert plant.max_co2 is not None
+        assert plant.max_co2.hass is None
+
+        # Force refresh on a species that's in the OPB mock.
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "plant_properties"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SPECIES: "monstera deliciosa",
+                FLOW_FORCE_SPECIES_UPDATE: True,
+                OPB_DISPLAY_PID: "Monstera deliciosa",
+                ATTR_ENTITY_PICTURE: "https://example.com/test.jpg",
+            },
+        )
+
+        # The form must complete cleanly even with disabled thresholds
+        # in the loop. Before the fix this raised RuntimeError and the
+        # form returned "Unknown error occurred".
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        # An enabled threshold (moisture) should pick up the OPB value.
+        assert (
+            plant.max_moisture.native_value
+            == GET_RESULT_MONSTERA_DELICIOSA["max_soil_moist"]
+        )
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
 
     async def test_force_update_not_persisted_to_options(
         self,


### PR DESCRIPTION
Hotfix for two beta1-surfaced regressions, both pre-existing bugs unmasked by recent changes.

## Summary
1. **\`refresh_plant_from_openplantbook\` crashes on disabled thresholds.** When a plant has no CO2 / soil-temperature / etc. sensor configured, the corresponding threshold entities are default-disabled. HA's \`EntityPlatform.add_to_platform_abort()\` runs for those, setting \`entity.hass = None\`. The disabled instance is still referenced from \`plant.add_thresholds\`, so the OPB refresh loop iterates over it and crashes with \`RuntimeError: Attribute hass is None for <entity unknown.unknown=unknown>\`. The form returns \"Unknown error occurred\" to the user. Bug pre-dates beta9 — was masked because the listener invoked refresh via \`async_create_task\` (which swallowed exceptions). Calling refresh directly from the form handler now propagates it.
2. **\`update_registry()\` called from sync \`update()\` trips HA 2026.5's thread-safety check.** \`PlantDevice.update()\` runs in an executor thread (via \`hass.async_add_executor_job\`). \`device_registry.async_get_or_create(...)\` was tightened in HA 2026.5 from a warning to a \`RuntimeError\` when called off the event loop. The polling failed every 30 s.

## Fixes
1. Skip threshold entities whose \`hass is None\` alongside the existing \`is None\` check in \`refresh_plant_from_openplantbook\`. Disabled thresholds will pick up new defaults next time the user enables their sensor (which re-creates the entity with fresh hass).
2. Drop the \`self.update_registry()\` call from sync \`update()\`. Device-registry data is already refreshed by every async path that can change it: \`async_added_to_hass\` on first add, \`update_plant_options\` on any options change, \`refresh_plant_from_openplantbook\` on species/force-refresh. The polling caller was redundant *and* thread-unsafe.

## Test plan
- [x] New regression test \`test_force_refresh_skips_disabled_threshold_entities\` reproduces the exact \`Attribute hass is None\` RuntimeError without the fix and asserts the form completes cleanly with it (251 tests pass total).
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [ ] Manual on the user's HA 2026.5 install: change species → no \"Unknown error occurred\", thresholds update, no thread-safety errors in the log every 30 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)