### PR TITLE
fix: temperature unit handling for imperial-configured installs

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -99,9 +99,14 @@ ATTR_CURRENT = "current"
 DEFAULT_MIN_BATTERY_LEVEL = 20
 DEFAULT_MIN_TEMPERATURE = 10
 DEFAULT_MAX_TEMPERATURE = 40
-# Absolute minimum/maximum allowed temperature values for thresholds
+# Absolute minimum/maximum allowed temperature values for thresholds, in °C.
 TEMPERATURE_MIN_VALUE = -50
 TEMPERATURE_MAX_VALUE = 100
+# Imperial counterparts. Chosen as round numbers in °F rather than literal
+# conversions of the °C bounds, so the slider extremes don't look like
+# "obviously converted from Celsius" (212, -58).
+TEMPERATURE_MIN_VALUE_FAHRENHEIT = -50
+TEMPERATURE_MAX_VALUE_FAHRENHEIT = 200
 DEFAULT_MIN_MOISTURE = 20
 DEFAULT_MAX_MOISTURE = 60
 DEFAULT_MIN_CONDUCTIVITY = 500

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -243,6 +243,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
+def _convert_default_temp(value_c: float, target_unit: str) -> float:
+    """Convert a Celsius default value to ``target_unit``, rounded.
+
+    Defaults in ``const.py`` and from OpenPlantbook are expressed in °C.
+    When HA's system unit is °F we need to convert before stamping the
+    value onto a temperature threshold entity, otherwise the user gets a
+    °C-numeric value labelled °F (e.g. a 40 °F max-temp ceiling).
+    """
+    if target_unit == UnitOfTemperature.CELSIUS:
+        return value_c
+    return round(
+        TemperatureConverter.convert(value_c, UnitOfTemperature.CELSIUS, target_unit)
+    )
+
+
 class PlantMinMax(RestoreNumber):
     """Parent class for the min/max classes below"""
 
@@ -480,8 +495,11 @@ class PlantMaxTemperature(PlantMinMax):
     ) -> None:
         """Initialize the Plant component."""
         self._attr_unique_id = f"{config.entry_id}-max-temperature"
-        self._default_value = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-            CONF_MAX_TEMPERATURE, DEFAULT_MAX_TEMPERATURE
+        self._default_value = _convert_default_temp(
+            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
+                CONF_MAX_TEMPERATURE, DEFAULT_MAX_TEMPERATURE
+            ),
+            hass.config.units.temperature_unit,
         )
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
@@ -572,8 +590,11 @@ class PlantMinTemperature(PlantMinMax):
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
         """Initialize the component."""
-        self._default_value = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-            CONF_MIN_TEMPERATURE, DEFAULT_MIN_TEMPERATURE
+        self._default_value = _convert_default_temp(
+            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
+                CONF_MIN_TEMPERATURE, DEFAULT_MIN_TEMPERATURE
+            ),
+            hass.config.units.temperature_unit,
         )
         self._attr_unique_id = f"{config.entry_id}-min-temperature"
         super().__init__(hass, config, plantdevice)
@@ -936,8 +957,11 @@ class PlantMaxSoilTemperature(PlantMinMax):
     ) -> None:
         """Initialize the Plant component."""
         self._attr_unique_id = f"{config.entry_id}-max-soil-temperature"
-        self._default_value = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-            CONF_MAX_SOIL_TEMPERATURE, DEFAULT_MAX_SOIL_TEMPERATURE
+        self._default_value = _convert_default_temp(
+            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
+                CONF_MAX_SOIL_TEMPERATURE, DEFAULT_MAX_SOIL_TEMPERATURE
+            ),
+            hass.config.units.temperature_unit,
         )
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
@@ -1012,8 +1036,11 @@ class PlantMinSoilTemperature(PlantMinMax):
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
         """Initialize the component."""
