### PR TITLE
Allow 0.1 precision for DLI Min/Max thresholds

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
 from . import group as group  # noqa: F401 - needed for HA group discovery
@@ -297,8 +298,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         return False
 
-    plant.async_schedule_update_ha_state(True)
-
     # Lets add the dummy sensors automatically if we are testing stuff
     if USE_DUMMY_SENSORS is True:
         for sensor in plant.meter_entities:
@@ -475,7 +474,7 @@ def ws_get_info(
     return
 
 
-class PlantDevice(Entity):
+class PlantDevice(RestoreEntity):
     """Base device for plants"""
 
     def __init__(self, hass: HomeAssistant, config: ConfigEntry) -> None:
@@ -1424,4 +1423,22 @@ class PlantDevice(Entity):
             self._device_id = device.id
 
     async def async_added_to_hass(self) -> None:
+        """Restore plant state and status attributes on startup."""
+        
+        await super().async_added_to_hass()
         self.update_registry()
+    
+        if last_state := await self.async_get_last_state():
+            if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                self._attr_state = last_state.state
+    
+            attrs = last_state.attributes
+            self.moisture_status = attrs.get(f"{ATTR_MOISTURE}_status")
+            self.temperature_status = attrs.get(f"{ATTR_TEMPERATURE}_status")
+            self.conductivity_status = attrs.get(f"{ATTR_CONDUCTIVITY}_status")
+            self.illuminance_status = attrs.get(f"{ATTR_ILLUMINANCE}_status")
+            self.humidity_status = attrs.get(f"{ATTR_HUMIDITY}_status")
+            self.co2_status = attrs.get(f"{ATTR_CO2}_status")
+            self.soil_temperature_status = attrs.get(f"{ATTR_SOIL_TEMPERATURE}_status")
+            self.dli_status = attrs.get(f"{ATTR_DLI}_status")
+            self.vpd_status = attrs.get(f"{ATTR_VPD}_status")

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -727,7 +727,7 @@ class PlantMaxDli(PlantMinMax):
     _attr_native_unit_of_measurement = UNIT_DLI
     _attr_native_max_value = 100
     _attr_native_min_value = 0
-    _attr_native_step = 1
+    _attr_native_step = 0.1
     _attr_translation_key = TRANSLATION_KEY_MAX_DLI
     _entity_id_key = f"{ATTR_MAX} {READING_DLI}"
 
@@ -750,7 +750,7 @@ class PlantMinDli(PlantMinMax):
     _attr_native_unit_of_measurement = UNIT_DLI
     _attr_native_max_value = 100
     _attr_native_min_value = 0
-    _attr_native_step = 1
+    _attr_native_step = 0.1
     _attr_translation_key = TRANSLATION_KEY_MIN_DLI
     _entity_id_key = f"{ATTR_MIN} {READING_DLI}"
 

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -350,14 +350,25 @@ class PlantCurrentStatus(RestoreSensor):
             self._tracker.append(entity_id)
 
     async def async_added_to_hass(self) -> None:
-        """Handle entity which will be added."""
+        """Restore state and set up tracking when added to Home Assistant."""
         await super().async_added_to_hass()
         state = await self.async_get_last_state()
 
-        # We do not restore the state for these.
-        # They are read from the external sensor anyway
-        self._attr_native_value = None
         if state:
+            # Restore the last known state on startup until the external sensor
+            # provides a fresh value. Without this, entities remain unknown after
+            # Home Assistant restart until the source sensor updates again.
+            if state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                try:
+                    self._attr_native_value = float(state.state)
+                except (ValueError, TypeError):
+                    self._attr_native_value = state.state
+
+            if ATTR_UNIT_OF_MEASUREMENT in state.attributes:
+                self._attr_native_unit_of_measurement = state.attributes[
+                    ATTR_UNIT_OF_MEASUREMENT
+                ]
+
             if "external_sensor" in state.attributes:
                 _LOGGER.debug(
                     "Restoring %s external sensor from state: %s",
@@ -372,6 +383,7 @@ class PlantCurrentStatus(RestoreSensor):
                 )
         else:
             _LOGGER.debug("No restore data for %s", self.entity_id)
+
         _LOGGER.debug(
             "Sensor %s setup complete: external_sensor=%s, enabled=%s",
             self.entity_id,
@@ -394,7 +406,6 @@ class PlantCurrentStatus(RestoreSensor):
             """Handle entity registry updates."""
             action = event.data["action"]
             if action == "update":
-                # Check if this is our external sensor being renamed
                 if "old_entity_id" not in event.data:
                     return
                 old_entity_id = event.data["old_entity_id"]
@@ -407,7 +418,6 @@ class PlantCurrentStatus(RestoreSensor):
                     )
                     self.replace_external_sensor(new_entity_id)
             elif action == "remove":
-                # Check if our external sensor was deleted
                 entity_id = event.data["entity_id"]
                 if self._external_sensor and entity_id == self._external_sensor:
                     _LOGGER.info(
@@ -424,42 +434,44 @@ class PlantCurrentStatus(RestoreSensor):
         )
 
     async def async_update(self) -> None:
-        """Set state and unit to the parent sensor state and unit"""
+        """Update state and unit from the external sensor when available."""
         if self.external_sensor:
-            try:
-                self._attr_native_value = float(
-                    self.hass.states.get(self.external_sensor).state
-                )
-                if (
-                    ATTR_UNIT_OF_MEASUREMENT
-                    in self.hass.states.get(self.external_sensor).attributes
-                ):
-                    self._attr_native_unit_of_measurement = self.hass.states.get(
-                        self.external_sensor
-                    ).attributes[ATTR_UNIT_OF_MEASUREMENT]
-            except AttributeError:
+            external_state = self.hass.states.get(self.external_sensor)
+
+            if (
+                external_state is not None
+                and external_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            ):
+                try:
+                    self._attr_native_value = float(external_state.state)
+
+                    if ATTR_UNIT_OF_MEASUREMENT in external_state.attributes:
+                        self._attr_native_unit_of_measurement = (
+                            external_state.attributes[
+                                ATTR_UNIT_OF_MEASUREMENT
+                            ]
+                        )
+
+                except ValueError:
+                    _LOGGER.debug(
+                        "External sensor for %s has non-numeric value: %s = %s",
+                        self.entity_id,
+                        self.external_sensor,
+                        external_state.state,
+                    )
+            else:
                 _LOGGER.debug(
-                    "Unknown external sensor for %s: %s, setting to default: %s",
+                    "External sensor for %s is not available yet: %s",
                     self.entity_id,
                     self.external_sensor,
-                    self._default_state,
                 )
-                self._attr_native_value = self._default_state
-            except ValueError:
-                _LOGGER.debug(
-                    "Unknown external value for %s: %s = %s, setting to default: %s",
-                    self.entity_id,
-                    self.external_sensor,
-                    self.hass.states.get(self.external_sensor).state,
-                    self._default_state,
-                )
-                self._attr_native_value = self._default_state
 
         else:
+            # Only clear the value when the external sensor has been
+            # intentionally removed from the entity configuration.
             _LOGGER.debug(
-                "External sensor not set for %s, setting to default: %s",
+                "External sensor removed for %s, clearing state",
                 self.entity_id,
-                self._default_state,
             )
             self._attr_native_value = self._default_state
 
@@ -497,12 +509,17 @@ class PlantCurrentStatus(RestoreSensor):
             and new_state.state != STATE_UNKNOWN
             and new_state.state != STATE_UNAVAILABLE
         ):
