### PR TITLE
ci: add workflow permissions and fix master→main triggers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,9 +4,12 @@ on:
   push:
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 15 * *"
+
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -3,12 +3,15 @@ name: HACS Validation
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 16 * *"
+
+permissions:
+  contents: read
 
 jobs:
   hacs:

--- a/.github/workflows/remove-awaiting-feedback.yml
+++ b/.github/workflows/remove-awaiting-feedback.yml
@@ -4,6 +4,10 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   remove-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -5,6 +5,10 @@ on:
     - cron: "0 6 * * *"  # Run daily at 6 AM UTC
   workflow_dispatch:  # Allow manual trigger
 
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Hardens GitHub Actions workflows and fixes branch triggers that still referenced the old `master` default branch.

### 1. Resolves 6 CodeQL `actions/missing-workflow-permissions` alerts (medium)

Adds explicit least-privilege `permissions:` blocks so `GITHUB_TOKEN` no longer inherits broad repo-default scopes:

| Workflow | Scope | Why |
|---|---|---|
| `CI.yml` | `contents: read` | lint/test/validate are read-only |
| `hacs.yml` | `contents: read` | checkout + HACS validation only |
| `stale-issues.yml` | `contents: read`, `issues: write` | adds the `stale` label |
| `remove-awaiting-feedback.yml` | `contents: read`, `issues: write` | removes the `awaiting feedback` label |

### 2. Fixes `master` → `main` branch triggers

The default branch is `main`, but several triggers filtered on `master`, so they never matched:

- `CI.yml`: `pull_request.branches` `master` → `main` — **CI lint/tests now actually run on PRs** (they previously only ran via the unfiltered `push:` trigger)
- `hacs.yml`: `push.branches` and `pull_request.branches` `master` → `main`

### Deliberately left untouched

- `CI.yml` `home-assistant/actions/hassfest@master` — this is the hassfest action's own version ref, not a branch trigger.
- `release.yml` — already declares `permissions: contents: write`, and its `workflow_run` trigger already includes `main` (`[main, master]`), so it works correctly.

### Verification

- All four files validated as well-formed YAML.
- Changes are limited to `on:`/`permissions:` headers; no job logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)