### PR TITLE
release: 2026.5.1-beta1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.5.0"
+  "version": "2026.5.1-beta1"
 }


### PR DESCRIPTION
First beta of the **2026.5.1** patch cycle. Two related fixes split out from @Majawat's #431.

## Included since 2026.5.0
- #432 — fix: pick up OpenPlantbook soil-temperature thresholds. \`CONF_PLANTBOOK_MAPPING\` was missing entries for \`CONF_MIN_SOIL_TEMPERATURE\` / \`CONF_MAX_SOIL_TEMPERATURE\`, so \`generate_configentry\`'s OPB branch silently skipped soil temperature and the user always saw the un-converted defaults. (Majawat's original \`const.py\` + \`plant_helpers.py\` changes verbatim, plus a regression test.)
- #433 — fix: temperature unit conversion (air + soil) no longer reverts on the next \`async_write_ha_state\`. Air-temperature classes wrote the converted value via \`hass.states.async_set\` only — \`_attr_native_value\` stayed in the old unit, and the next entity write silently undid the conversion. Soil-temperature classes had the inverse half-fix (updated internal state, never published). Both now use the hybrid pattern: update internal state AND publish via \`hass.states.async_set\`. Includes 5 new regression tests.

## Test plan
- [x] \`pytest tests/\` — 256 passed
- [x] \`ruff check .\` clean
- [x] \`black --check .\` clean
- [ ] Manual: force-refresh a plant whose OPB entry has \`max_soil_temp\` set; soil thresholds should adopt the OPB values.
- [ ] Manual: change HA's temperature unit (°C ↔ °F); both air and soil thresholds should display in the new unit immediately and stay there through subsequent UI interactions.