### PR TITLE
release: 2026.5.1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.5.1-beta1"
+  "version": "2026.5.1"
 }


### PR DESCRIPTION
Promote `2026.5.1-beta1` to the stable **2026.5.1** release.

Only change: `manifest.json` version `2026.5.1-beta1` → `2026.5.1`. CI handles tag creation and the GitHub release on merge.

## Changes since 2026.5.1-beta1

- #436 — fix: coerce numeric config-flow limit fields instead of type-checking (Fixes #435)

The beta1 release already carried the earlier fixes (#432 OpenPlantbook soil-temperature mapping, #433 temperature unit conversion). The only functional change between beta1 and this stable release is #436.

🤖 Generated with [Claude Code](https://claude.com/claude-code)