### PR TITLE
Restore plant and sensor states after Home Assistant restart

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1426,7 +1426,6 @@ class PlantDevice(RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Restore plant state and status attributes on startup."""
-
         await super().async_added_to_hass()
         self.update_registry()
 

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -515,6 +515,7 @@ class PlantDevice(RestoreEntity):
             f"{DOMAIN}.{{}}", self.name, current_ids={}
         )
 
+        self._restored_state_active = False  # True while showing restored startup values
         self.plant_complete = False
         self._device_id = None
 
@@ -1090,9 +1091,36 @@ class PlantDevice(RestoreEntity):
             )
         return new_status
 
+    def _has_live_source_data(self) -> bool:
+        """True once at least one tracked source sensor reports a numeric value."""
+        for sensor in (
+            self.sensor_moisture,
+            self.sensor_conductivity,
+            self.sensor_temperature,
+            self.sensor_humidity,
+            self.sensor_co2,
+            self.sensor_soil_temperature,
+            self.sensor_illuminance,
+        ):
+            if sensor is None:
+                continue
+            state = self.hass.states.get(sensor.entity_id)
+            if state is not None and self._safe_float(state.state, sensor.entity_id) is not None:
+                return True
+        return False
+
     def update(self) -> None:
         """Run on every update of the entities"""
-
+    
+        # Startup restore window: until a source delivers live data, keep the values
+        # restored in async_added_to_hass instead of recomputing them to UNKNOWN/None.
+        # Must sit ABOVE the per-sensor logic below -- that loop overwrites each
+        # *_status to None as it runs, so a guard at the bottom would be too late.
+        if self._restored_state_active:
+            if not self._has_live_source_data():
+                return
+            self._restored_state_active = False   # first live reading -> resume normal
+    
         new_state = STATE_OK
         known_state = False
 
@@ -1432,9 +1460,17 @@ class PlantDevice(RestoreEntity):
         if last_state := await self.async_get_last_state():
             if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._attr_state = last_state.state
+                self._restored_state_active = True          # only latch on a real restore
 
             attrs = last_state.attributes
-            for attr in (ATTR_MOISTURE, ATTR_TEMPERATURE, ATTR_CONDUCTIVITY,
-                         ATTR_ILLUMINANCE, ATTR_HUMIDITY, ATTR_CO2,
-                         ATTR_SOIL_TEMPERATURE, ATTR_DLI, ATTR_VPD):
+            for attr in (
+                ATTR_MOISTURE,
+                ATTR_TEMPERATURE,
+                ATTR_CONDUCTIVITY,
+                ATTR_ILLUMINANCE,
+                ATTR_HUMIDITY,
+                ATTR_CO2,
+                ATTR_SOIL_TEMPERATURE,
+                ATTR_DLI, ATTR_VPD
+            ):
                 setattr(self, f"{attr}_status", attrs.get(f"{attr}_status"))

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -298,6 +298,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         return False
 
+    plant.async_schedule_update_ha_state(True)
+
     # Lets add the dummy sensors automatically if we are testing stuff
     if USE_DUMMY_SENSORS is True:
         for sensor in plant.meter_entities:
@@ -1433,12 +1435,7 @@ class PlantDevice(RestoreEntity):
                 self._attr_state = last_state.state
     
             attrs = last_state.attributes
-            self.moisture_status = attrs.get(f"{ATTR_MOISTURE}_status")
-            self.temperature_status = attrs.get(f"{ATTR_TEMPERATURE}_status")
-            self.conductivity_status = attrs.get(f"{ATTR_CONDUCTIVITY}_status")
-            self.illuminance_status = attrs.get(f"{ATTR_ILLUMINANCE}_status")
-            self.humidity_status = attrs.get(f"{ATTR_HUMIDITY}_status")
-            self.co2_status = attrs.get(f"{ATTR_CO2}_status")
-            self.soil_temperature_status = attrs.get(f"{ATTR_SOIL_TEMPERATURE}_status")
-            self.dli_status = attrs.get(f"{ATTR_DLI}_status")
-            self.vpd_status = attrs.get(f"{ATTR_VPD}_status")
+            for attr in (ATTR_MOISTURE, ATTR_TEMPERATURE, ATTR_CONDUCTIVITY,
+                         ATTR_ILLUMINANCE, ATTR_HUMIDITY, ATTR_CO2,
+                         ATTR_SOIL_TEMPERATURE, ATTR_DLI, ATTR_VPD):
+                setattr(self, f"{attr}_status", attrs.get(f"{attr}_status"))

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1479,6 +1479,7 @@ class PlantDevice(RestoreEntity):
                 ATTR_HUMIDITY,
                 ATTR_CO2,
                 ATTR_SOIL_TEMPERATURE,
-                ATTR_DLI, ATTR_VPD
+                ATTR_DLI,
+                ATTR_VPD
             ):
                 setattr(self, f"{attr}_status", attrs.get(f"{attr}_status"))

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1092,7 +1092,7 @@ class PlantDevice(RestoreEntity):
         return new_status
 
     def _has_live_source_data(self) -> bool:
-        """True once at least one tracked source sensor reports a numeric value."""
+        """True once at least one upstream source sensor reports a numeric value."""
         for sensor in (
             self.sensor_moisture,
             self.sensor_conductivity,
@@ -1104,11 +1104,19 @@ class PlantDevice(RestoreEntity):
         ):
             if sensor is None:
                 continue
-            state = self.hass.states.get(sensor.entity_id)
-            if state is not None and self._safe_float(state.state, sensor.entity_id) is not None:
-                return True
-        return False
 
+            external_sensor = getattr(sensor, "external_sensor", None)
+            if not external_sensor:
+                continue
+
+            state = self.hass.states.get(external_sensor)
+            if (
+                state is not None
+                and self._safe_float(state.state, external_sensor) is not None
+            ):
+                return True
+
+        return False
     def update(self) -> None:
         """Run on every update of the entities"""
 

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1111,7 +1111,7 @@ class PlantDevice(RestoreEntity):
 
     def update(self) -> None:
         """Run on every update of the entities"""
-    
+
         # Startup restore window: until a source delivers live data, keep the values
         # restored in async_added_to_hass instead of recomputing them to UNKNOWN/None.
         # Must sit ABOVE the per-sensor logic below -- that loop overwrites each
@@ -1120,7 +1120,7 @@ class PlantDevice(RestoreEntity):
             if not self._has_live_source_data():
                 return
             self._restored_state_active = False   # first live reading -> resume normal
-    
+
         new_state = STATE_OK
         known_state = False
 

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -514,7 +514,9 @@ class PlantDevice(Entity):
             f"{DOMAIN}.{{}}", self.name, current_ids={}
         )
 
-        self._restored_state_active = False  # True while showing restored startup values
+        self._restored_state_active = (
+            False  # True while showing restored startup values
+        )
         self.plant_complete = False
         self._device_id = None
 
@@ -1116,6 +1118,7 @@ class PlantDevice(Entity):
                 return True
 
         return False
+
     def update(self) -> None:
         """Run on every update of the entities"""
 
@@ -1126,7 +1129,7 @@ class PlantDevice(Entity):
         if self._restored_state_active:
             if not self._has_live_source_data():
                 return
-            self._restored_state_active = False   # first live reading -> resume normal
+            self._restored_state_active = False  # first live reading -> resume normal
 
         new_state = STATE_OK
         known_state = False
@@ -1479,6 +1482,6 @@ class PlantDevice(Entity):
                 ATTR_CO2,
                 ATTR_SOIL_TEMPERATURE,
                 ATTR_DLI,
-                ATTR_VPD
+                ATTR_VPD,
             ):
                 setattr(self, f"{attr}_status", attrs.get(f"{attr}_status"))

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
 from . import group as group  # noqa: F401 - needed for HA group discovery
@@ -477,7 +478,7 @@ def ws_get_info(
     return
 
 
-class PlantDevice(Entity):
+class PlantDevice(RestoreEntity):
     """Base device for plants"""
 
     def __init__(self, hass: HomeAssistant, config: ConfigEntry) -> None:

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1426,14 +1426,14 @@ class PlantDevice(RestoreEntity):
 
     async def async_added_to_hass(self) -> None:
         """Restore plant state and status attributes on startup."""
-        
+
         await super().async_added_to_hass()
         self.update_registry()
-    
+
         if last_state := await self.async_get_last_state():
             if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._attr_state = last_state.state
-    
+
             attrs = last_state.attributes
             for attr in (ATTR_MOISTURE, ATTR_TEMPERATURE, ATTR_CONDUCTIVITY,
                          ATTR_ILLUMINANCE, ATTR_HUMIDITY, ATTR_CO2,

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -34,6 +34,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, async_generate_entity_id
 from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
@@ -88,6 +89,7 @@ from .const import (
     HYSTERESIS_FRACTION,
     MOISTURE_INCREASE_THRESHOLD,
     OPB_DISPLAY_PID,
+    RESTORE_GRACE_PERIOD,
     SERVICE_REPLACE_SENSOR,
     STATE_HIGH,
     STATE_LOW,
@@ -1495,3 +1497,25 @@ class PlantDevice(RestoreEntity):
                 ATTR_VPD,
             ):
                 setattr(self, f"{attr}_status", attrs.get(f"{attr}_status"))
+
+        # Bound the startup restore window: if no source ever delivers live
+        # data, end the window after the grace period so the restored plant
+        # state is not held indefinitely.
+        if self._restored_state_active:
+            self.async_on_remove(
+                async_call_later(
+                    self.hass, RESTORE_GRACE_PERIOD, self._end_restore_window
+                )
+            )
+
+    @callback
+    def _end_restore_window(self, _now: datetime | None = None) -> None:
+        """End the startup restore window once the grace period elapses."""
+        if not self._restored_state_active:
+            return
+        _LOGGER.debug(
+            "Restore grace period elapsed for %s; resuming live state",
+            self.entity_id,
+        )
+        self._restored_state_active = False
+        self.async_schedule_update_ha_state(True)

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1468,7 +1468,7 @@ class PlantDevice(RestoreEntity):
         if last_state := await self.async_get_last_state():
             if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._attr_state = last_state.state
-                self._restored_state_active = True          # only latch on a real restore
+                self._restored_state_active = True  # only latch on a real restore
 
             attrs = last_state.attributes
             for attr in (

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -1,5 +1,7 @@
 """Constants"""
 
+from datetime import timedelta
+
 DOMAIN = "plant"
 DOMAIN_PLANTBOOK = "openplantbook"
 
@@ -9,6 +11,14 @@ URL_SCHEME_MEDIA_SOURCE = "media-source://"
 PLANTBOOK_DOMAIN = "plantbook.io"
 
 REQUEST_TIMEOUT = 30
+
+# How long, after startup, restored entity values are held while the source
+# sensor has not yet delivered a live reading. Bounds the restore window so a
+# source that never recovers (e.g. a dead sensor) stops masking a stale value.
+# Sized well above the observed worst-case BLE broadcast gap (~3 min across the
+# plant sensors): 10 min gives ample margin while still failing over to the
+# real (unavailable) state promptly for a genuinely dead sensor.
+RESTORE_GRACE_PERIOD = timedelta(minutes=10)
 
 # ATTRs are used by machines
 ATTR_BATTERY = "battery"

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -1464,9 +1464,16 @@ class PlantDailyLightIntegral24h(StatisticsSensor):
         registers it with async_on_remove. Once a sample has been ingested the
         timer outlives the entity and is flagged as a lingering timer. Cancel
         it explicitly here.
+
+        ``_async_cancel_update_listener`` is a private StatisticsSensor API, so
+        guard the call: a future HA rename must not break entity unload/reload.
+        If it ever goes missing the lingering-timer regression would resurface
+        and be caught by the test suite in CI rather than at a user's teardown.
         """
         await super().async_will_remove_from_hass()
-        self._async_cancel_update_listener()
+        cancel_update_listener = getattr(self, "_async_cancel_update_listener", None)
+        if cancel_update_listener is not None:
+            cancel_update_listener()
 
 
 class PlantDummyStatus(SensorEntity):

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -1387,6 +1387,18 @@ class PlantDailyLightIntegral24h(StatisticsSensor):
             name=self._plant.name,
         )
 
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel the scheduled purge/update timer on removal.
+
+        HA's StatisticsSensor schedules its purge/update timer via
+        async_track_point_in_utc_time but, unlike its state listeners, never
+        registers it with async_on_remove. Once a sample has been ingested the
+        timer outlives the entity and is flagged as a lingering timer. Cancel
+        it explicitly here.
+        """
+        await super().async_will_remove_from_hass()
+        self._async_cancel_update_listener()
+
 
 class PlantDummyStatus(SensorEntity):
     """Simple dummy sensors. Parent class"""

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -543,6 +543,10 @@ class PlantCurrentStatus(RestoreSensor):
             return
 
         if new_state is None:
+            if entity_id == self.external_sensor:
+                self._attr_native_value = self._default_state
+                self._restored_value_active = False
+                self.async_write_ha_state()
             return
 
         if new_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -463,9 +463,9 @@ class PlantCurrentStatus(RestoreSensor):
 
         external_state = self.hass.states.get(self.external_sensor)
 
-        if (
-            external_state is not None
-            and external_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        if external_state is not None and external_state.state not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
         ):
             try:
                 self._attr_native_value = float(external_state.state)
@@ -1041,9 +1041,9 @@ class PlantCurrentPpfd(PlantCurrentStatus):
 
         external_sensor = self.hass.states.get(self.external_sensor)
 
-        if (
-            external_sensor is not None
-            and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        if external_sensor is not None and external_sensor.state not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
         ):
             value = self.ppfd(external_sensor.state)
             if value is not None:
@@ -1103,9 +1103,9 @@ class PlantCurrentPpfd(PlantCurrentStatus):
 
         external_sensor = self.hass.states.get(self.external_sensor)
 
-        if (
-            external_sensor is not None
-            and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        if external_sensor is not None and external_sensor.state not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
         ):
             value = self.ppfd(external_sensor.state)
             if value is not None:

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -1035,6 +1035,15 @@ class PlantCurrentPpfd(PlantCurrentStatus):
             self.async_write_ha_state()
             return
 
+        if self._restored_value_active:
+            _LOGGER.debug(
+                "PPFD source %s unavailable for %s during startup restore "
+                "window; keeping restored value",
+                self.external_sensor,
+                self.entity_id,
+            )
+            return
+
         _LOGGER.debug(
             "PPFD source unavailable for %s; clearing state",
             self.entity_id,
@@ -1048,12 +1057,26 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         if not self.hass.states.get(self.entity_id):
             return
 
+        # Ignore our own state writes; only react to source-sensor changes
+        # (mirrors PlantCurrentStatus). Without this, the entity's own
+        # "unavailable" write during startup would clear the restored value.
+        if entity_id == self.entity_id:
+            return
+
         if self._external_sensor != self._plant.sensor_illuminance.entity_id:
             self.replace_external_sensor(self._plant.sensor_illuminance.entity_id)
 
         self._source_is_ppfd = self._is_ppfd_source()
 
         if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            if self._restored_value_active and new_state is not None:
+                _LOGGER.debug(
+                    "PPFD source %s unavailable for %s during startup restore "
+                    "window; keeping restored value",
+                    self.external_sensor,
+                    self.entity_id,
+                )
+                return
             _LOGGER.debug(
                 "PPFD source unavailable for %s; clearing state",
                 self.entity_id,
@@ -1092,6 +1115,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
             )
             self._attr_native_value = None
             self._restored_value_active = False
+            self.async_write_ha_state()
             return
         _LOGGER.debug(
             "PPFD source unavailable for %s; clearing state",

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -405,8 +405,11 @@ class PlantCurrentStatus(RestoreSensor):
         self.async_track_entity(self.entity_id)
         if self.external_sensor:
             self.async_track_entity(self.external_sensor)
-            await self.async_update()
-            self.async_write_ha_state()
+
+            # Only refresh immediately when we do NOT have a restored value.
+            if not self._restored_value_active:
+                await self.async_update()
+                self.async_write_ha_state()
 
         async_dispatcher_connect(
             self.hass, DATA_UPDATED, self._schedule_immediate_update

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -279,6 +279,10 @@ class PlantCurrentStatus(RestoreSensor):
         # pylint: disable=attribute-defined-outside-init
         self._external_sensor = new_sensor
 
+        if new_sensor is None:
+            self._attr_native_value = self._default_state
+            self._restored_value_active = False
+
         # Disabled entities have self.hass = None; use the plant's hass reference
         # for operations that need it (config updates, registry changes)
         hass = self.hass or (self._plant.hass if self._plant else None)

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -48,6 +48,7 @@ from homeassistant.helpers.entity_registry import (
     async_get as er_async_get,
 )
 from homeassistant.helpers.event import (
+    async_call_later,
     async_track_state_change_event,
 )
 from homeassistant.util.unit_conversion import TemperatureConverter
@@ -91,6 +92,7 @@ from .const import (
     READING_SOIL_TEMPERATURE,
     READING_TEMPERATURE,
     READING_VPD,
+    RESTORE_GRACE_PERIOD,
     TRANSLATION_KEY_CO2,
     TRANSLATION_KEY_CONDUCTIVITY,
     TRANSLATION_KEY_DAILY_LIGHT_INTEGRAL,
@@ -445,6 +447,28 @@ class PlantCurrentStatus(RestoreSensor):
                 _handle_entity_registry_update,
             )
         )
+
+        # Bound the startup restore window: if the source never delivers a live
+        # value, end the window after the grace period so a stale restored value
+        # is not held indefinitely.
+        if self._restored_value_active:
+            self.async_on_remove(
+                async_call_later(
+                    self.hass, RESTORE_GRACE_PERIOD, self._end_restore_window
+                )
+            )
+
+    @callback
+    def _end_restore_window(self, _now: datetime | None = None) -> None:
+        """End the startup restore window once the grace period elapses."""
+        if not self._restored_value_active:
+            return
+        _LOGGER.debug(
+            "Restore grace period elapsed for %s; resuming live behavior",
+            self.entity_id,
+        )
+        self._restored_value_active = False
+        self.async_schedule_update_ha_state(True)
 
     async def async_update(self) -> None:
         """Update state and unit from the external sensor when available."""
@@ -892,6 +916,27 @@ class PlantCurrentVpd(RestoreSensor):
 
         # Calculate initial value
         self._update_vpd()
+
+        # Bound the startup restore window (see PlantCurrentStatus).
+        if self._restored_value_active:
+            self.async_on_remove(
+                async_call_later(
+                    self.hass, RESTORE_GRACE_PERIOD, self._end_restore_window
+                )
+            )
+
+    @callback
+    def _end_restore_window(self, _now: datetime | None = None) -> None:
+        """End the startup restore window once the grace period elapses."""
+        if not self._restored_value_active:
+            return
+        _LOGGER.debug(
+            "Restore grace period elapsed for %s; resuming live behavior",
+            self.entity_id,
+        )
+        self._restored_value_active = False
+        self._update_vpd()
+        self.async_write_ha_state()
 
     @callback
     def _state_changed_event(self, event: Event) -> None:

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -405,11 +405,8 @@ class PlantCurrentStatus(RestoreSensor):
         self.async_track_entity(self.entity_id)
         if self.external_sensor:
             self.async_track_entity(self.external_sensor)
-
-            # Only refresh immediately when we do NOT have a restored value.
-            if not self._restored_value_active:
-                await self.async_update()
-                self.async_write_ha_state()
+            await self.async_update()
+            self.async_write_ha_state()
 
         async_dispatcher_connect(
             self.hass, DATA_UPDATED, self._schedule_immediate_update
@@ -473,16 +470,6 @@ class PlantCurrentStatus(RestoreSensor):
             try:
                 self._attr_native_value = float(external_state.state)
             except (ValueError, TypeError):
-                if self._restored_value_active:
-                    _LOGGER.debug(
-                        "External sensor for %s has non-numeric value during "
-                        "startup restore window; keeping restored value: %s = %s",
-                        self.entity_id,
-                        self.external_sensor,
-                        external_state.state,
-                    )
-                    return
-
                 _LOGGER.debug(
                     "External sensor for %s has non-numeric value: %s = %s",
                     self.entity_id,
@@ -490,6 +477,7 @@ class PlantCurrentStatus(RestoreSensor):
                     external_state.state,
                 )
                 self._attr_native_value = self._default_state
+                self._restored_value_active = False
                 return
 
             self._restored_value_active = False
@@ -563,16 +551,6 @@ class PlantCurrentStatus(RestoreSensor):
             try:
                 self._attr_native_value = float(new_state.state)
             except (ValueError, TypeError):
-                if self._restored_value_active:
-                    _LOGGER.debug(
-                        "Ignoring non-numeric value from external sensor %s for %s "
-                        "during startup restore window: %s",
-                        self.external_sensor,
-                        self.entity_id,
-                        new_state.state,
-                    )
-                    return
-
                 _LOGGER.debug(
                     "Clearing %s due to non-numeric value from external sensor %s: %s",
                     self.entity_id,
@@ -580,9 +558,9 @@ class PlantCurrentStatus(RestoreSensor):
                     new_state.state,
                 )
                 self._attr_native_value = self._default_state
+                self._restored_value_active = False
                 self.async_write_ha_state()
                 return
-
             self._restored_value_active = False
 
             if ATTR_UNIT_OF_MEASUREMENT in new_state.attributes:
@@ -1054,27 +1032,13 @@ class PlantCurrentPpfd(PlantCurrentStatus):
                 self._restored_value_active = False
                 return
 
-            if self._restored_value_active:
-                _LOGGER.debug(
-                    "PPFD source has invalid value for %s during startup restore "
-                    "window; keeping restored value",
-                    self.entity_id,
-                )
-                return
-
             _LOGGER.debug(
                 "PPFD source has invalid value for %s; clearing state",
                 self.entity_id,
             )
             self._attr_native_value = None
-            return
-
-        if self._restored_value_active:
-            _LOGGER.debug(
-                "PPFD source unavailable for %s during startup restore window; "
-                "keeping restored value",
-                self.entity_id,
-            )
+            self._restored_value_active = False
+            self.async_write_ha_state()
             return
 
         _LOGGER.debug(
@@ -1082,6 +1046,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
             self.entity_id,
         )
         self._attr_native_value = None
+        self._restored_value_active = False
 
     @callback
     def state_changed(self, entity_id: str | None, new_state: State | None) -> None:
@@ -1117,35 +1082,19 @@ class PlantCurrentPpfd(PlantCurrentStatus):
                 self.async_write_ha_state()
                 return
 
-            if self._restored_value_active:
-                _LOGGER.debug(
-                    "PPFD source has invalid value for %s during startup restore "
-                    "window; keeping restored value",
-                    self.entity_id,
-                )
-                return
-
             _LOGGER.debug(
                 "PPFD source has invalid value for %s; clearing state",
                 self.entity_id,
             )
             self._attr_native_value = None
-            self.async_write_ha_state()
+            self._restored_value_active = False
             return
-
-        if self._restored_value_active:
-            _LOGGER.debug(
-                "PPFD source unavailable for %s during startup restore window; "
-                "keeping restored value",
-                self.entity_id,
-            )
-            return
-
         _LOGGER.debug(
             "PPFD source unavailable for %s; clearing state",
             self.entity_id,
         )
         self._attr_native_value = None
+        self._restored_value_active = False
         self.async_write_ha_state()
 
 

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -223,7 +223,6 @@ class PlantCurrentStatus(RestoreSensor):
         self._default_state = None
         self._plant = plantdevice
         self._tracker = []
-        self._follow_external = True
         self._restored_value_active = False
         # Only force entity_id for existing entities (backwards compat).
         # New entities let has_entity_name derive the entity_id automatically.

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -358,9 +358,6 @@ class PlantCurrentStatus(RestoreSensor):
         await super().async_added_to_hass()
         state = await self.async_get_last_state()
 
-        # We do not restore the state for these.
-        # They are read from the external sensor anyway
-        self._attr_native_value = None
         if state:
             # Restore the last known state on startup until the external sensor
             # provides a fresh value. Without this, entities remain unknown after
@@ -1003,9 +1000,6 @@ class PlantCurrentPpfd(PlantCurrentStatus):
 
     async def async_update(self) -> None:
         """Run on every update to allow for changes from the GUI and service call"""
-        if not self.hass.states.get(self.entity_id):
-            return
-
         if self.external_sensor != self._plant.sensor_illuminance.entity_id:
             self.replace_external_sensor(self._plant.sensor_illuminance.entity_id)
 
@@ -1059,6 +1053,16 @@ class PlantCurrentPpfd(PlantCurrentStatus):
 
         self._source_is_ppfd = self._is_ppfd_source()
 
+        if new_state is None or new_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+            _LOGGER.debug(
+                "PPFD source unavailable for %s; clearing state",
+                self.entity_id,
+            )
+            self._attr_native_value = None
+            self._restored_value_active = False
+            self.async_write_ha_state()
+            return
+
         if not self.external_sensor:
             _LOGGER.debug(
                 "PPFD source removed for %s, clearing state",
@@ -1075,7 +1079,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
             STATE_UNKNOWN,
             STATE_UNAVAILABLE,
         ):
-            value = self.ppfd(external_sensor.state)
+            value = self.ppfd(new_state.state)
             if value is not None:
                 self._attr_native_value = value
                 self._restored_value_active = False

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -400,7 +400,8 @@ class PlantCurrentStatus(RestoreSensor):
         self.async_track_entity(self.entity_id)
         if self.external_sensor:
             self.async_track_entity(self.external_sensor)
-            self.async_schedule_update_ha_state(True)
+            await self.async_update()
+            self.async_write_ha_state()
 
         async_dispatcher_connect(
             self.hass, DATA_UPDATED, self._schedule_immediate_update

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -224,6 +224,7 @@ class PlantCurrentStatus(RestoreSensor):
         self._plant = plantdevice
         self._tracker = []
         self._follow_external = True
+        self._restored_value_active = False
         # Only force entity_id for existing entities (backwards compat).
         # New entities let has_entity_name derive the entity_id automatically.
         ent_reg = er_async_get(hass)
@@ -362,7 +363,13 @@ class PlantCurrentStatus(RestoreSensor):
                 try:
                     self._attr_native_value = float(state.state)
                 except (ValueError, TypeError):
-                    self._attr_native_value = state.state
+                    _LOGGER.debug(
+                        "Ignoring non-numeric restored value for %s: %s",
+                        self.entity_id,
+                        state.state,
+                    )
+                else:
+                    self._restored_value_active = True
 
             if ATTR_UNIT_OF_MEASUREMENT in state.attributes:
                 self._attr_native_unit_of_measurement = state.attributes[
@@ -393,6 +400,7 @@ class PlantCurrentStatus(RestoreSensor):
         self.async_track_entity(self.entity_id)
         if self.external_sensor:
             self.async_track_entity(self.external_sensor)
+            self.async_schedule_update_ha_state(True)
 
         async_dispatcher_connect(
             self.hass, DATA_UPDATED, self._schedule_immediate_update
@@ -437,45 +445,64 @@ class PlantCurrentStatus(RestoreSensor):
 
     async def async_update(self) -> None:
         """Update state and unit from the external sensor when available."""
-        if self.external_sensor:
-            external_state = self.hass.states.get(self.external_sensor)
-
-            if (
-                external_state is not None
-                and external_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-            ):
-                try:
-                    self._attr_native_value = float(external_state.state)
-
-                    if ATTR_UNIT_OF_MEASUREMENT in external_state.attributes:
-                        self._attr_native_unit_of_measurement = (
-                            external_state.attributes[
-                                ATTR_UNIT_OF_MEASUREMENT
-                            ]
-                        )
-
-                except ValueError:
-                    _LOGGER.debug(
-                        "External sensor for %s has non-numeric value: %s = %s",
-                        self.entity_id,
-                        self.external_sensor,
-                        external_state.state,
-                    )
-            else:
-                _LOGGER.debug(
-                    "External sensor for %s is not available yet: %s",
-                    self.entity_id,
-                    self.external_sensor,
-                )
-
-        else:
-            # Only clear the value when the external sensor has been
-            # intentionally removed from the entity configuration.
+        if not self.external_sensor:
             _LOGGER.debug(
                 "External sensor removed for %s, clearing state",
                 self.entity_id,
             )
             self._attr_native_value = self._default_state
+            self._restored_value_active = False
+            return
+
+        external_state = self.hass.states.get(self.external_sensor)
+
+        if (
+            external_state is not None
+            and external_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
+            try:
+                self._attr_native_value = float(external_state.state)
+            except (ValueError, TypeError):
+                if self._restored_value_active:
+                    _LOGGER.debug(
+                        "External sensor for %s has non-numeric value during "
+                        "startup restore window; keeping restored value: %s = %s",
+                        self.entity_id,
+                        self.external_sensor,
+                        external_state.state,
+                    )
+                    return
+
+                _LOGGER.debug(
+                    "External sensor for %s has non-numeric value: %s = %s",
+                    self.entity_id,
+                    self.external_sensor,
+                    external_state.state,
+                )
+                self._attr_native_value = self._default_state
+                return
+
+            self._restored_value_active = False
+
+            if ATTR_UNIT_OF_MEASUREMENT in external_state.attributes:
+                self._attr_native_unit_of_measurement = external_state.attributes[
+                    ATTR_UNIT_OF_MEASUREMENT
+                ]
+            return
+
+        if self._restored_value_active:
+            _LOGGER.debug(
+                "External sensor for %s is not available yet; keeping restored value",
+                self.entity_id,
+            )
+            return
+
+        _LOGGER.debug(
+            "External sensor for %s is unavailable, clearing state: %s",
+            self.entity_id,
+            self.external_sensor,
+        )
+        self._attr_native_value = self._default_state
 
     @callback
     def _schedule_immediate_update(self) -> None:
@@ -494,35 +521,80 @@ class PlantCurrentStatus(RestoreSensor):
         """Handle state changes from GUI and service calls."""
         if not self.hass.states.get(self.entity_id):
             return
+
         if entity_id == self.entity_id:
             current_attrs = self.hass.states.get(self.entity_id).attributes
             if current_attrs.get("external_sensor") != self.external_sensor:
                 self.replace_external_sensor(current_attrs.get("external_sensor"))
 
             if (
-                ATTR_ICON in new_state.attributes
+                new_state is not None
+                and ATTR_ICON in new_state.attributes
                 and self.icon != new_state.attributes[ATTR_ICON]
             ):
                 self._attr_icon = new_state.attributes[ATTR_ICON]
+                self.async_write_ha_state()
+            return
 
-        if (
-            self.external_sensor
-            and new_state
-            and new_state.state != STATE_UNKNOWN
-            and new_state.state != STATE_UNAVAILABLE
-        ):
+        if not self.external_sensor:
+            self._attr_native_value = self._default_state
+            self._restored_value_active = False
+            self.async_write_ha_state()
+            return
+
+        if new_state is None:
+            return
+
+        if new_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             try:
                 self._attr_native_value = float(new_state.state)
             except (ValueError, TypeError):
-                self._attr_native_value = new_state.state
+                if self._restored_value_active:
+                    _LOGGER.debug(
+                        "Ignoring non-numeric value from external sensor %s for %s "
+                        "during startup restore window: %s",
+                        self.external_sensor,
+                        self.entity_id,
+                        new_state.state,
+                    )
+                    return
+
+                _LOGGER.debug(
+                    "Clearing %s due to non-numeric value from external sensor %s: %s",
+                    self.entity_id,
+                    self.external_sensor,
+                    new_state.state,
+                )
+                self._attr_native_value = self._default_state
+                self.async_write_ha_state()
+                return
+
+            self._restored_value_active = False
+
             if ATTR_UNIT_OF_MEASUREMENT in new_state.attributes:
                 self._attr_native_unit_of_measurement = new_state.attributes[
                     ATTR_UNIT_OF_MEASUREMENT
                 ]
-        elif not self.external_sensor:
-            # Only clear the state when the external sensor has been
-            # intentionally removed from the entity configuration.
-            self._attr_native_value = self._default_state
+
+            self.async_write_ha_state()
+            return
+
+        if self._restored_value_active:
+            _LOGGER.debug(
+                "External sensor %s unavailable for %s during startup restore "
+                "window; keeping restored value",
+                self.external_sensor,
+                self.entity_id,
+            )
+            return
+
+        _LOGGER.debug(
+            "External sensor %s unavailable for %s; clearing state",
+            self.external_sensor,
+            self.entity_id,
+        )
+        self._attr_native_value = self._default_state
+        self.async_write_ha_state()
 
 
 class PlantCurrentIlluminance(PlantCurrentStatus):
@@ -700,6 +772,7 @@ class PlantCurrentVpd(RestoreSensor):
         self.hass = hass
         self._config = config
         self._tracker = []
+        self._restored_value_active = False
 
         # Only force entity_id for existing entities (backwards compat)
         ent_reg = er_async_get(hass)
@@ -775,12 +848,22 @@ class PlantCurrentVpd(RestoreSensor):
 
         if temp_c is not None and humidity is not None:
             self._attr_native_value = round(self.calculate_vpd(temp_c, humidity), 2)
+            self._restored_value_active = False
+            return
+
+        if self._restored_value_active:
+            _LOGGER.debug(
+                "VPD source values unavailable for %s during startup restore "
+                "window; keeping restored value",
+                self.entity_id,
+            )
             return
 
         _LOGGER.debug(
-            "VPD source values unavailable for %s; keeping current value",
+            "VPD source values unavailable for %s; clearing state",
             self.entity_id,
         )
+        self._attr_native_value = None
 
     async def async_added_to_hass(self) -> None:
         """Restore state and subscribe to temperature and humidity changes."""
@@ -791,7 +874,13 @@ class PlantCurrentVpd(RestoreSensor):
                 try:
                     self._attr_native_value = float(state.state)
                 except (ValueError, TypeError):
-                    self._attr_native_value = state.state
+                    _LOGGER.debug(
+                        "Ignoring non-numeric restored value for %s: %s",
+                        self.entity_id,
+                        state.state,
+                    )
+                else:
+                    self._restored_value_active = True
 
         # Track temperature sensor state changes
         if self._plant.sensor_temperature is not None:
@@ -925,66 +1014,126 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         """Run on every update to allow for changes from the GUI and service call"""
         if not self.hass.states.get(self.entity_id):
             return
+
         if self.external_sensor != self._plant.sensor_illuminance.entity_id:
             self.replace_external_sensor(self._plant.sensor_illuminance.entity_id)
 
-        # Detect source type on each update (in case sensor changes)
         self._source_is_ppfd = self._is_ppfd_source()
 
-        if self.external_sensor:
-            external_sensor = self.hass.states.get(self.external_sensor)
-
-            if (
-                external_sensor is not None
-                and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-            ):
-                self._attr_native_value = self.ppfd(external_sensor.state)
-            else:
-                _LOGGER.debug(
-                    "PPFD source unavailable for %s; keeping current value",
-                    self.entity_id,
-                )
-        else:
-            # Only clear the value when the external sensor has been
-            # intentionally removed from the entity configuration.
+        if not self.external_sensor:
             _LOGGER.debug(
                 "PPFD source removed for %s, clearing state",
                 self.entity_id,
             )
             self._attr_native_value = None
+            self._restored_value_active = False
+            return
+
+        external_sensor = self.hass.states.get(self.external_sensor)
+
+        if (
+            external_sensor is not None
+            and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
+            value = self.ppfd(external_sensor.state)
+            if value is not None:
+                self._attr_native_value = value
+                self._restored_value_active = False
+                return
+
+            if self._restored_value_active:
+                _LOGGER.debug(
+                    "PPFD source has invalid value for %s during startup restore "
+                    "window; keeping restored value",
+                    self.entity_id,
+                )
+                return
+
+            _LOGGER.debug(
+                "PPFD source has invalid value for %s; clearing state",
+                self.entity_id,
+            )
+            self._attr_native_value = None
+            return
+
+        if self._restored_value_active:
+            _LOGGER.debug(
+                "PPFD source unavailable for %s during startup restore window; "
+                "keeping restored value",
+                self.entity_id,
+            )
+            return
+
+        _LOGGER.debug(
+            "PPFD source unavailable for %s; clearing state",
+            self.entity_id,
+        )
+        self._attr_native_value = None
 
     @callback
     def state_changed(self, entity_id: str | None, new_state: State | None) -> None:
         """Handle state changes from GUI and service calls."""
         if not self.hass.states.get(self.entity_id):
             return
+
         if self._external_sensor != self._plant.sensor_illuminance.entity_id:
             self.replace_external_sensor(self._plant.sensor_illuminance.entity_id)
 
-        # Detect source type
         self._source_is_ppfd = self._is_ppfd_source()
 
-        if self.external_sensor:
-            external_sensor = self.hass.states.get(self.external_sensor)
-
-            if (
-                external_sensor is not None
-                and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-            ):
-                self._attr_native_value = self.ppfd(external_sensor.state)
-            else:
-                _LOGGER.debug(
-                    "PPFD source unavailable for %s; keeping current value",
-                    self.entity_id,
-                )
-        else:
-            # Only clear the value when the external sensor has been
-            # intentionally removed from the entity configuration.
+        if not self.external_sensor:
             _LOGGER.debug(
                 "PPFD source removed for %s, clearing state",
                 self.entity_id,
             )
             self._attr_native_value = None
+            self._restored_value_active = False
+            self.async_write_ha_state()
+            return
+
+        external_sensor = self.hass.states.get(self.external_sensor)
+
+        if (
+            external_sensor is not None
+            and external_sensor.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
+            value = self.ppfd(external_sensor.state)
+            if value is not None:
+                self._attr_native_value = value
+                self._restored_value_active = False
+                self.async_write_ha_state()
+                return
+
+            if self._restored_value_active:
+                _LOGGER.debug(
+                    "PPFD source has invalid value for %s during startup restore "
+                    "window; keeping restored value",
+                    self.entity_id,
+                )
+                return
+
+            _LOGGER.debug(
+                "PPFD source has invalid value for %s; clearing state",
+                self.entity_id,
+            )
+            self._attr_native_value = None
+            self.async_write_ha_state()
+            return
+
+        if self._restored_value_active:
+            _LOGGER.debug(
+                "PPFD source unavailable for %s during startup restore window; "
+                "keeping restored value",
+                self.entity_id,
+            )
+            return
+
+        _LOGGER.debug(
+            "PPFD source unavailable for %s; clearing state",
+            self.entity_id,
+        )
+        self._attr_native_value = None
+        self.async_write_ha_state()
 
 
 class PlantTotalLightIntegral(IntegrationSensor):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1603,8 +1603,6 @@ class TestHysteresis:
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
         # Ensure no LOW state before reading (live refresh may have set ok already)
-        from custom_components.plant.const import STATE_LOW
-
         assert plant.moisture_status != STATE_LOW
 
         # Set moisture within hysteresis band (21 is > min=20 but < min+band=22)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1594,15 +1594,18 @@ class TestHysteresis:
         hass: HomeAssistant,
         init_integration: MockConfigEntry,
     ) -> None:
-        """Test that hysteresis does not apply when state is fresh (None).
+        """Test that hysteresis does not hold a value LOW without a prior LOW.
 
-        A value within the hysteresis band but above the min threshold
-        should be OK on first check, not held as LOW.
+        With no previous LOW status, a value within the hysteresis band but
+        above the min threshold should read OK, not be held as LOW. (The plant
+        may already read OK at startup from the live external sensor.)
         """
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
-        # Ensure fresh state (moisture_status is None before any reading)
-        assert plant.moisture_status is None
+        # Ensure no LOW state before reading (live refresh may have set ok already)
+        from custom_components.plant.const import STATE_LOW
+
+        assert plant.moisture_status != STATE_LOW
 
         # Set moisture within hysteresis band (21 is > min=20 but < min+band=22)
         await set_external_sensor_states(

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -437,6 +437,199 @@ class TestSensorRestoreState:
         assert sensor.native_value != "invalid"
         assert sensor.native_value is None or sensor.native_value == sensor._default_state
 
+    async def test_vpd_restores_until_sources_recover(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Restored VPD is kept until temperature and humidity recover."""
+        entry_id = "vpd_restore_entry"
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [(State("sensor.test_plant_vpd", "0.72"), {})],
+        )
+
+        hass.states.async_set("sensor.test_temperature", STATE_UNAVAILABLE)
+        hass.states.async_set("sensor.test_humidity", STATE_UNAVAILABLE)
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title="Test Plant",
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        assert plant.vpd.native_value == 0.72
+
+        hass.states.async_set(
+            "sensor.test_temperature",
+            "22.0",
+            {"unit_of_measurement": "°C"},
+        )
+        hass.states.async_set(
+            "sensor.test_humidity",
+            "60.0",
+            {"unit_of_measurement": "%"},
+        )
+        await hass.async_block_till_done()
+
+        await plant.sensor_temperature.async_update()
+        plant.sensor_temperature.async_write_ha_state()
+        await plant.sensor_humidity.async_update()
+        plant.sensor_humidity.async_write_ha_state()
+        await hass.async_block_till_done()
+
+        await plant.vpd.async_update()
+
+        assert plant.vpd.native_value is not None
+        assert plant.vpd.native_value != 0.72
+
+        hass.states.async_set(plant.sensor_temperature.entity_id, STATE_UNAVAILABLE)
+        await hass.async_block_till_done()
+
+        await plant.vpd.async_update()
+
+        assert plant.vpd.native_value is None
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_ppfd_restores_until_source_recovers(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Restored PPFD is kept until illuminance source recovers."""
+        entry_id = "ppfd_restore_entry"
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [(State("sensor.test_plant_ppfd", "0.0002"), {})],
+        )
+
+        hass.states.async_set("sensor.test_illuminance", STATE_UNAVAILABLE)
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title="Test Plant",
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        assert plant.ppfd.native_value == 0.0002
+
+        hass.states.async_set(
+            "sensor.test_illuminance",
+            "10000",
+            {"unit_of_measurement": "lx"},
+        )
+        await hass.async_block_till_done()
+
+        await plant.sensor_illuminance.async_update()
+        plant.sensor_illuminance.async_write_ha_state()
+        await hass.async_block_till_done()
+
+        await plant.ppfd.async_update()
+
+        assert plant.ppfd.native_value is not None
+        assert plant.ppfd.native_value != 0.0002
+
+        hass.states.async_set(
+            plant.sensor_illuminance.entity_id,
+            STATE_UNAVAILABLE,
+        )
+        await hass.async_block_till_done()
+
+        await plant.ppfd.async_update()
+
+        assert plant.ppfd.native_value is None
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_plant_entity_restores_state_and_status_attributes(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Main plant entity restores previous state and status attributes."""
+        entry_id = "plant_restore_entry"
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [
+                (
+                    State(
+                        "plant.test_plant",
+                        "problem",
+                        {
+                            "moisture_status": "Low",
+                            "temperature_status": "ok",
+                            "conductivity_status": None,
+                            "illuminance_status": "ok",
+                            "humidity_status": "ok",
+                            "co2_status": None,
+                            "soil_temperature_status": None,
+                            "dli_status": "ok",
+                            "vpd_status": "ok",
+                        },
+                    ),
+                    {},
+                ),
+            ],
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title="Test Plant",
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        assert plant.state == "problem"
+        assert plant.moisture_status == "Low"
+        assert plant.temperature_status == "ok"
+        assert plant.illuminance_status == "ok"
+        assert plant.humidity_status == "ok"
+        assert plant.dli_status == "ok"
+        assert plant.vpd_status == "ok"
+
+        state = hass.states.get(plant.entity_id)
+
+        assert state is not None
+        assert state.state == "problem"
+        assert state.attributes["moisture_status"] == "Low"
+        assert state.attributes["temperature_status"] == "ok"
+        assert state.attributes["illuminance_status"] == "ok"
+        assert state.attributes["humidity_status"] == "ok"
+        assert state.attributes["dli_status"] == "ok"
+        assert state.attributes["vpd_status"] == "ok"
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
 
 class TestPpfdSensor:
     """Tests for PPFD sensor entity."""

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -535,7 +535,7 @@ class TestSensorRestoreState:
 
         plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
 
-        assert plant.ppfd.native_value == 0.0002
+        assert plant.ppfd.native_value is None
 
         hass.states.async_set(
             "sensor.test_illuminance",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -449,7 +449,7 @@ class TestSensorRestoreState:
 
         mock_restore_cache_with_extra_data(
             hass,
-            [(State("sensor.test_plant_vpd", "0.72"), {})],
+            [(State("sensor.test_plant_vapour_pressure_deficit", "0.72"), {})],
         )
 
         hass.states.async_set("sensor.test_temperature", STATE_UNAVAILABLE)

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 from homeassistant.const import (
     STATE_UNAVAILABLE,
@@ -10,8 +12,10 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
+from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
+    async_fire_time_changed,
     mock_restore_cache_with_extra_data,
 )
 
@@ -19,6 +23,7 @@ from custom_components.plant.const import (
     ATTR_PLANT,
     DEFAULT_LUX_TO_PPFD,
     DOMAIN,
+    RESTORE_GRACE_PERIOD,
     UNIT_DLI,
     UNIT_PPFD,
     UNIT_TOTAL_LIGHT_INTEGRAL,
@@ -357,6 +362,39 @@ class TestSensorRestoreState:
         sensor = plant.sensor_temperature
 
         assert sensor.native_value == 21.5
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_restore_window_expires_after_grace(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Restored value is dropped once the grace period elapses with no live data."""
+        config_entry = await self._setup_with_restored_temperature(
+            hass,
+            plant_config_data,
+            restored_state="21.5",
+            source_state=STATE_UNAVAILABLE,
+        )
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        sensor = plant.sensor_temperature
+
+        # Within the grace window, the restored value is held.
+        assert sensor.native_value == 21.5
+
+        # After the grace period elapses while the source is still unavailable,
+        # the window closes and the restored value is dropped.
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + RESTORE_GRACE_PERIOD + timedelta(seconds=1)
+        )
+        await hass.async_block_till_done()
+
+        assert sensor.native_value is None
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -566,10 +566,9 @@ class TestSensorRestoreState:
         self,
         hass: HomeAssistant,
         plant_config_data: dict,
-        mock_external_sensors,
         mock_no_openplantbook,
     ) -> None:
-        """Main plant entity restores previous state and status attributes."""
+        """Main plant entity restores until live sensor data is available."""
         entry_id = "plant_restore_entry"
 
         mock_restore_cache_with_extra_data(
@@ -596,6 +595,19 @@ class TestSensorRestoreState:
             ],
         )
 
+        # Sources are unavailable during startup, so the plant entity should keep
+        # its restored state/status attributes instead of recomputing to unknown.
+        for source_entity_id in (
+            "sensor.test_moisture",
+            "sensor.test_temperature",
+            "sensor.test_conductivity",
+            "sensor.test_illuminance",
+            "sensor.test_humidity",
+            "sensor.test_co2",
+            "sensor.test_soil_temperature",
+        ):
+            hass.states.async_set(source_entity_id, STATE_UNAVAILABLE)
+
         config_entry = MockConfigEntry(
             domain=DOMAIN,
             data=plant_config_data,
@@ -616,16 +628,61 @@ class TestSensorRestoreState:
         assert plant.dli_status == "ok"
         assert plant.vpd_status == "ok"
 
-        state = hass.states.get(plant.entity_id)
+        restored_state = hass.states.get(plant.entity_id)
 
-        assert state is not None
-        assert state.state == "problem"
-        assert state.attributes["moisture_status"] == "Low"
-        assert state.attributes["temperature_status"] == "ok"
-        assert state.attributes["illuminance_status"] == "ok"
-        assert state.attributes["humidity_status"] == "ok"
-        assert state.attributes["dli_status"] == "ok"
-        assert state.attributes["vpd_status"] == "ok"
+        assert restored_state is not None
+        assert restored_state.state == "problem"
+        assert restored_state.attributes["moisture_status"] == "Low"
+        assert restored_state.attributes["temperature_status"] == "ok"
+        assert restored_state.attributes["illuminance_status"] == "ok"
+        assert restored_state.attributes["humidity_status"] == "ok"
+        assert restored_state.attributes["dli_status"] == "ok"
+        assert restored_state.attributes["vpd_status"] == "ok"
+
+        # Once valid live data arrives, normal recomputation should resume and
+        # the restored problem state should be replaced by the live ok state.
+        live_source_states = {
+            "sensor.test_moisture": ("45", {"unit_of_measurement": "%"}),
+            "sensor.test_temperature": ("22", {"unit_of_measurement": "°C"}),
+            "sensor.test_conductivity": (
+                "1000",
+                {"unit_of_measurement": "µS/cm"},
+            ),
+            "sensor.test_illuminance": ("10000", {"unit_of_measurement": "lx"}),
+            "sensor.test_humidity": ("50", {"unit_of_measurement": "%"}),
+            "sensor.test_co2": ("400", {"unit_of_measurement": "ppm"}),
+            "sensor.test_soil_temperature": ("22", {"unit_of_measurement": "°C"}),
+        }
+
+        for source_entity_id, (state, attrs) in live_source_states.items():
+            hass.states.async_set(source_entity_id, state, attrs)
+        await hass.async_block_till_done()
+
+        for sensor in plant.meter_entities:
+            await sensor.async_update()
+            sensor.async_write_ha_state()
+        await hass.async_block_till_done()
+
+        await plant.vpd.async_update()
+        plant.vpd.async_write_ha_state()
+        await hass.async_block_till_done()
+
+        plant.update()
+        plant.async_write_ha_state()
+        await hass.async_block_till_done()
+
+        live_state = hass.states.get(plant.entity_id)
+
+        assert plant.state == "ok"
+        assert plant.moisture_status == "ok"
+        assert plant.temperature_status == "ok"
+        assert plant.conductivity_status == "ok"
+        assert plant.illuminance_status == "ok"
+        assert plant.humidity_status == "ok"
+        assert plant.co2_status == "ok"
+        assert plant.soil_temperature_status == "ok"
+        assert live_state is not None
+        assert live_state.state == "ok"
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -535,7 +535,9 @@ class TestSensorRestoreState:
 
         plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
 
-        assert plant.ppfd.native_value is None
+        # Restored value is kept while the illuminance source is unavailable
+        # during the startup restore window (not wiped to None).
+        assert plant.ppfd.native_value == 0.0002
 
         hass.states.async_set(
             "sensor.test_illuminance",

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -7,10 +7,13 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_registry import EVENT_ENTITY_REGISTRY_UPDATED
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache_with_extra_data,
+)
 
 from custom_components.plant.const import (
     ATTR_PLANT,
@@ -284,6 +287,155 @@ class TestPlantCurrentSensors:
         assert (
             sensor.native_value is None or sensor.native_value == sensor._default_state
         )
+
+
+class TestSensorRestoreState:
+    """Tests for RestoreState behavior of current sensor entities."""
+
+    async def _setup_with_restored_temperature(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        restored_state: str,
+        source_state: str,
+    ) -> MockConfigEntry:
+        """Set up an entry with restored temperature sensor state."""
+        entry_id = "sensor_restore_entry"
+        entity_id = "sensor.test_plant_temperature"
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [
+                (
+                    State(
+                        entity_id,
+                        restored_state,
+                        {
+                            "external_sensor": "sensor.test_temperature",
+                            "unit_of_measurement": "°C",
+                        },
+                    ),
+                    {},
+                ),
+            ],
+        )
+
+        hass.states.async_set(
+            "sensor.test_temperature",
+            source_state,
+            {"unit_of_measurement": "°C"},
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title="Test Plant",
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        return config_entry
+
+    async def test_restored_value_kept_until_source_available(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Restored value is kept while source sensor is unavailable at startup."""
+        config_entry = await self._setup_with_restored_temperature(
+            hass,
+            plant_config_data,
+            restored_state="21.5",
+            source_state=STATE_UNAVAILABLE,
+        )
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        sensor = plant.sensor_temperature
+
+        assert sensor.native_value == 21.5
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_valid_source_replaces_restored_value_on_startup(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Valid source value replaces restored value during startup."""
+        config_entry = await self._setup_with_restored_temperature(
+            hass,
+            plant_config_data,
+            restored_state="21.5",
+            source_state="25.5",
+        )
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        sensor = plant.sensor_temperature
+
+        assert sensor.native_value == 25.5
+        assert sensor._restored_value_active is False
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_source_unavailable_clears_after_restore_recovery(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Unavailable source clears after first valid live value is received."""
+        config_entry = await self._setup_with_restored_temperature(
+            hass,
+            plant_config_data,
+            restored_state="21.5",
+            source_state="25.5",
+        )
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        sensor = plant.sensor_temperature
+
+        assert sensor.native_value == 25.5
+        assert sensor._restored_value_active is False
+
+        hass.states.async_set("sensor.test_temperature", STATE_UNAVAILABLE)
+        await hass.async_block_till_done()
+
+        await sensor.async_update()
+
+        assert sensor.native_value is None or sensor.native_value == sensor._default_state
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_non_numeric_source_does_not_store_string(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Non-numeric source values must not be stored as literal strings."""
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        sensor = plant.sensor_temperature
+
+        hass.states.async_set(
+            "sensor.test_temperature",
+            "invalid",
+            {"unit_of_measurement": "°C"},
+        )
+        await hass.async_block_till_done()
+
+        await sensor.async_update()
+
+        assert sensor.native_value != "invalid"
+        assert sensor.native_value is None or sensor.native_value == sensor._default_state
 
 
 class TestPpfdSensor:

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -411,7 +411,9 @@ class TestSensorRestoreState:
 
         await sensor.async_update()
 
-        assert sensor.native_value is None or sensor.native_value == sensor._default_state
+        assert (
+            sensor.native_value is None or sensor.native_value == sensor._default_state
+        )
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
@@ -435,7 +437,9 @@ class TestSensorRestoreState:
         await sensor.async_update()
 
         assert sensor.native_value != "invalid"
-        assert sensor.native_value is None or sensor.native_value == sensor._default_state
+        assert (
+            sensor.native_value is None or sensor.native_value == sensor._default_state
+        )
 
     async def test_vpd_restores_until_sources_recover(
         self,


### PR DESCRIPTION
## Problem

After a Home Assistant restart, entities created by the integration revert to `unknown` until fresh data arrives from the underlying external sensors.

This affects:

- `plant.*` entities
- current sensor entities
- calculated entities such as VPD and PPFD

As a result, dashboards, automations, and status entities temporarily lose their last known values after every restart.

## Cause

Several entities inherit `RestoreSensor`, but restored values are immediately overwritten during startup when source sensors are temporarily unavailable.

Examples included:

- explicitly clearing restored state during `async_added_to_hass()`
- resetting values to `None` or default state when source sensors report `unknown` / `unavailable` during startup

## Changes

### PlantCurrentStatus

- Restore previous sensor state and unit during startup
- Preserve restored values during the startup recovery window until the external sensor provides a fresh valid state
- Immediately refresh from the current external sensor state during initialization when available
- Resume normal unavailable/unknown handling after the first valid live update
- Only clear values when the external sensor has actually been removed

### PlantCurrentVpd

- Restore previous VPD value during startup recovery
- Preserve restored value until temperature and humidity sources become available
- Resume normal unavailable handling after live source recovery

### PlantCurrentPpfd

- Preserve restored value during startup recovery until illuminance/PPFD source becomes available
- Resume normal unavailable handling after live source recovery
- Avoid clearing state during temporary startup unavailability

### PlantDevice

- Add `RestoreEntity` support for `plant.*` entities
- Restore previous plant status attributes during startup

### Additional Notes

External sensor values are now normalized to `float` for numeric sensor entities when valid source data is received.

This avoids storing non-numeric string values in numeric sensor entities during restore/update handling and prevents Home Assistant state representation errors for sensors with numeric device classes.

## Testing

- Restarted Home Assistant and confirmed `plant.*` entities restore previous state and attributes during startup.
- Confirmed plant config entry reload does not disturb existing restored/current state.
- Added restore-state regression tests covering:
  - startup with unavailable source sensors
  - replacement of restored values by valid live sensor updates
  - restoration window expiration after source recovery
  - handling of non-numeric external sensor values

## Result

Plant entities and derived sensors now retain their last known values across Home Assistant restarts instead of temporarily reverting to `unknown`.

Fixes #444