### PR TITLE
fix: coerce numeric config-flow limit fields (#435)

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -377,7 +377,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_MOISTURE
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             data_schema[
                 vol.Required(
                     CONF_MIN_MOISTURE,
@@ -385,7 +385,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MIN_MOISTURE
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
 
         if show_all or selected_sensors["illuminance"]:
             data_schema[
@@ -395,7 +395,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_ILLUMINANCE
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             data_schema[
                 vol.Required(
                     CONF_MIN_ILLUMINANCE,
@@ -403,7 +403,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MIN_ILLUMINANCE
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             # Always show DLI together with illuminance
             data_schema[
                 vol.Required(
@@ -412,7 +412,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_DLI
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             data_schema[
                 vol.Required(
                     CONF_MIN_DLI,
@@ -420,7 +420,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MIN_DLI
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
 
         if show_all or selected_sensors["temperature"]:
             data_schema[
@@ -430,7 +430,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_TEMPERATURE
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             data_schema[
                 vol.Required(
                     CONF_MIN_TEMPERATURE,
@@ -438,7 +438,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MIN_TEMPERATURE
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
 
         if show_all or selected_sensors["conductivity"]:
             data_schema[
@@ -448,7 +448,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_CONDUCTIVITY
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             data_schema[
                 vol.Required(
                     CONF_MIN_CONDUCTIVITY,
@@ -456,7 +456,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MIN_CONDUCTIVITY
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
 
         if show_all or selected_sensors["humidity"]:
             data_schema[
@@ -466,7 +466,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MAX_HUMIDITY
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
             data_schema[
                 vol.Required(
                     CONF_MIN_HUMIDITY,
@@ -474,7 +474,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         CONF_MIN_HUMIDITY
                     ),
                 )
-            ] = int
+            ] = vol.Coerce(int)
 
         # Show VPD thresholds when both temperature and humidity are selected
         if show_all or (
@@ -487,13 +487,13 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_MAX_VPD,
                     default=max_vpd if max_vpd is not None else DEFAULT_MAX_VPD,
                 )
-            ] = float
+            ] = vol.Coerce(float)
             data_schema[
                 vol.Required(
                     CONF_MIN_VPD,
                     default=min_vpd if min_vpd is not None else DEFAULT_MIN_VPD,
                 )
-            ] = float
+            ] = vol.Coerce(float)
 
         data_schema[
             vol.Optional(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -386,6 +386,107 @@ class TestConfigFlowLimitsStep:
         assert result["title"] == "My Plant"
         assert FLOW_PLANT_INFO in result["data"]
 
+    async def test_limits_step_accepts_integer_vpd(
+        self,
+        hass: HomeAssistant,
+        mock_no_openplantbook,
+    ) -> None:
+        """Integer-valued VPD must be accepted by the limits step.
+
+        Regression for #435: the HA frontend has no int/float distinction,
+        so a whole number entered for VPD (e.g. 3 or 3.0) is serialised to
+        JSON as ``3`` and parsed back as a Python ``int``. A bare ``float``
+        schema is an ``isinstance`` check, not a coercion, so integer VPD
+        input was rejected with "expected float". ``vol.Coerce(float)``
+        must convert it instead.
+        """
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {ATTR_NAME: "My Plant", ATTR_SPECIES: "some plant"},
+        )
+        # Sensors step - no sensors
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                OPB_DISPLAY_PID: "Some Plant",
+                CONF_MAX_MOISTURE: 60,
+                CONF_MIN_MOISTURE: 20,
+                CONF_MAX_TEMPERATURE: 40,
+                CONF_MIN_TEMPERATURE: 10,
+                CONF_MAX_CONDUCTIVITY: 3000,
+                CONF_MIN_CONDUCTIVITY: 500,
+                CONF_MAX_ILLUMINANCE: 100000,
+                CONF_MIN_ILLUMINANCE: 0,
+                CONF_MAX_HUMIDITY: 60,
+                CONF_MIN_HUMIDITY: 20,
+                CONF_MAX_DLI: 30,
+                CONF_MIN_DLI: 2,
+                CONF_MAX_VPD: 3,
+                CONF_MIN_VPD: 1,
+                ATTR_ENTITY_PICTURE: "",
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        limits = result["data"][FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
+        assert limits[CONF_MAX_VPD] == 3.0
+        assert limits[CONF_MIN_VPD] == 1.0
+
+    async def test_limits_step_accepts_string_numeric_input(
+        self,
+        hass: HomeAssistant,
+        mock_no_openplantbook,
+    ) -> None:
+        """Numeric limit fields submitted as strings must be coerced.
+
+        Every numeric field in the limits step uses a bare Python type,
+        which rejects anything that is not already that exact type. The
+        schema must coerce string input (e.g. ``"40"``) to the proper
+        numeric type so the flow does not error on otherwise valid values.
+        """
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {ATTR_NAME: "My Plant", ATTR_SPECIES: "some plant"},
+        )
+        # Sensors step - no sensors
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                OPB_DISPLAY_PID: "Some Plant",
+                CONF_MAX_MOISTURE: "60",
+                CONF_MIN_MOISTURE: "20",
+                CONF_MAX_TEMPERATURE: "40",
+                CONF_MIN_TEMPERATURE: "10",
+                CONF_MAX_CONDUCTIVITY: "3000",
+                CONF_MIN_CONDUCTIVITY: "500",
+                CONF_MAX_ILLUMINANCE: "100000",
+                CONF_MIN_ILLUMINANCE: "0",
+                CONF_MAX_HUMIDITY: "60",
+                CONF_MIN_HUMIDITY: "20",
+                CONF_MAX_DLI: "30",
+                CONF_MIN_DLI: "2",
+                CONF_MAX_VPD: "1.6",
+                CONF_MIN_VPD: "0.4",
+                ATTR_ENTITY_PICTURE: "",
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        limits = result["data"][FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
+        # Integer fields coerced to int, VPD fields coerced to float.
+        assert limits[CONF_MAX_TEMPERATURE] == 40
+        assert isinstance(limits[CONF_MAX_TEMPERATURE], int)
+        assert limits[CONF_MAX_VPD] == 1.6
+        assert isinstance(limits[CONF_MAX_VPD], float)
+
     async def test_limits_step_with_opb_data(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Summary

Fixes #435 — the **Max VPD** field (and every other numeric field) in the initial config flow rejected otherwise valid input with a type error.

The `limits` config-flow step declared its 14 numeric fields with bare Python types (`int` / `float`). In voluptuous a bare type is an `isinstance` check, **not** a coercion, so it rejects any value whose type doesn't match exactly.

The HA frontend has no int/float distinction: a whole number entered for VPD (e.g. `3` or `3.0`) is serialised to JSON as `3` and parsed back as a Python `int`, which fails `isinstance(value, float)` with *"expected float"*. Only fractional values like `0.5` survived — exactly the symptom reported.

## Fix

Replace the bare types with `vol.Coerce(int)` / `vol.Coerce(float)` so int, float and numeric-string input all convert cleanly — the same pattern already used for the moisture grace period field.

## Test coverage

The bug slipped through because every existing test fed VPD as float literals (`1.6`, `0.4`), which trivially satisfy `isinstance(x, float)`. Two regression tests close the gap (written test-first, confirmed to fail against the old code):

- `test_limits_step_accepts_integer_vpd` — the precise #435 case (integer-valued VPD)
- `test_limits_step_accepts_string_numeric_input` — every numeric field submitted as a string, asserting coercion to the correct type

Full suite: 259 passing. `black` and `ruff` clean.

Thanks to @TimPasquini for the clear report and spot-on diagnosis. 🌱

🤖 Generated with [Claude Code](https://claude.com/claude-code)