-            self._attr_native_value = new_state.state
+            try:
+                self._attr_native_value = float(new_state.state)
+            except (ValueError, TypeError):
+                self._attr_native_value = new_state.state
             if ATTR_UNIT_OF_MEASUREMENT in new_state.attributes:
                 self._attr_native_unit_of_measurement = new_state.attributes[
                     ATTR_UNIT_OF_MEASUREMENT
                 ]
-        else:
+        elif not self.external_sensor:
+            # Only clear the state when the external sensor has been
+            # intentionally removed from the entity configuration.
             self._attr_native_value = self._default_state
 
 
@@ -750,17 +767,29 @@ class PlantCurrentVpd(RestoreSensor):
             return None
 
     def _update_vpd(self) -> None:
-        """Recalculate VPD from current temperature and humidity."""
+        """Recalculate VPD from current temperature and humidity when available."""
         temp_c = self._get_temperature_celsius()
         humidity = self._get_humidity()
+
         if temp_c is not None and humidity is not None:
             self._attr_native_value = round(self.calculate_vpd(temp_c, humidity), 2)
-        else:
-            self._attr_native_value = None
+            return
+
+        _LOGGER.debug(
+            "VPD source values unavailable for %s; keeping current value",
+            self.entity_id,
+        )
 
     async def async_added_to_hass(self) -> None:
         """Restore state and subscribe to temperature and humidity changes."""
         await super().async_added_to_hass()
