### PR TITLE
release: 2026.5.0

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.5.0-beta2"
+  "version": "2026.5.0"
 }


### PR DESCRIPTION
First **stable** release of the 2026.5 cycle. Reporter confirmed beta2 works on their real install (species change clean, no thread-safety errors), so promoting straight to stable.

## Cumulative changelog since 2026.4.0
**Bug fixes**
- #421 — fix: HA 2026.5 \"wrong domain\" warnings on every threshold and current-value entity. Legacy-entity-id override was using the integration domain (\`plant\`) instead of the platform domain (\`sensor\`/\`number\`).
- #423 — fix: edge-trigger OpenPlantbook force-refresh. Stale \`force_update=True\` in entry.options no longer makes HA's listener-on-change silently skip the refresh, and the same path now publishes plant attributes (species, display, picture) immediately instead of waiting for the next 30 s poll.
- #413 — fix: brand-new threshold entities skip RestoreState. Delete + re-add of a same-named plant within HA's ~7 day retention window no longer restores the deleted entity's stale value over the fresh OPB default.
- #428 — fix: OPB refresh skips disabled threshold entities (e.g., CO2 thresholds when no CO2 sensor configured) instead of failing the form with \"Unknown error occurred\". Same PR removes \`update_registry()\` from the sync polling path, which HA 2026.5 promoted from a warning to a RuntimeError.

**Internal**
- #421 — refactor: drop \`DOMAIN_SENSOR\` / \`ENTITY_ID_PREFIX_SENSOR\` from \`const.py\`; each platform file imports its own \`DOMAIN as <X>_DOMAIN\` directly from HA. Enables \`combine-as-imports\` in ruff config.
- #426 — chore: declare \`pytest-freezer\` as a test dep (thanks @SuperSandro2000).

## Test plan
- [x] \`pytest tests/\` — 251 passed
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [x] Manually verified on HA 2026.5 by the maintainer (beta2)