### PR TITLE
fix: temperature unit conversion no longer reverts on next state write (refs #431)

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -544,6 +544,16 @@ class PlantMaxTemperature(PlantMinMax):
                 new_state,
             )
 
+        # Update internal state AND publish via hass.states.async_set.
+        # Setting only _attr_native_value (without async_set) leaves the
+        # state machine stale until the next entity update; setting only
+        # via async_set leaves _attr_native_value stale so the next
+        # async_write_ha_state silently reverts the conversion. Both are
+        # required.
+        self._attr_native_value = new_state
+        self._attr_native_unit_of_measurement = new_attributes.get(
+            ATTR_UNIT_OF_MEASUREMENT
+        )
         self.hass.states.async_set(self.entity_id, new_state, new_attributes)
 
 
@@ -627,6 +637,10 @@ class PlantMinTemperature(PlantMinMax):
                 new_state,
             )
 
+        self._attr_native_value = new_state
+        self._attr_native_unit_of_measurement = new_attributes.get(
+            ATTR_UNIT_OF_MEASUREMENT
+        )
         self.hass.states.async_set(self.entity_id, new_state, new_attributes)
 
 
@@ -980,6 +994,7 @@ class PlantMaxSoilTemperature(PlantMinMax):
         self._attr_native_unit_of_measurement = new_attributes.get(
             ATTR_UNIT_OF_MEASUREMENT
         )
+        self.hass.states.async_set(self.entity_id, new_state, new_attributes)
 
 
 class PlantMinSoilTemperature(PlantMinMax):
@@ -1056,6 +1071,7 @@ class PlantMinSoilTemperature(PlantMinMax):
         self._attr_native_unit_of_measurement = new_attributes.get(
             ATTR_UNIT_OF_MEASUREMENT
         )
+        self.hass.states.async_set(self.entity_id, new_state, new_attributes)
 
 
 class PlantLuxToPpfd(PlantMinMax):

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -554,6 +554,137 @@ class TestTemperatureUnitConversion:
         state = hass.states.get(threshold.entity_id)
         assert state.state == initial_value
 
