### PR TITLE
release: 2026.5.0-beta2

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.5.0-beta1"
+  "version": "2026.5.0-beta2"
 }


### PR DESCRIPTION
Hotfix release for two regressions surfaced in beta1.

## Included since 2026.5.0-beta1
- #428 — fix: skip disabled thresholds in OPB refresh + drop thread-unsafe poll call
  - Species change no longer fails with "Unknown error occurred" when a plant has any disabled threshold (e.g., CO2 thresholds without a CO2 sensor configured).
  - Polling no longer logs "calls device_registry._async_update_device from a thread other than the event loop" + RuntimeError every 30 s on HA 2026.5+.

## Test plan
- [x] \`pytest tests/\` — 251 passed (new regression test included)
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [ ] Manual: change species on a plant that has at least one missing sensor (e.g., no CO2). Form should complete cleanly, no "Unknown error" dialog, no thread-safety errors in the log.