-        self._default_value = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-            CONF_MIN_SOIL_TEMPERATURE, DEFAULT_MIN_SOIL_TEMPERATURE
+        self._default_value = _convert_default_temp(
+            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
+                CONF_MIN_SOIL_TEMPERATURE, DEFAULT_MIN_SOIL_TEMPERATURE
+            ),
+            hass.config.units.temperature_unit,
         )
         self._attr_unique_id = f"{config.entry_id}-min-soil-temperature"
         super().__init__(hass, config, plantdevice)

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -110,7 +110,9 @@ from .const import (
     READING_TEMPERATURE,
     READING_VPD,
     TEMPERATURE_MAX_VALUE,
+    TEMPERATURE_MAX_VALUE_FAHRENHEIT,
     TEMPERATURE_MIN_VALUE,
+    TEMPERATURE_MIN_VALUE_FAHRENHEIT,
     TRANSLATION_KEY_LUX_TO_PPFD,
     TRANSLATION_KEY_MAX_CO2,
     TRANSLATION_KEY_MAX_CONDUCTIVITY,
@@ -501,6 +503,9 @@ class PlantMaxTemperature(PlantMinMax):
             ),
             hass.config.units.temperature_unit,
         )
+        if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
+            self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
@@ -597,6 +602,9 @@ class PlantMinTemperature(PlantMinMax):
             hass.config.units.temperature_unit,
         )
         self._attr_unique_id = f"{config.entry_id}-min-temperature"
+        if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
+            self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
@@ -963,6 +971,9 @@ class PlantMaxSoilTemperature(PlantMinMax):
             ),
             hass.config.units.temperature_unit,
         )
+        if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
+            self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
@@ -1043,6 +1054,9 @@ class PlantMinSoilTemperature(PlantMinMax):
             hass.config.units.temperature_unit,
         )
         self._attr_unique_id = f"{config.entry_id}-min-soil-temperature"
+        if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
+            self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
+            self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -245,7 +245,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-def _convert_default_temp(value_c: float, target_unit: str) -> float:
+def _convert_default_temp(value_c: float, target_unit: UnitOfTemperature) -> float:
     """Convert a Celsius default value to ``target_unit``, rounded.
 
     Defaults in ``const.py`` and from OpenPlantbook are expressed in °C.

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -713,7 +713,8 @@ class PlantCurrentVpd(RestoreSensor):
 
         The mirror entity inherits its unit of measurement from the source
         sensor (and from HA's system unit), so the published state may be
-        in °C or °F. Convert to °C before returning.
+        in °C, °F, or K. Convert to °C before returning. Unknown or
+        missing units fall through unconverted (treated as already °C).
         """
         if self._plant.sensor_temperature is None:
             return None
@@ -724,13 +725,12 @@ class PlantCurrentVpd(RestoreSensor):
             temp = float(state_obj.state)
         except (ValueError, TypeError):
             return None
+        unit = state_obj.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
         if (
-            state_obj.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
-            == UnitOfTemperature.FAHRENHEIT
+            unit in TemperatureConverter.VALID_UNITS
+            and unit != UnitOfTemperature.CELSIUS
         ):
