### PR TITLE
fix: pick up OpenPlantbook soil-temperature thresholds (refs #431)

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -272,4 +272,6 @@ CONF_PLANTBOOK_MAPPING = {
     CONF_MAX_MMOL: "max_light_mmol",
     CONF_MIN_DLI: "min_dli",
     CONF_MAX_DLI: "max_dli",
+    CONF_MIN_SOIL_TEMPERATURE: "min_soil_temp",
+    CONF_MAX_SOIL_TEMPERATURE: "max_soil_temp",
 }

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -369,6 +369,24 @@ class PlantHelper:
                 UnitOfTemperature.CELSIUS,
                 0,
             )
+            max_soil_temperature = display_temp(
+                self.hass,
+                _to_int(
+                    opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_SOIL_TEMPERATURE]),
+                    DEFAULT_MAX_SOIL_TEMPERATURE,
+                ),
+                UnitOfTemperature.CELSIUS,
+                0,
+            )
+            min_soil_temperature = display_temp(
+                self.hass,
+                _to_int(
+                    opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_SOIL_TEMPERATURE]),
+                    DEFAULT_MIN_SOIL_TEMPERATURE,
+                ),
+                UnitOfTemperature.CELSIUS,
+                0,
+            )
             # Prefer pre-computed DLI from openplantbook integration (includes
             # ratio-based detection). Fall back to mmol × PPFD_DLI_FACTOR.
             opb_max_dli = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_DLI])

--- a/tests/fixtures/openplantbook_responses.py
+++ b/tests/fixtures/openplantbook_responses.py
@@ -18,6 +18,8 @@ GET_RESULT_MONSTERA_DELICIOSA = {
     "min_light_lux": 1500,
     "max_temp": 30,
     "min_temp": 15,
+    "max_soil_temp": 28,
+    "min_soil_temp": 12,
     "max_env_humid": 80,
     "min_env_humid": 50,
     "max_soil_moist": 60,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1319,6 +1319,48 @@ class TestOptionsFlow:
             == "https://example.com/rebranded.jpg"
         )
 
+    async def test_force_refresh_picks_up_opb_soil_temperature(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_services,
+    ) -> None:
+        """OPB-fetched soil temperature thresholds (max_soil_temp /
+        min_soil_temp) must propagate to the plant. Without the
+        CONF_PLANTBOOK_MAPPING entries, generate_configentry's
+        if opb_plant: block silently skipped soil temp and the user
+        always saw the un-converted default values.
+        """
+        entry = init_integration
+        plant = hass.data[DOMAIN][entry.entry_id]["plant"]
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "plant_properties"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SPECIES: "monstera deliciosa",
+                FLOW_FORCE_SPECIES_UPDATE: True,
+                OPB_DISPLAY_PID: "Monstera deliciosa",
+                ATTR_ENTITY_PICTURE: "https://example.com/monstera.jpg",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        # HA test default unit system is metric (Celsius); display_temp
+        # passes the OPB Celsius value through unchanged.
+        assert (
+            plant.max_soil_temperature.native_value
+            == GET_RESULT_MONSTERA_DELICIOSA["max_soil_temp"]
+        )
+        assert (
+            plant.min_soil_temperature.native_value
+            == GET_RESULT_MONSTERA_DELICIOSA["min_soil_temp"]
+        )
+
     async def test_force_refresh_skips_disabled_threshold_entities(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
First of two PRs replacing #431. This is **@Majawat's \`const.py\` + \`plant_helpers.py\` changes verbatim**, plus a fixture extension and a regression test.

## Bug
\`CONF_PLANTBOOK_MAPPING\` is missing entries for \`CONF_MIN_SOIL_TEMPERATURE\` / \`CONF_MAX_SOIL_TEMPERATURE\`. Inside \`generate_configentry\`'s \`if opb_plant:\` block, every other threshold is fetched via \`opb_plant.get(CONF_PLANTBOOK_MAPPING[…])\` — soil temperature was simply not in the loop. Result: the \`max_soil_temperature\` / \`min_soil_temperature\` variables stayed at their initial defaults from the top of the function (40 / 10 °C, unit-converted at the top but never updated from OPB). Users saw the un-converted default values.

## Fix
- Add the two mapping entries to \`CONF_PLANTBOOK_MAPPING\` (\`min_soil_temp\` / \`max_soil_temp\` — matches OPB's API field naming).
- Inside the \`if opb_plant:\` block, add the \`display_temp()\` lookup for both, mirroring the air-temp pattern directly above. The variables flow through to \`FLOW_PLANT_LIMITS\` unchanged.

## Test
- \`GET_RESULT_MONSTERA_DELICIOSA\` fixture extended with \`max_soil_temp=28\` / \`min_soil_temp=12\`.
- New \`test_force_refresh_picks_up_opb_soil_temperature\` exercises the full options-flow + force-refresh path and asserts \`plant.max_soil_temperature.native_value == 28\`. RED-proven: the test fails on \`main\` (without these changes) because the values stay at the configured defaults.

## Test plan
- [x] \`pytest tests/\` — 252 passed
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [ ] Manual: force-refresh a plant whose OPB entry has \`max_soil_temp\` set, confirm the threshold updates to that value.

Part 2 (the \`number.py\` unit-conversion fix done properly across both air and soil temperature classes) lands separately. Closing #431 once both replacements are open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)