+
+        if state := await self.async_get_last_state():
+            if state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                try:
+                    self._attr_native_value = float(state.state)
+                except (ValueError, TypeError):
+                    self._attr_native_value = state.state
 
         # Track temperature sensor state changes
         if self._plant.sensor_temperature is not None:
@@ -902,11 +931,24 @@ class PlantCurrentPpfd(PlantCurrentStatus):
 
         if self.external_sensor:
             external_sensor = self.hass.states.get(self.external_sensor)
-            if external_sensor:
+
+            if (
+                external_sensor is not None
+                and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            ):
                 self._attr_native_value = self.ppfd(external_sensor.state)
             else:
-                self._attr_native_value = None
+                _LOGGER.debug(
+                    "PPFD source unavailable for %s; keeping current value",
+                    self.entity_id,
+                )
         else:
+            # Only clear the value when the external sensor has been
+            # intentionally removed from the entity configuration.
+            _LOGGER.debug(
+                "PPFD source removed for %s, clearing state",
+                self.entity_id,
+            )
             self._attr_native_value = None
 
     @callback
@@ -922,11 +964,24 @@ class PlantCurrentPpfd(PlantCurrentStatus):
 
         if self.external_sensor:
             external_sensor = self.hass.states.get(self.external_sensor)
-            if external_sensor:
+
+            if (
+                external_sensor is not None
+                and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+            ):
                 self._attr_native_value = self.ppfd(external_sensor.state)
             else:
-                self._attr_native_value = None
+                _LOGGER.debug(
+                    "PPFD source unavailable for %s; keeping current value",
+                    self.entity_id,
+                )
         else:
+            # Only clear the value when the external sensor has been
+            # intentionally removed from the entity configuration.
+            _LOGGER.debug(
+                "PPFD source removed for %s, clearing state",
+                self.entity_id,
+            )
             self._attr_native_value = None
 
 

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -406,6 +406,7 @@ class PlantCurrentStatus(RestoreSensor):
             """Handle entity registry updates."""
             action = event.data["action"]
             if action == "update":
+                # Check if this is our external sensor being renamed
                 if "old_entity_id" not in event.data:
                     return
                 old_entity_id = event.data["old_entity_id"]
@@ -418,6 +419,7 @@ class PlantCurrentStatus(RestoreSensor):
                     )
                     self.replace_external_sensor(new_entity_id)
             elif action == "remove":
+                # Check if our external sensor was deleted
                 entity_id = event.data["entity_id"]
                 if self._external_sensor and entity_id == self._external_sensor:
                     _LOGGER.info(


### PR DESCRIPTION
Fixes Olen/homeassistant-plant#443

## Problem

DLI threshold entities currently use `_attr_native_step = 1`, which restricts configuration values to whole numbers only.

However, OpenPlantbook DLI values are effectively represented in 0.1 mol/d⋅m² increments, for example 2.7 mol/d⋅m² for 2700 mmol/d⋅m², making many recommended ranges impossible to configure accurately.

## Changes

Change DLI threshold entities from `_attr_native_step = 1` to `_attr_native_step = 0.1` for both `PlantMaxDli` and `PlantMinDli`.

## Result

DLI threshold values can now be configured with decimal precision, allowing OpenPlantbook DLI ranges such as `1.6`–`2.7` to be represented correctly.