-            temp = TemperatureConverter.convert(
-                temp, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
-            )
+            temp = TemperatureConverter.convert(temp, unit, UnitOfTemperature.CELSIUS)
         return temp
 
     def _get_humidity(self) -> float | None:

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -50,6 +50,7 @@ from homeassistant.helpers.entity_registry import (
 from homeassistant.helpers.event import (
     async_track_state_change_event,
 )
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from . import SETUP_DUMMY_SENSORS
 from .const import (
@@ -708,21 +709,28 @@ class PlantCurrentVpd(RestoreSensor):
         return svp * (1 - humidity / 100.0)
 
     def _get_temperature_celsius(self) -> float | None:
-        """Get the current temperature in Celsius from the plant's temperature sensor."""
+        """Read the plant's temperature sensor and return the value in Celsius.
+
+        The mirror entity inherits its unit of measurement from the source
+        sensor (and from HA's system unit), so the published state may be
+        in °C or °F. Convert to °C before returning.
+        """
         if self._plant.sensor_temperature is None:
             return None
-        state = getattr(
-            self.hass.states.get(self._plant.sensor_temperature.entity_id),
-            "state",
-            None,
-        )
-        if state is None or state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
+        state_obj = self.hass.states.get(self._plant.sensor_temperature.entity_id)
+        if state_obj is None or state_obj.state in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return None
         try:
-            temp = float(state)
+            temp = float(state_obj.state)
         except (ValueError, TypeError):
             return None
-        # The plant sensor stores values in Celsius
+        if (
+            state_obj.attributes.get(ATTR_UNIT_OF_MEASUREMENT)
+            == UnitOfTemperature.FAHRENHEIT
+        ):
+            temp = TemperatureConverter.convert(
+                temp, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.CELSIUS
+            )
         return temp
 
     def _get_humidity(self) -> float | None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -864,13 +864,18 @@ class TestThresholdRestoreState:
 
 
 class TestThresholdImperialDefaults:
-    """Tests for #438a: temperature defaults must be converted at creation time.
+    """Tests for the temperature threshold setup behavior in imperial mode.
 
-    Defaults in const.py and from OpenPlantbook are in °C. When HA's system
-    unit is °F, the four temperature threshold entities used to stamp the
-    °F unit onto the unconverted °C numeric, producing nonsensical limits
-    (e.g. a 40 °F max-temperature ceiling). They must convert °C → °F when
-    the system is imperial.
+    Covers two related defects from #438:
+
+    * #438a — defaults in ``const.py`` and from OpenPlantbook are in °C; the
+      four temperature threshold entities must convert them to the system
+      unit before stamping the °F label, otherwise a 40 °C default becomes
+      "40 °F" instead of "104 °F".
+    * #438b — the slider bounds (``native_min_value`` / ``native_max_value``)
+      must widen to °F-appropriate values in imperial mode; otherwise the
+      100 °C cap silently becomes a 100 °F cap (≈ 37.8 °C), too low for
+      heat-tolerant species.
     """
 
     async def test_temperature_thresholds_converted_when_system_imperial(
@@ -919,3 +924,51 @@ class TestThresholdImperialDefaults:
         assert plant.min_temperature.native_value == 10
         assert plant.max_soil_temperature.native_value == 40
         assert plant.min_soil_temperature.native_value == 10
+
+    async def test_temperature_slider_bounds_widen_when_system_imperial(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Slider bounds for the four temperature thresholds are 200 / -50 °F."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+
+        for threshold in (
+            plant.max_temperature,
+            plant.min_temperature,
+            plant.max_soil_temperature,
+            plant.min_soil_temperature,
+        ):
+            assert threshold.native_max_value == 200
+            assert threshold.native_min_value == -50
+
+    async def test_temperature_slider_bounds_unchanged_when_system_metric(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Baseline: metric system leaves the existing -50 / 100 °C bounds."""
+        from homeassistant.util.unit_system import METRIC_SYSTEM
+
+        hass.config.units = METRIC_SYSTEM
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+
+        for threshold in (
+            plant.max_temperature,
+            plant.min_temperature,
+            plant.max_soil_temperature,
+            plant.min_soil_temperature,
+        ):
+            assert threshold.native_max_value == 100
+            assert threshold.native_min_value == -50

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -861,3 +861,61 @@ class TestThresholdRestoreState:
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+
+
+class TestThresholdImperialDefaults:
+    """Tests for #438a: temperature defaults must be converted at creation time.
+
+    Defaults in const.py and from OpenPlantbook are in °C. When HA's system
+    unit is °F, the four temperature threshold entities used to stamp the
+    °F unit onto the unconverted °C numeric, producing nonsensical limits
+    (e.g. a 40 °F max-temperature ceiling). They must convert °C → °F when
+    the system is imperial.
+    """
+
+    async def test_temperature_thresholds_converted_when_system_imperial(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """All four temperature thresholds use °F values when system is imperial."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+
+        # Defaults in conftest: max=40°C, min=10°C, max_soil=40°C, min_soil=10°C
+        # Converted: 40°C → 104°F, 10°C → 50°F
+        assert plant.max_temperature.native_value == 104
+        assert plant.min_temperature.native_value == 50
+        assert plant.max_soil_temperature.native_value == 104
+        assert plant.min_soil_temperature.native_value == 50
+
+        assert plant.max_temperature._attr_native_unit_of_measurement == "°F"
+        assert plant.min_temperature._attr_native_unit_of_measurement == "°F"
+        assert plant.max_soil_temperature._attr_native_unit_of_measurement == "°F"
+        assert plant.min_soil_temperature._attr_native_unit_of_measurement == "°F"
+
+    async def test_temperature_thresholds_unchanged_when_system_metric(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Baseline: metric system leaves the °C defaults alone."""
+        from homeassistant.util.unit_system import METRIC_SYSTEM
+
+        hass.config.units = METRIC_SYSTEM
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+
+        assert plant.max_temperature.native_value == 40
+        assert plant.min_temperature.native_value == 10
+        assert plant.max_soil_temperature.native_value == 40
+        assert plant.min_soil_temperature.native_value == 10

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1058,6 +1058,12 @@ class TestVpdSensor:
     system unit is °F, the plant-owned mirror temperature sensor (device
     class ``temperature``) publishes its state in °F to ``hass.states``,
     and ``_get_temperature_celsius`` reads it back without converting.
+
+    The Kelvin test guards the generalised form of the fix: any unit in
+    ``TemperatureConverter.VALID_UNITS`` other than Celsius should be
+    converted before Tetens is applied. HA's system unit can only be °C
+    or °F, but external sensors (thermocouples, etc.) may legitimately
+    publish in Kelvin.
     """
 
     async def test_vpd_when_system_unit_is_celsius(
@@ -1113,6 +1119,46 @@ class TestVpdSensor:
             "sensor.test_temperature",
             "62.0",
             {"unit_of_measurement": "°F", "device_class": "temperature"},
+        )
+        hass.states.async_set(
+            "sensor.test_humidity",
+            "74.4",
+            {"unit_of_measurement": "%", "device_class": "humidity"},
+        )
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+        await plant.sensor_temperature.async_update()
+        plant.sensor_temperature.async_write_ha_state()
+        await plant.sensor_humidity.async_update()
+        plant.sensor_humidity.async_write_ha_state()
+        await hass.async_block_till_done()
+        await plant.vpd.async_update()
+
+        assert plant.vpd.native_value == pytest.approx(0.49, abs=0.01)
+
+    async def test_vpd_when_source_sensor_reports_kelvin(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Source sensors reporting in Kelvin must also be converted.
+
+        HA's system unit cannot be Kelvin (UnitSystem rejects it), but an
+        external sensor with ``device_class=temperature`` and
+        ``unit_of_measurement="K"`` can still propagate K through the
+        mirror entity. 289.82 K = 16.67 °C, so with 74.4 % RH the VPD
+        should still land near 0.49 kPa.
+        """
+        from homeassistant.util.unit_system import METRIC_SYSTEM
+
+        hass.config.units = METRIC_SYSTEM
+        hass.states.async_set(
+            "sensor.test_temperature",
+            "289.82",
+            {"unit_of_measurement": "K", "device_class": "temperature"},
         )
         hass.states.async_set(
             "sensor.test_humidity",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1049,3 +1049,86 @@ class TestProblemDetectionWithPpfdSource:
         # Plant state should not be "problem" due to illuminance
         # (it may still be unknown if no other sensors have values)
         assert plant.illuminance_status is None
+
+
+class TestVpdSensor:
+    """Tests for the VPD sensor calculation.
+
+    The Fahrenheit test mirrors the real bug condition for #440: when HA's
+    system unit is °F, the plant-owned mirror temperature sensor (device
+    class ``temperature``) publishes its state in °F to ``hass.states``,
+    and ``_get_temperature_celsius`` reads it back without converting.
+    """
+
+    async def test_vpd_when_system_unit_is_celsius(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Baseline: HA system in °C, external sensor in °C → correct VPD."""
+        from homeassistant.util.unit_system import METRIC_SYSTEM
+
+        hass.config.units = METRIC_SYSTEM
+        hass.states.async_set(
+            "sensor.test_temperature",
+            "16.67",
+            {"unit_of_measurement": "°C", "device_class": "temperature"},
+        )
+        hass.states.async_set(
+            "sensor.test_humidity",
+            "74.4",
+            {"unit_of_measurement": "%", "device_class": "humidity"},
+        )
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+        await plant.sensor_temperature.async_update()
+        plant.sensor_temperature.async_write_ha_state()
+        await plant.sensor_humidity.async_update()
+        plant.sensor_humidity.async_write_ha_state()
+        await hass.async_block_till_done()
+        await plant.vpd.async_update()
+
+        # SVP(16.67°C) * (1 - 74.4/100) ≈ 1.897 * 0.256 ≈ 0.486 kPa
+        assert plant.vpd.native_value == pytest.approx(0.49, abs=0.01)
+
+    async def test_vpd_when_system_unit_is_fahrenheit(
+        self,
+        hass: HomeAssistant,
+        mock_config_entry: MockConfigEntry,
+    ) -> None:
+        """Regression test for #440.
+
+        HA system unit is °F; the external sensor reports 62 °F (= 16.67 °C).
+        VPD must come out near 0.49 kPa. Before the fix, the mirror sensor
+        published "62.0 °F" to hass.states, ``_get_temperature_celsius``
+        returned 62 (treating °F as °C), and VPD landed near 5.6 kPa.
+        """
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+        hass.states.async_set(
+            "sensor.test_temperature",
+            "62.0",
+            {"unit_of_measurement": "°F", "device_class": "temperature"},
+        )
+        hass.states.async_set(
+            "sensor.test_humidity",
+            "74.4",
+            {"unit_of_measurement": "%", "device_class": "humidity"},
+        )
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][mock_config_entry.entry_id][ATTR_PLANT]
+        await plant.sensor_temperature.async_update()
+        plant.sensor_temperature.async_write_ha_state()
+        await plant.sensor_humidity.async_update()
+        plant.sensor_humidity.async_write_ha_state()
+        await hass.async_block_till_done()
+        await plant.vpd.async_update()
+
+        assert plant.vpd.native_value == pytest.approx(0.49, abs=0.01)


### PR DESCRIPTION
## Summary

Three related bugs in temperature unit handling, all manifesting on Home Assistant instances configured for imperial (°F) units. Each lands as its own commit so the history reflects the diagnosis.

- **#440 — VPD off by ~10×.** ``PlantCurrentVpd._get_temperature_celsius`` read the mirror sensor's state without checking its ``unit_of_measurement`` attribute. On imperial installs the mirror publishes °F to ``hass.states`` (because ``device_class=temperature`` makes HA auto-convert to the system unit), so the Tetens formula was fed °F numerics. Example: 62 °F @ 74.4 % RH used to produce VPD ≈ 5.6 kPa instead of the correct ≈ 0.49 kPa, forcing plants into ``problem`` state under normal conditions.
- **#438a — threshold defaults stamped with the wrong unit.** Defaults in ``const.py`` and from OpenPlantbook are expressed in °C. The four temperature threshold entities (``max/min_temperature``, ``max/min_soil_temperature``) used to read those raw °C numbers and then label them with the system unit, giving imperial users a "40 °F" max-temp ceiling instead of "104 °F." New ``_convert_default_temp`` helper converts °C → system unit (rounded) at threshold ``__init__`` time.
- **#438b — slider upper bound silently capped at 100 °F.** ``TEMPERATURE_MAX_VALUE = 100`` was applied unit-agnostically, so users on imperial installs couldn't set max-temp values above 100 °F (≈ 37.8 °C). New ``TEMPERATURE_{MIN,MAX}_VALUE_FAHRENHEIT`` constants (-50 / 200); the °F max is 200 rather than 212 so it doesn't read as an obvious conversion of 100 °C.

## ⚠️ Note for existing imperial-mode users

Plants created on a prior version that ran on an imperial-configured HA instance will have **wrong stored values** for the four temperature thresholds — the buggy defaults (40, 10, 40, 10) were written into the config entry, and ``RestoreNumber`` restores whatever was last saved. This PR does **not** auto-migrate those values, because we can't tell which existing users accepted the buggy default vs. intentionally set those numbers.

**After upgrading, imperial users should manually review:**
- ``number.<plant>_max_temperature`` and ``number.<plant>_min_temperature``
- ``number.<plant>_max_soil_temperature`` and ``number.<plant>_min_soil_temperature``

The widened slider bounds from #438b at least make manual correction possible — before this PR, the slider literally couldn't reach 200 °F.

This note should also flow into the release notes for the version that ships this fix.

## Test plan

- [x] New regression tests for all three defects (system-unit switch from metric → imperial in the test setup mirrors the real user scenario).
  - ``tests/test_sensor.py::TestVpdSensor`` — two tests, °C baseline + °F regression.
  - ``tests/test_number.py::TestThresholdImperialDefaults`` — four tests covering both default conversion and slider bounds, in both °C and °F modes.
- [x] Full suite passes (265 tests).
- [x] ``black --check`` and ``ruff check`` clean.
- [ ] Manual smoke test on an actual imperial-configured HA install (recommend doing this before merge — automated tests don't cover the full HA UI flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)