### PR TITLE
release: 2026.5.2-beta1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -17,5 +17,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.5.1"
+  "version": "2026.5.2-beta1"
 }


### PR DESCRIPTION
## Summary

Beta release that ships the fixes from #441 (closes #440 and #438).

- VPD now correctly converts °F (and K) temperature readings to °C before applying Tetens.
- Temperature threshold defaults are converted from °C to the system unit at creation, so imperial installs no longer get a 40 °F max-temperature ceiling.
- Slider bounds widen to -50 / 200 °F in imperial mode.

## ⚠️ Migration note for imperial-mode users

Plants created on a prior version under an imperial-configured HA may have wrong stored values for the four temperature thresholds. This release does **not** auto-migrate — review these manually after upgrading:

- ``number.<plant>_max_temperature`` and ``number.<plant>_min_temperature``
- ``number.<plant>_max_soil_temperature`` and ``number.<plant>_min_soil_temperature``

## Test plan

- [x] All checks passed on #441.
- [ ] Manual smoke test on an imperial-configured HA install (recommended before promoting beta → stable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)