+    async def test_max_soil_temperature_converts_fahrenheit_to_celsius(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Soil-temperature thresholds must publish converted values to
+        the state machine on unit change, mirroring the existing air
+        max_temperature behavior. Pre-fix the soil class only mutated
+        _attr_native_value without writing state, so the published
+        state stayed in the old unit."""
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        threshold = plant.max_soil_temperature
+
+        await threshold.async_set_native_value(68)
+        await hass.async_block_till_done()
+
+        threshold.state_attributes_changed(
+            {"unit_of_measurement": "°F"},
+            {"unit_of_measurement": "°C"},
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get(threshold.entity_id)
+        assert state is not None
+        assert int(state.state) == 20
+
+    async def test_max_soil_temperature_converts_celsius_to_fahrenheit(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Soil max-temperature: °C → °F."""
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        threshold = plant.max_soil_temperature
+
+        await threshold.async_set_native_value(20)
+        await hass.async_block_till_done()
+
+        threshold.state_attributes_changed(
+            {"unit_of_measurement": "°C"},
+            {"unit_of_measurement": "°F"},
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get(threshold.entity_id)
+        assert state is not None
+        assert int(state.state) == 68
+
+    async def test_min_soil_temperature_converts_fahrenheit_to_celsius(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Soil min-temperature: °F → °C."""
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        threshold = plant.min_soil_temperature
+
+        await threshold.async_set_native_value(50)
+        await hass.async_block_till_done()
+
+        threshold.state_attributes_changed(
+            {"unit_of_measurement": "°F"},
+            {"unit_of_measurement": "°C"},
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get(threshold.entity_id)
+        assert state is not None
+        assert int(state.state) == 10
+
+    async def test_min_soil_temperature_converts_celsius_to_fahrenheit(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Soil min-temperature: °C → °F."""
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        threshold = plant.min_soil_temperature
+
+        await threshold.async_set_native_value(10)
+        await hass.async_block_till_done()
+
+        threshold.state_attributes_changed(
+            {"unit_of_measurement": "°C"},
+            {"unit_of_measurement": "°F"},
+        )
+        await hass.async_block_till_done()
+
+        state = hass.states.get(threshold.entity_id)
+        assert state is not None
+        assert int(state.state) == 50
+
+    async def test_temperature_conversion_persists_through_next_state_write(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Unit conversion must update the entity's _attr_native_value
+        AND publish state — not just one or the other.
+
+        Pre-fix the air-temp classes wrote the converted value via
+        hass.states.async_set, leaving _attr_native_value untouched.
+        The next time the entity calls async_write_ha_state (user
+        edit, polling, RestoreState restoration), it published from
+        native_value and the conversion was silently reverted.
+        """
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        threshold = plant.max_temperature
+
+        await threshold.async_set_native_value(68)
+        await hass.async_block_till_done()
+
+        threshold.state_attributes_changed(
+            {"unit_of_measurement": "°F"},
+            {"unit_of_measurement": "°C"},
+        )
+        await hass.async_block_till_done()
+
+        # Conversion happened correctly the first time. (hass.states.async_set
+        # writes the int value; subsequent NumberEntity writes format as
+        # "20.0" — float() handles both.)
+        assert float(hass.states.get(threshold.entity_id).state) == 20
+
+        # Force any subsequent state write — same channel that polling,
+        # restoration, or user edits would use.
+        threshold.async_write_ha_state()
+        await hass.async_block_till_done()
+
+        # State must still reflect the converted value, not revert.
+        assert float(hass.states.get(threshold.entity_id).state) == 20
+
 
 class TestLuxToPpfdEntity:
     """Tests for lux to PPFD conversion factor entity."""


### PR DESCRIPTION
Second of two PRs replacing #431. Goes further than the original by fixing **both** air and soil temperature classes against a deeper underlying bug.

## Summary
\`PlantMaxTemperature\` / \`PlantMinTemperature\` (air) used \`hass.states.async_set\` with the converted value but left \`_attr_native_value\` untouched. The conversion was visible in the state machine — until the next time anything called \`async_write_ha_state\` on the entity (poll, restore, user edit), at which point HA published from \`native_value\` (still in the old unit) and silently undid the conversion.

\`PlantMaxSoilTemperature\` / \`PlantMinSoilTemperature\` had the inverse half-fix: they updated \`_attr_native_value\` / \`_attr_native_unit_of_measurement\` but never wrote to the state machine, so the converted value was never visible at all (the bug @Majawat originally reported).

Both classes now use the same hybrid pattern:

\`\`\`python
self._attr_native_value = new_state
self._attr_native_unit_of_measurement = new_attributes.get(ATTR_UNIT_OF_MEASUREMENT)
self.hass.states.async_set(self.entity_id, new_state, new_attributes)
\`\`\`

## Why the obvious fix doesn't work
My first attempt was to drop \`hass.states.async_set\` entirely and just call \`async_write_ha_state\` after updating native_value. That broke 5 of the 12 conversion tests because \`NumberEntity\` (with \`device_class=TEMPERATURE\`) runs automatic unit conversion in its \`value\` property — when \`native_unit_of_measurement\` differs from HA's configured \`unit_of_measurement\`, it converts the value on every read. In the test environment HA's unit stays at C, so writing native=68 with native_unit=F made NumberEntity re-convert back to 20°C on the next read.

\`hass.states.async_set\` bypasses that property entirely, so it preserves the manually-set conversion. Setting both gets us the immediate display correctness AND keeps internal state consistent with what the state machine holds.

## Tests
- 4 new soil-temp conversion tests mirroring the existing 4 air-temp tests (max/min × F→C/C→F). RED-proven against main.
- 1 new revert-on-next-write test that calls \`async_write_ha_state\` after the conversion and asserts the converted value persists. RED-proven against main with the air-temp implementation.

## Test plan
- [x] \`pytest tests/\` — 256 passed
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [ ] Manual: change HA's temperature unit from °C to °F (or vice versa). Air and soil temperature thresholds should display in the new unit immediately, and stay there through subsequent UI interactions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)