### PR TITLE
fix: soil temperature thresholds not converted to HA temperature unit

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -272,4 +272,6 @@ CONF_PLANTBOOK_MAPPING = {
     CONF_MAX_MMOL: "max_light_mmol",
     CONF_MIN_DLI: "min_dli",
     CONF_MAX_DLI: "max_dli",
+    CONF_MIN_SOIL_TEMPERATURE: "min_soil_temp",
+    CONF_MAX_SOIL_TEMPERATURE: "max_soil_temp",
 }

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -976,10 +976,7 @@ class PlantMaxSoilTemperature(PlantMinMax):
                 )
             )
 
-        self._attr_native_value = new_state
-        self._attr_native_unit_of_measurement = new_attributes.get(
-            ATTR_UNIT_OF_MEASUREMENT
-        )
+        self.hass.states.async_set(self.entity_id, new_state, new_attributes)
 
 
 class PlantMinSoilTemperature(PlantMinMax):
@@ -1052,10 +1049,7 @@ class PlantMinSoilTemperature(PlantMinMax):
                 )
             )
 
-        self._attr_native_value = new_state
-        self._attr_native_unit_of_measurement = new_attributes.get(
-            ATTR_UNIT_OF_MEASUREMENT
-        )
+        self.hass.states.async_set(self.entity_id, new_state, new_attributes)
 
 
 class PlantLuxToPpfd(PlantMinMax):

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -369,6 +369,24 @@ class PlantHelper:
                 UnitOfTemperature.CELSIUS,
                 0,
             )
+            max_soil_temperature = display_temp(
+                self.hass,
+                _to_int(
+                    opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_SOIL_TEMPERATURE]),
+                    DEFAULT_MAX_SOIL_TEMPERATURE,
+                ),
+                UnitOfTemperature.CELSIUS,
+                0,
+            )
+            min_soil_temperature = display_temp(
+                self.hass,
+                _to_int(
+                    opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_SOIL_TEMPERATURE]),
+                    DEFAULT_MIN_SOIL_TEMPERATURE,
+                ),
+                UnitOfTemperature.CELSIUS,
+                0,
+            )
             # Prefer pre-computed DLI from openplantbook integration (includes
             # ratio-based detection). Fall back to mmol × PPFD_DLI_FACTOR.
             opb_max_dli = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_DLI])


### PR DESCRIPTION
Two bugs caused soil temperature thresholds to ignore HA's configured unit (°C/°F):

1. CONF_MIN/MAX_SOIL_TEMPERATURE were absent from CONF_PLANTBOOK_MAPPING in const.py, and the if opb_plant: block in plant_helpers.py never fetched or converted the OPB soil temp values. Add the mapping keys ("min_soil_temp"/"max_soil_temp") and mirror the same display_temp() fetch pattern already used for min_temp/max_temp directly above.

2. PlantMaxSoilTemperature and PlantMinSoilTemperature performed the TemperatureConverter.convert() calculation on unit change but only wrote the result to self._attr_native_value without calling hass.states.async_set(), so the converted value was silently discarded. Replace with hass.states.async_set() to match the identical fix already present in PlantMaxTemperature/PlantMinTemperature.