### PR TITLE
Expose OpenPlantbook care guidance as care_* attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,19 @@ Go to **Settings** → **Devices & Services** → **Plant Monitor** → *Your Pl
 > [!NOTE]
 > If the current image points to a local file or non-OpenPlantbook URL, it is **not** replaced unless "Force refresh" is checked.
 
+### 🪴 Care Guidance *(OpenPlantbook)*
+
+When OpenPlantbook has care information for a species, the plant device exposes it as free-text **attributes** you can show on a dashboard or use in automations and templates. Only the fields OpenPlantbook provides for a given species appear:
+
+- `care_watering`
+- `care_sunlight`
+- `care_soil`
+- `care_pruning`
+- `care_fertilization`
+
+> [!NOTE]
+> Care guidance is fetched together with the species data, so **existing plants only get it after a refresh** — use **Force refresh** (above) or change the species. Newly added plants get it automatically.
+
 ---
 
 ## 🃏 Lovelace Card

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -40,6 +40,7 @@ from . import group as group  # noqa: F401 - needed for HA group discovery
 from .config_flow import update_plant_options
 from .const import (
     ATTR_BRIGHTNESS,
+    ATTR_CARE,
     ATTR_CO2,
     ATTR_CONDUCTIVITY,
     ATTR_CURRENT,
@@ -495,6 +496,9 @@ class PlantDevice(Entity):
         self.species = self._config.options.get(
             ATTR_SPECIES, self._config.data[FLOW_PLANT_INFO].get(ATTR_SPECIES)
         )
+        # Static per-species care text from OpenPlantbook (include: care).
+        # Stored at config/refresh time; only fields OPB returned are present.
+        self.care = self._config.data[FLOW_PLANT_INFO].get(ATTR_CARE, {})
         # Get display_species from options or from initial config
         # Capitalize first letter for proper binomial nomenclature (genus capitalized)
         raw_display_species = (
@@ -679,6 +683,8 @@ class PlantDevice(Entity):
             f"{ATTR_VPD}_status": self.vpd_status,
             f"{ATTR_SPECIES}_original": self.species,
         }
+        for field, value in self.care.items():
+            attributes[f"care_{field}"] = value
         return attributes
 
     def _get_entity_icon(self, entity: Entity) -> str | None:

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -41,6 +41,7 @@ from .config_flow import update_plant_options
 from .const import (
     ATTR_BRIGHTNESS,
     ATTR_CARE,
+    ATTR_CARE_PREFIX,
     ATTR_CO2,
     ATTR_CONDUCTIVITY,
     ATTR_CURRENT,
@@ -686,7 +687,7 @@ class PlantDevice(Entity):
             f"{ATTR_SPECIES}_original": self.species,
         }
         for field, value in self.care.items():
-            attributes[f"care_{field}"] = value
+            attributes[f"{ATTR_CARE_PREFIX}{field}"] = value
         return attributes
 
     def _get_entity_icon(self, entity: Entity) -> str | None:

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -498,7 +498,9 @@ class PlantDevice(Entity):
         )
         # Static per-species care text from OpenPlantbook (include: care).
         # Stored at config/refresh time; only fields OPB returned are present.
-        self.care = self._config.data[FLOW_PLANT_INFO].get(ATTR_CARE, {})
+        # Copy on read: ConfigEntry.data is treated as immutable, so avoid sharing
+        # a reference to the entry's internal care dict.
+        self.care = dict(self._config.data[FLOW_PLANT_INFO].get(ATTR_CARE, {}))
         # Get display_species from options or from initial config
         # Capitalize first letter for proper binomial nomenclature (genus capitalized)
         raw_display_species = (

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.selector import selector
 
 from .const import (
+    ATTR_CARE,
     ATTR_ENTITY,
     ATTR_LIMITS,
     ATTR_OPTIONS,
@@ -333,6 +334,9 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ATTR_SENSORS: {},
             }
         )
+        care = plant_config[FLOW_PLANT_INFO].get(ATTR_CARE)
+        if care:
+            self.plant_info[ATTR_CARE] = care
         extra_desc = ""
         if plant_config[FLOW_PLANT_INFO].get(OPB_DISPLAY_PID):
             # We got data from OPB.  Display a "wrong plant" switch

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -334,9 +334,10 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 ATTR_SENSORS: {},
             }
         )
-        care = plant_config[FLOW_PLANT_INFO].get(ATTR_CARE)
-        if care:
-            self.plant_info[ATTR_CARE] = care
+        # Always overwrite (do not guard on truthiness): if the user switches to a
+        # species with no care via the "wrong plant" path, stale care from the
+        # previous species must be cleared, not left behind.
+        self.plant_info[ATTR_CARE] = plant_config[FLOW_PLANT_INFO].get(ATTR_CARE, {})
         extra_desc = ""
         if plant_config[FLOW_PLANT_INFO].get(OPB_DISPLAY_PID):
             # We got data from OPB.  Display a "wrong plant" switch

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -912,6 +912,7 @@ async def refresh_plant_from_openplantbook(
     plant.display_species = (
         opb_display_raw[0].upper() + opb_display_raw[1:] if opb_display_raw else ""
     )
+    plant.care = plant_config[FLOW_PLANT_INFO].get(ATTR_CARE, {})
 
     limits = plant_config[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS]
     _LOGGER.debug("Updating %d threshold entities from OPB data", len(limits))
@@ -950,6 +951,7 @@ async def refresh_plant_from_openplantbook(
     data = dict(entry.data)
     plant_info = dict(data.get(FLOW_PLANT_INFO, {}))
     plant_info[FLOW_PLANT_LIMITS] = dict(limits)
+    plant_info[ATTR_CARE] = dict(plant.care)
     data[FLOW_PLANT_INFO] = plant_info
     options = dict(entry.options)
     options[OPB_DISPLAY_PID] = plant.display_species

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -40,6 +40,10 @@ ATTR_SPECIES = "species"
 ATTR_IMAGE = "image"
 ATTR_SEARCH_FOR = "search_for"
 ATTR_CARE = "care"
+# Public state-attribute prefix for per-field care guidance (e.g. care_watering).
+# Kept separate from ATTR_CARE (the internal storage key) so the public attribute
+# names stay stable even if the storage key is ever renamed.
+ATTR_CARE_PREFIX = "care_"
 
 # Readings are used by humans
 READING_BATTERY = "battery"

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -39,6 +39,7 @@ ATTR_PLANT = "plant"
 ATTR_SPECIES = "species"
 ATTR_IMAGE = "image"
 ATTR_SEARCH_FOR = "search_for"
+ATTR_CARE = "care"
 
 # Readings are used by humans
 READING_BATTERY = "battery"
@@ -196,6 +197,8 @@ OPB_SEARCH = "search"
 OPB_SEARCH_RESULT = "search_result"
 OPB_PID = "pid"
 OPB_DISPLAY_PID = "display_pid"
+OPB_ATTR_INCLUDE = "include"
+OPB_INCLUDE_CARE = "care"
 
 # Hysteresis: fraction of (max - min) range that the value must clear
 # before a problem state is removed. Prevents flapping when a sensor
@@ -280,3 +283,7 @@ CONF_PLANTBOOK_MAPPING = {
     CONF_MIN_SOIL_TEMPERATURE: "min_soil_temp",
     CONF_MAX_SOIL_TEMPERATURE: "max_soil_temp",
 }
+
+# OpenPlantbook `include: care` returns these free-text fields per species.
+# Order is the canonical attribute order used when exposing them.
+CARE_FIELDS = ["watering", "sunlight", "soil", "pruning", "fertilization"]

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -82,8 +82,10 @@ from .const import (
     FLOW_SENSOR_MOISTURE,
     FLOW_SENSOR_SOIL_TEMPERATURE,
     FLOW_SENSOR_TEMPERATURE,
+    OPB_ATTR_INCLUDE,
     OPB_DISPLAY_PID,
     OPB_GET,
+    OPB_INCLUDE_CARE,
     OPB_SEARCH,
     PLANTBOOK_DOMAIN,
     PPFD_DLI_FACTOR,
@@ -174,7 +176,10 @@ class PlantHelper:
         if not species or species == "":
             return None
 
-        service_data = {ATTR_SPECIES: species.lower()}
+        service_data = {
+            ATTR_SPECIES: species.lower(),
+            OPB_ATTR_INCLUDE: OPB_INCLUDE_CARE,
+        }
         if not cache:
             service_data["cache"] = False
 

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.temperature import display_temp
 
 from .const import (
     ATTR_BRIGHTNESS,
+    ATTR_CARE,
     ATTR_CO2,
     ATTR_CONDUCTIVITY,
     ATTR_ILLUMINANCE,
@@ -30,6 +31,7 @@ from .const import (
     ATTR_SOIL_TEMPERATURE,
     ATTR_SPECIES,
     ATTR_TEMPERATURE,
+    CARE_FIELDS,
     CONF_MAX_BRIGHTNESS,
     CONF_MAX_CO2,
     CONF_MAX_CONDUCTIVITY,
@@ -299,6 +301,7 @@ class PlantHelper:
         entity_picture = None
         display_species = None
         data_source = DATA_SOURCE_DEFAULT
+        care_data: dict[str, Any] = {}
 
         # If we have image defined in the config, or a local file
         # prefer that.  If neither, image will be set to openplantbook
@@ -428,6 +431,9 @@ class PlantHelper:
                 opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_HUMIDITY]),
                 DEFAULT_MIN_HUMIDITY,
             )
+            care_data = {
+                field: opb_plant[field] for field in CARE_FIELDS if opb_plant.get(field)
+            }
             _LOGGER.info("Picture: %s", entity_picture)
             if (
                 entity_picture is None
@@ -471,6 +477,7 @@ class PlantHelper:
                 ATTR_SPECIES: config.get(ATTR_SPECIES) or "",
                 ATTR_ENTITY_PICTURE: entity_picture or "",
                 OPB_DISPLAY_PID: display_species or "",
+                ATTR_CARE: care_data,
                 ATTR_LIMITS: {
                     CONF_MAX_ILLUMINANCE: config.get(
                         CONF_MAX_BRIGHTNESS,

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -202,6 +202,7 @@ class PlantHelper:
                 )
         except TimeoutError:
             _LOGGER.warning("OpenPlantbook request timed out")
+            return None
         except Exception as ex:
             _LOGGER.warning("OpenPlantbook does not work, error: %s", ex)
             return None

--- a/docs/superpowers/plans/2026-06-01-care-attributes.md
+++ b/docs/superpowers/plans/2026-06-01-care-attributes.md
@@ -1,0 +1,686 @@
+# Care Attributes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expose OpenPlantbook's `care` fields (watering, sunlight, soil, pruning, fertilization) as separate `care_*` state attributes on the plant device.
+
+**Architecture:** The plant integration requests `include: care` on every OPB `get` call, extracts the returned care fields into a `care` sub-dict inside the persisted `FLOW_PLANT_INFO`, and spreads them as individually-named `care_*` attributes in `PlantDevice.extra_state_attributes`. No new entities. Mirrors how `display_species`/limits/image are already fetched-once-and-persisted across the three code paths that build/refresh a plant.
+
+**Tech Stack:** Python, Home Assistant custom integration, pytest + pytest-homeassistant-custom-component.
+
+**Spec:** `docs/superpowers/specs/2026-06-01-care-attributes-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `custom_components/plant/const.py` | Constants | Add include/care constants + canonical `CARE_FIELDS` list + `ATTR_CARE` storage key |
+| `custom_components/plant/plant_helpers.py` | OPB calls + config generation | Request `include: care`; extract care into `FLOW_PLANT_INFO["care"]` |
+| `custom_components/plant/__init__.py` | `PlantDevice` | Read stored care; emit `care_*` attributes |
+| `custom_components/plant/config_flow.py` | Config + species-refresh flows | Persist care in the user-create path and the refresh path |
+| `tests/fixtures/openplantbook_responses.py` | OPB mock data | Add care fields |
+| `tests/conftest.py` | OPB service mock | Make `mock_get` care-aware (only returns care when `include=care`) |
+| `tests/test_plant_helpers.py` | Unit tests | Fetch + extract tests |
+| `tests/test_init.py` | Unit tests | Expose `care_*` attribute test |
+| `tests/test_config_flow.py` | Unit tests | Persistence-path tests |
+
+**Canonical values used throughout this plan:**
+- `CARE_FIELDS = ["watering", "sunlight", "soil", "pruning", "fertilization"]`
+- Attribute prefix: `care_` (e.g. `care_watering`)
+- Storage key: `FLOW_PLANT_INFO["care"]` via `ATTR_CARE = "care"`
+- Service param: `include` (`OPB_ATTR_INCLUDE`) = `"care"` (`OPB_INCLUDE_CARE`)
+
+---
+
+## Task 1: Constants
+
+**Files:**
+- Modify: `custom_components/plant/const.py`
+- Test: `tests/test_plant_helpers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_plant_helpers.py` (top-level, after the existing imports add the new names to the `from custom_components.plant.const import (...)` block, then add this test class at the end of the file):
+
+```python
+class TestCareConstants:
+    """Tests for the care-field constants."""
+
+    def test_care_fields_canonical_list(self) -> None:
+        from custom_components.plant.const import CARE_FIELDS
+
+        assert CARE_FIELDS == [
+            "watering",
+            "sunlight",
+            "soil",
+            "pruning",
+            "fertilization",
+        ]
+
+    def test_include_constants(self) -> None:
+        from custom_components.plant.const import (
+            ATTR_CARE,
+            OPB_ATTR_INCLUDE,
+            OPB_INCLUDE_CARE,
+        )
+
+        assert OPB_ATTR_INCLUDE == "include"
+        assert OPB_INCLUDE_CARE == "care"
+        assert ATTR_CARE == "care"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_plant_helpers.py::TestCareConstants -v`
+Expected: FAIL with `ImportError: cannot import name 'CARE_FIELDS'`
+
+- [ ] **Step 3: Add the constants**
+
+In `custom_components/plant/const.py`, near the other `OPB_*` constants (around line 194-198, after `OPB_DISPLAY_PID`), add:
+
+```python
+OPB_ATTR_INCLUDE = "include"
+OPB_INCLUDE_CARE = "care"
+```
+
+Near the `ATTR_*` constants (e.g. after `ATTR_SPECIES` around line 39), add:
+
+```python
+ATTR_CARE = "care"
+```
+
+Add the canonical field list (place it after the `CONF_PLANTBOOK_MAPPING` block at the end of the file, or alongside the other lists):
+
+```python
+# OpenPlantbook `include: care` returns these free-text fields per species.
+# Order is the canonical attribute order used when exposing them.
+CARE_FIELDS = ["watering", "sunlight", "soil", "pruning", "fertilization"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/test_plant_helpers.py::TestCareConstants -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/plant/const.py tests/test_plant_helpers.py
+git commit -m "feat: add care-field constants for OPB include:care
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Request `include: care` from OpenPlantbook
+
+**Files:**
+- Modify: `custom_components/plant/plant_helpers.py:177-179` (inside `openplantbook_get`)
+- Test: `tests/test_plant_helpers.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Add this test to the `TestPlantHelperGet` class in `tests/test_plant_helpers.py`. It patches the service call directly so it can inspect the `service_data` passed to OPB:
+
+```python
+    async def test_openplantbook_get_requests_care(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Every OPB get must request the care category via include=care."""
+        from unittest.mock import AsyncMock, patch
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+        from tests.fixtures.openplantbook_responses import (
+            GET_RESULT_MONSTERA_DELICIOSA,
+        )
+
+        helper = PlantHelper(hass)
+        mock_call = AsyncMock(return_value=GET_RESULT_MONSTERA_DELICIOSA)
+        with patch(
+            "homeassistant.core.ServiceRegistry.async_services",
+            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+        ):
+            with patch(
+                "homeassistant.core.ServiceRegistry.async_call",
+                new=mock_call,
+            ):
+                await helper.openplantbook_get("monstera deliciosa")
+
+        assert mock_call.await_count == 1
+        service_data = mock_call.await_args.kwargs["service_data"]
+        assert service_data["include"] == "care"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_plant_helpers.py::TestPlantHelperGet::test_openplantbook_get_requests_care -v`
+Expected: FAIL with `KeyError: 'include'`
+
+- [ ] **Step 3: Implement**
+
+In `custom_components/plant/plant_helpers.py`, add `OPB_ATTR_INCLUDE` and `OPB_INCLUDE_CARE` to the existing `from .const import (...)` block. Then in `openplantbook_get`, the current block is:
+
+```python
+        service_data = {ATTR_SPECIES: species.lower()}
+        if not cache:
+            service_data["cache"] = False
+```
+
+Change it to:
+
+```python
+        service_data = {
+            ATTR_SPECIES: species.lower(),
+            OPB_ATTR_INCLUDE: OPB_INCLUDE_CARE,
+        }
+        if not cache:
+            service_data["cache"] = False
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_plant_helpers.py::TestPlantHelperGet -v`
+Expected: PASS (all get tests, including the new one)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/plant/plant_helpers.py tests/test_plant_helpers.py
+git commit -m "feat: request OPB care data on every species get
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Extract care into `FLOW_PLANT_INFO["care"]`
+
+**Files:**
+- Modify: `tests/fixtures/openplantbook_responses.py` (add care data)
+- Modify: `tests/conftest.py:238-243` (care-aware `mock_get`)
+- Modify: `custom_components/plant/plant_helpers.py` (`generate_configentry`)
+- Test: `tests/test_plant_helpers.py`
+
+- [ ] **Step 1: Add care data to the fixtures**
+
+In `tests/fixtures/openplantbook_responses.py`, add a care payload constant at the end of the file:
+
+```python
+# Care fields returned by OPB only when include=care is requested.
+CARE_MONSTERA_DELICIOSA = {
+    "watering": "Likes wet envs; reduce watering in winter.",
+    "sunlight": "Relatively shade-tolerant, prefers half-shade.",
+    "soil": "Well-draining, peat-based potting mix.",
+    "pruning": "Timely remove dead and yellowish leaves.",
+    "fertilization": "Dilute fertilizer once every 15 days.",
+}
+```
+
+- [ ] **Step 2: Make the conftest mock care-aware**
+
+In `tests/conftest.py`, add `CARE_MONSTERA_DELICIOSA` to the fixtures import block (around line 61 where `GET_RESULT_MONSTERA_DELICIOSA` is imported). Then change the `mock_get` inside `mock_openplantbook_services` (lines 238-243) from:
+
+```python
+    async def mock_get(domain, service, service_data, blocking, return_response):
+        """Mock get service."""
+        species = service_data.get("species", "").lower()
+        if species == "monstera deliciosa":
+            return GET_RESULT_MONSTERA_DELICIOSA
+        return None
+```
+
+to:
+
+```python
+    async def mock_get(domain, service, service_data, blocking, return_response):
+        """Mock get service."""
+        species = service_data.get("species", "").lower()
+        if species == "monstera deliciosa":
+            result = dict(GET_RESULT_MONSTERA_DELICIOSA)
+            if service_data.get("include") == "care":
+                result.update(CARE_MONSTERA_DELICIOSA)
+            return result
+        return None
+```
+
+- [ ] **Step 3: Write the failing test**
+
+Add to `TestPlantHelperGenerateConfigentry` in `tests/test_plant_helpers.py` (add `ATTR_CARE` to the const import block and import `CARE_MONSTERA_DELICIOSA` from the fixtures):
+
+```python
+    async def test_generate_configentry_stores_care(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+    ) -> None:
+        """Care fields from OPB are stored under FLOW_PLANT_INFO['care']."""
+        helper = PlantHelper(hass)
+        config = {
+            ATTR_NAME: "My Monstera",
+            ATTR_SPECIES: "monstera deliciosa",
+            ATTR_SENSORS: {},
+        }
+
+        result = await helper.generate_configentry(config)
+
+        care = result[FLOW_PLANT_INFO][ATTR_CARE]
+        assert care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+        assert care["sunlight"] == CARE_MONSTERA_DELICIOSA["sunlight"]
+        assert care["soil"] == CARE_MONSTERA_DELICIOSA["soil"]
+        assert care["pruning"] == CARE_MONSTERA_DELICIOSA["pruning"]
+        assert care["fertilization"] == CARE_MONSTERA_DELICIOSA["fertilization"]
+
+    async def test_generate_configentry_omits_absent_care_fields(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+        monkeypatch,
+    ) -> None:
+        """Care fields OPB does not return are not stored (no empty strings)."""
+        import custom_components.plant.plant_helpers as ph
+
+        async def partial_care_get(self, species, cache=True):
+            return {
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa",
+                "max_soil_moist": 60,
+                "min_soil_moist": 20,
+                "max_light_lux": 35000,
+                "min_light_lux": 1500,
+                "watering": "Water weekly.",
+                # sunlight/soil/pruning/fertilization deliberately absent
+            }
+
+        monkeypatch.setattr(ph.PlantHelper, "openplantbook_get", partial_care_get)
+
+        helper = ph.PlantHelper(hass)
+        config = {
+            ATTR_NAME: "My Monstera",
+            ATTR_SPECIES: "monstera deliciosa",
+            ATTR_SENSORS: {},
+        }
+
+        result = await helper.generate_configentry(config)
+
+        care = result[FLOW_PLANT_INFO][ATTR_CARE]
+        assert care == {"watering": "Water weekly."}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_plant_helpers.py::TestPlantHelperGenerateConfigentry::test_generate_configentry_stores_care -v`
+Expected: FAIL with `KeyError: 'care'`
+
+- [ ] **Step 5: Implement the extraction**
+
+In `custom_components/plant/plant_helpers.py`, add `ATTR_CARE` and `CARE_FIELDS` to the `from .const import (...)` block.
+
+Initialize a `care_data` default alongside the other defaults in `generate_configentry` (near line 296, where `data_source = DATA_SOURCE_DEFAULT` is set):
+
+```python
+        care_data: dict[str, Any] = {}
+```
+
+Inside the `if opb_plant:` block (anywhere after `data_source = DATA_SOURCE_PLANTBOOK`, e.g. right before the `_LOGGER.debug("Parsing input config...` line), add:
+
+```python
+            care_data = {
+                field: opb_plant[field]
+                for field in CARE_FIELDS
+                if opb_plant.get(field)
+            }
+```
+
+Finally, add the care sub-dict to the returned `FLOW_PLANT_INFO`. In the `ret = { ... FLOW_PLANT_INFO: { ... } }` literal, add this entry alongside `OPB_DISPLAY_PID` (e.g. right after the `OPB_DISPLAY_PID: display_species or "",` line):
+
+```python
+                ATTR_CARE: care_data,
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_plant_helpers.py -v`
+Expected: PASS (all helper tests, including both new care tests)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add custom_components/plant/plant_helpers.py tests/conftest.py tests/fixtures/openplantbook_responses.py tests/test_plant_helpers.py
+git commit -m "feat: persist OPB care fields in FLOW_PLANT_INFO
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Expose `care_*` attributes on the plant device
+
+**Files:**
+- Modify: `custom_components/plant/__init__.py` (`PlantDevice.__init__` ~line 497, `extra_state_attributes` ~line 669)
+- Modify: `tests/conftest.py` (add optional `care` to `create_plant_config_data`)
+- Test: `tests/test_init.py`
+
+- [ ] **Step 1: Allow the test fixture to carry care data**
+
+In `tests/conftest.py`, find `create_plant_config_data(...)` (the helper that builds the dict shown around line 121). Add a `care=None` parameter to its signature, and inside the returned `FLOW_PLANT_INFO` dict add:
+
+```python
+            ATTR_CARE: care or {},
+```
+
+Add `ATTR_CARE` to the const import block in `tests/conftest.py` if not already present.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `TestPlantDevice` in `tests/test_init.py` (add `ATTR_CARE` to the const import block; import `create_plant_config_data` if the test builds its own entry — check the top of the file for how other tests import it):
+
+```python
+    async def test_plant_device_care_attributes(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Care fields are exposed as separate care_* attributes."""
+        from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+        from tests.conftest import create_plant_config_data
+
+        care = {
+            "watering": "Water weekly.",
+            "sunlight": "Bright indirect light.",
+            # soil/pruning/fertilization absent on purpose
+        }
+        data = create_plant_config_data(care=care)
+        entry = MockConfigEntry(domain=DOMAIN, data=data, options={})
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][entry.entry_id][ATTR_PLANT]
+        plant.plant_complete = True
+
+        attrs = plant.extra_state_attributes
+        assert attrs["care_watering"] == "Water weekly."
+        assert attrs["care_sunlight"] == "Bright indirect light."
+        # Absent fields must not appear, not even as empty strings
+        assert "care_soil" not in attrs
+        assert "care_pruning" not in attrs
+        assert "care_fertilization" not in attrs
+```
+
+> Note: check how `create_plant_config_data` and `ATTR_PLANT` are imported by existing `test_init.py` tests and match that style; the import lines above are illustrative.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_init.py::TestPlantDevice::test_plant_device_care_attributes -v`
+Expected: FAIL with `KeyError: 'care_watering'`
+
+- [ ] **Step 4: Implement**
+
+In `custom_components/plant/__init__.py`, add `ATTR_CARE` to the `from .const import (...)` block.
+
+In `PlantDevice.__init__`, after the `self.species = ...` assignment (around line 497), add:
+
+```python
+        # Static per-species care text from OpenPlantbook (include: care).
+        # Stored at config/refresh time; only fields OPB returned are present.
+        self.care = self._config.data[FLOW_PLANT_INFO].get(ATTR_CARE, {})
+```
+
+In `extra_state_attributes`, the current return is:
+
+```python
+        attributes = {
+            ATTR_SPECIES: self.display_species,
+            ...
+            f"{ATTR_SPECIES}_original": self.species,
+        }
+        return attributes
+```
+
+Change the end to spread the care fields in before returning:
+
+```python
+        attributes = {
+            ATTR_SPECIES: self.display_species,
+            ...
+            f"{ATTR_SPECIES}_original": self.species,
+        }
+        for field, value in self.care.items():
+            attributes[f"care_{field}"] = value
+        return attributes
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_init.py::TestPlantDevice -v`
+Expected: PASS (all plant-device tests, including the new one)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add custom_components/plant/__init__.py tests/conftest.py tests/test_init.py
+git commit -m "feat: expose OPB care fields as care_* plant attributes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Persist care in the config-flow user-create path
+
+**Files:**
+- Modify: `custom_components/plant/config_flow.py` (`async_step_limits`, after the `generate_configentry` call ~line 335)
+- Test: `tests/test_config_flow.py`
+
+**Why:** The user-create flow builds `self.plant_info` manually and stores it at `async_step_limits_done` (line 533). It calls `generate_configentry` only for limit/display defaults, so care must be copied into `self.plant_info` explicitly or it is lost on create.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_config_flow.py` (match the existing style there for driving the flow — find an existing end-to-end create test and mirror its `async_init` / `async_configure` calls). The assertion that matters:
+
+```python
+    async def test_create_flow_persists_care(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+    ) -> None:
+        """A plant created via the UI flow stores OPB care fields."""
+        from custom_components.plant.const import (
+            ATTR_CARE,
+            DOMAIN,
+            FLOW_PLANT_INFO,
+        )
+        from tests.fixtures.openplantbook_responses import (
+            CARE_MONSTERA_DELICIOSA,
+        )
+
+        # Drive the user -> select_species -> limits -> limits_done flow for
+        # species "monstera deliciosa" exactly as the existing create-flow
+        # test in this file does, capturing the final result dict.
+        result = await _run_full_create_flow(hass, species="monstera deliciosa")
+
+        assert result["type"] == "create_entry"
+        care = result["data"][FLOW_PLANT_INFO][ATTR_CARE]
+        assert care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+```
+
+> `_run_full_create_flow` is a stand-in: reuse whatever the existing successful-create test in `tests/test_config_flow.py` already does to walk the steps, then assert on `result["data"]`. If no such helper exists, inline the `async_init`/`async_configure` calls copied from that test.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_config_flow.py::*::test_create_flow_persists_care -v`
+Expected: FAIL with `KeyError: 'care'` (care not copied into `self.plant_info`)
+
+- [ ] **Step 3: Implement**
+
+In `custom_components/plant/config_flow.py`, add `ATTR_CARE` to the `from .const import (...)` block. In `async_step_limits`, immediately after the `plant_config = await plant_helper.generate_configentry(...)` call (the block ending at line 335), add:
+
+```python
+        care = plant_config[FLOW_PLANT_INFO].get(ATTR_CARE)
+        if care:
+            self.plant_info[ATTR_CARE] = care
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_config_flow.py -v`
+Expected: PASS (all config-flow tests, including the new one)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/plant/config_flow.py tests/test_config_flow.py
+git commit -m "feat: persist care fields when creating a plant via the UI
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Persist + refresh care in the species-refresh path
+
+**Files:**
+- Modify: `custom_components/plant/config_flow.py` (`refresh_plant_from_openplantbook` ~lines 905-954)
+- Test: `tests/test_config_flow.py`
+
+**Why:** When a user forces a species update, `refresh_plant_from_openplantbook` mutates `plant.*` and writes `entry.data[FLOW_PLANT_INFO]` atomically. Care must be updated on both the live `plant` object (so `extra_state_attributes` reflects it without a reload) and the persisted `plant_info`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_config_flow.py`. Find the existing test that exercises `refresh_plant_from_openplantbook` (search the file for `refresh_plant_from_openplantbook`) and mirror its setup; the new assertions:
+
+```python
+    async def test_refresh_updates_care(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+    ) -> None:
+        """Forcing a species refresh updates both plant.care and entry data."""
+        from custom_components.plant.config_flow import (
+            refresh_plant_from_openplantbook,
+        )
+        from custom_components.plant.const import ATTR_CARE, FLOW_PLANT_INFO
+        from tests.fixtures.openplantbook_responses import (
+            CARE_MONSTERA_DELICIOSA,
+        )
+
+        # Set up a plant entry (any species) exactly as the existing refresh
+        # test does, obtaining `hass`, `entry`, and the live `plant` object.
+        entry, plant = await _setup_plant_for_refresh(hass)
+
+        ok = await refresh_plant_from_openplantbook(
+            hass, entry, plant, new_species="monstera deliciosa"
+        )
+
+        assert ok is True
+        assert plant.care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+        stored = entry.data[FLOW_PLANT_INFO][ATTR_CARE]
+        assert stored["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+```
+
+> `_setup_plant_for_refresh` is a stand-in: reuse the existing refresh test's setup in this file to get `entry` and the live `plant`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/test_config_flow.py::*::test_refresh_updates_care -v`
+Expected: FAIL with `KeyError: 'watering'` (plant.care not updated)
+
+- [ ] **Step 3: Implement**
+
+In `refresh_plant_from_openplantbook`, after the existing plant-side mutations (after `plant.display_species = ...` around line 910), add:
+
+```python
+    plant.care = plant_config[FLOW_PLANT_INFO].get(ATTR_CARE, {})
+```
+
+Then in the atomic-update block (lines 946-949), after `plant_info[FLOW_PLANT_LIMITS] = dict(limits)`, add:
+
+```python
+    plant_info[ATTR_CARE] = dict(plant.care)
+```
+
+(`ATTR_CARE` was already added to the const import in Task 5.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `.venv/bin/pytest tests/test_config_flow.py -v`
+Expected: PASS (all config-flow tests, including the new one)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add custom_components/plant/config_flow.py tests/test_config_flow.py
+git commit -m "feat: update care fields on forced species refresh
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Full test suite, lint, and format
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `.venv/bin/pytest tests/ -v`
+Expected: PASS (no regressions)
+
+- [ ] **Step 2: Lint**
+
+Run: `ruff check custom_components/plant/`
+Expected: no errors. If import-order issues, run `ruff check --fix custom_components/plant/`.
+
+- [ ] **Step 3: Format check**
+
+Run: `.venv/bin/black . --check --fast --diff`
+Expected: no diff. If any, run `.venv/bin/black .` and re-run tests.
+
+- [ ] **Step 4: Commit any lint/format fixes**
+
+```bash
+git add -A
+git commit -m "chore: lint and format for care attributes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Release note
+
+**Files:**
+- Modify/Create: project release-notes location (check how prior notes are recorded; e.g. README "What's new" section or a `docs/` changelog — mirror the existing convention)
+
+- [ ] **Step 1: Add a release note**
+
+Add a user-facing note capturing:
+
+> **New:** Plants now expose OpenPlantbook care guidance as `care_watering`, `care_sunlight`, `care_soil`, `care_pruning`, and `care_fertilization` attributes (when OpenPlantbook provides them). **Existing plants must be refreshed** (force a species update) to populate care data — newly added plants get it automatically. Only fields OpenPlantbook returns appear.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add -A
+git commit -m "docs: release note for care attributes
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Out of scope (phase 2)
+
+Flower-card display of selected care fields via the `plant/get_info` websocket — see the spec's "Out of scope" section. Not part of this plan.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** fetch (Task 2), constants (Task 1), persist into `FLOW_PLANT_INFO["care"]` via the canonical generate path (Task 3) plus the two additional persistence paths the spec's data-flow implies — UI create (Task 5) and forced refresh (Task 6) — expose as `care_*` (Task 4), absent-field omission (Tasks 3 & 4), tests (each task), release note (Task 8). All covered.
+- **Naming consistency:** `ATTR_CARE="care"`, `CARE_FIELDS`, `OPB_ATTR_INCLUDE="include"`, `OPB_INCLUDE_CARE="care"`, attribute prefix `care_`, storage key `FLOW_PLANT_INFO["care"]` — used identically across all tasks.
+- **No `strings.json`/`translations` work:** state attributes have no display-name translations (the CLAUDE.md translation rule applies to entities only).

--- a/docs/superpowers/specs/2026-06-01-care-attributes-design.md
+++ b/docs/superpowers/specs/2026-06-01-care-attributes-design.md
@@ -1,0 +1,120 @@
+# Care Attributes — Design
+
+**Date:** 2026-06-01
+**Status:** Approved design, ready for implementation planning
+
+## Summary
+
+OpenPlantbook (OPB) integration v1.5.0 added a `care` data category, requested
+via `include: care` on its `get` service. It returns five free-text fields for a
+species: `watering`, `sunlight`, `soil`, `pruning`, `fertilization`.
+
+This change makes that care text **available** in the plant integration as
+separate, individually-named state attributes on the plant device entity. It
+does **not** add any new entities and does **not** change the flower-card (see
+Out of Scope).
+
+## Motivation
+
+Users want access to per-species care guidance (how to water, light, prune,
+etc.) within Home Assistant so they can template against it, use it in
+automations, or surface it on a dashboard. The data already exists in OPB; the
+plant integration just needs to fetch, persist, and expose it.
+
+## Why attributes, not entities
+
+The care fields are **static, free-text, per-species reference content** — not
+measured, changing state. That rules out sensors. Two decisive points:
+
+- **HA caps entity state at 255 characters** (`MAX_LENGTH_STATE_STATE`). OPB care
+  strings are prose and can exceed that; a sensor whose state goes over the limit
+  is rejected/logged as an error. State attributes have a much larger budget
+  (~16 KB), so they sidestep this.
+- `EntityCategory.DIAGNOSTIC` is semantically about **device operational health**
+  (signal, battery, uptime, firmware), not informational content. Using it just
+  to tuck care text into a collapsed expander overloads the category.
+
+The integration already has a clear convention: *measured/changing → entity;
+static species facts → attribute* (see `species` / `species_original` on the
+plant device). Care fields slot into the second bucket.
+
+## Design
+
+Mirrors how `display_species`, image, and limits already flow: fetched once at
+config time, persisted into the config entry, read at runtime.
+
+### 1. Fetch — `plant_helpers.py` (`openplantbook_get`)
+
+Always request care data by passing `include: care` in the OPB `get` service
+call. One extra param on an existing call; OPB caches results, so the extra
+payload cost is negligible.
+
+### 2. Constants — `const.py`
+
+Add:
+- An OPB include constant (e.g. `OPB_ATTR_INCLUDE = "include"`,
+  `OPB_INCLUDE_CARE = "care"`).
+- A canonical list of the five care field names (e.g. `CARE_FIELDS`) used by both
+  the persist and expose steps so the field set is defined in exactly one place.
+
+### 3. Persist — `plant_helpers.py` (`generate_configentry`)
+
+After a successful `opb_plant` fetch, extract the care fields that are present
+into a new sub-dict `FLOW_PLANT_INFO["care"]` (key → value, only for fields OPB
+actually returned). Stored in the config entry; survives restarts and OPB being
+offline/uninstalled. No empty `""` fields are stored.
+
+### 4. Expose — `__init__.py` (`PlantDevice.extra_state_attributes`)
+
+Read the stored `care` dict and spread each field as a separate attribute with a
+`care_` prefix, alongside the existing species attributes:
+
+- `care_watering`
+- `care_sunlight`
+- `care_soil`
+- `care_pruning`
+- `care_fertilization`
+
+Only fields present in storage are emitted — no empty `care_*: ""` clutter. The
+`care_` prefix namespaces them and groups them in the attribute list.
+
+## Decisions
+
+- **Attribute naming:** `care_` prefix (namespaced, collision-safe, groups
+  together), not bare OPB field names.
+- **Fetch policy:** always include `care` (available by default), not behind a
+  config option.
+
+## Behavior notes (for release notes)
+
+- **Existing plants** won't show care data until their **species is refreshed**
+  (the `FLOW_FORCE_SPECIES_UPDATE` path), because care is captured at config
+  time. This matches how a species' limits/image already behave. Worth a release
+  note, same spirit as the #438/#440 imperial-temperature note.
+- Care text **persists** in the config entry, so it remains available when OPB is
+  offline or uninstalled.
+- Plants whose species OPB has no care data for simply get no `care_*` attributes.
+
+## Testing
+
+- When the mocked OPB `get` returns care fields, the plant device exposes the
+  corresponding `care_*` attributes with the expected values.
+- Fields OPB omits are not emitted as attributes (no empty strings).
+- `include: care` is actually passed through to the OPB service call.
+- A species with no care data produces no `care_*` attributes and does not error.
+
+## Out of scope (potential phase 2)
+
+**Flower-card integration.** A future change may let the
+[lovelace-flower-card](https://github.com/Olen/lovelace-flower-card) optionally
+display selected care fields. The per-field separation in this design is the
+enabler for that: the card (via the `plant/get_info` websocket) could let users
+tick which care fields to show. That work — websocket payload changes here and
+rendering in the card repo — is deliberately **not** part of this spec.
+
+## Explicitly not doing
+
+- No new entities (sensor / diagnostic / config / text).
+- No `strings.json` / `translations/` changes — those govern *entity* names, not
+  state attributes, so the usual translation rule does not apply here.
+- No flower-card or `plant/get_info` websocket changes in this phase.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@ pytest_plugins = "pytest_homeassistant_custom_component"
 
 
 from custom_components.plant.const import (
+    ATTR_CARE,
     ATTR_LIMITS,
     ATTR_SPECIES,
     CONF_MAX_CO2,
@@ -93,6 +94,7 @@ def create_plant_config_data(
     soil_temperature_sensor: str | None = "sensor.test_soil_temperature",
     data_source: str = DATA_SOURCE_DEFAULT,
     limits: dict | None = None,
+    care: dict | None = None,
 ) -> dict[str, Any]:
     """Create plant configuration data for testing."""
     if limits is None:
@@ -125,6 +127,7 @@ def create_plant_config_data(
             OPB_DISPLAY_PID: display_species,
             ATTR_ENTITY_PICTURE: entity_picture,
             ATTR_LIMITS: limits,
+            ATTR_CARE: care or {},
             FLOW_SENSOR_TEMPERATURE: temperature_sensor,
             FLOW_SENSOR_MOISTURE: moisture_sensor,
             FLOW_SENSOR_CONDUCTIVITY: conductivity_sensor,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,7 @@ from custom_components.plant.const import (
 )
 
 from .fixtures.openplantbook_responses import (
+    CARE_MONSTERA_DELICIOSA,
     GET_RESULT_MONSTERA_DELICIOSA,
     GET_RESULT_WITH_DLI,
     SEARCH_RESULT_MONSTERA,
@@ -239,7 +240,10 @@ def mock_openplantbook_services() -> Generator[MagicMock, None, None]:
         """Mock get service."""
         species = service_data.get("species", "").lower()
         if species == "monstera deliciosa":
-            return GET_RESULT_MONSTERA_DELICIOSA
+            result = dict(GET_RESULT_MONSTERA_DELICIOSA)
+            if service_data.get("include") == "care":
+                result.update(CARE_MONSTERA_DELICIOSA)
+            return result
         return None
 
     async def mock_service_call(

--- a/tests/fixtures/openplantbook_responses.py
+++ b/tests/fixtures/openplantbook_responses.py
@@ -83,3 +83,12 @@ SEARCH_RESULT_EMPTY = {}
 
 # Result when species not found
 GET_RESULT_NOT_FOUND = None
+
+# Care fields returned by OPB only when include=care is requested.
+CARE_MONSTERA_DELICIOSA = {
+    "watering": "Likes wet envs; reduce watering in winter.",
+    "sunlight": "Relatively shade-tolerant, prefers half-shade.",
+    "soil": "Well-draining, peat-based potting mix.",
+    "pruning": "Timely remove dead and yellowish leaves.",
+    "fertilization": "Dilute fertilizer once every 15 days.",
+}

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1665,8 +1665,8 @@ class TestOptionsFlow:
         await hass.async_block_till_done()
 
         # Live object must have care populated from OPB.
-        assert plant.care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+        assert plant.care == CARE_MONSTERA_DELICIOSA
 
         # Entry.data must also have care persisted so it survives a reload.
         stored = entry.data[FLOW_PLANT_INFO][ATTR_CARE]
-        assert stored["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+        assert stored == CARE_MONSTERA_DELICIOSA

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -39,6 +39,7 @@ from custom_components.plant.const import (
 
 from .conftest import create_plant_config_data
 from .fixtures.openplantbook_responses import (
+    CARE_MONSTERA_DELICIOSA,
     GET_RESULT_MONSTERA_DELICIOSA,
 )
 
@@ -870,6 +871,72 @@ class TestConfigFlowFullFlow:
 
         assert result["type"] == FlowResultType.CREATE_ENTRY
         assert result["title"] == "My Monstera"
+
+    async def test_full_flow_with_opb_persists_care(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+    ) -> None:
+        """Test that care data from OPB is persisted in the created entry."""
+        from custom_components.plant.const import ATTR_CARE
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                ATTR_NAME: "My Monstera",
+                ATTR_SPECIES: "monstera",
+            },
+        )
+        assert result["step_id"] == "select_species"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SEARCH_FOR: "monstera",
+                ATTR_SPECIES: "monstera deliciosa",
+            },
+        )
+        assert result["step_id"] == "sensors"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {},
+        )
+        assert result["step_id"] == "limits"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                FLOW_RIGHT_PLANT: True,
+                OPB_DISPLAY_PID: "Monstera deliciosa",
+                CONF_MAX_MOISTURE: 60,
+                CONF_MIN_MOISTURE: 20,
+                CONF_MAX_TEMPERATURE: 30,
+                CONF_MIN_TEMPERATURE: 15,
+                CONF_MAX_CONDUCTIVITY: 2000,
+                CONF_MIN_CONDUCTIVITY: 350,
+                CONF_MAX_ILLUMINANCE: 35000,
+                CONF_MIN_ILLUMINANCE: 1500,
+                CONF_MAX_HUMIDITY: 80,
+                CONF_MIN_HUMIDITY: 50,
+                CONF_MAX_DLI: 22,
+                CONF_MIN_DLI: 5,
+                CONF_MAX_VPD: 1.6,
+                CONF_MIN_VPD: 0.4,
+                ATTR_ENTITY_PICTURE: GET_RESULT_MONSTERA_DELICIOSA["image_url"],
+            },
+        )
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        assert result["title"] == "My Monstera"
+
+        care = result["data"][FLOW_PLANT_INFO][ATTR_CARE]
+        assert care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
 
 
 class TestConfigFlowImport:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1628,3 +1628,45 @@ class TestOptionsFlow:
         await hass.async_block_till_done()
 
         assert FLOW_FORCE_SPECIES_UPDATE not in entry.options
+
+    async def test_force_refresh_updates_care_on_plant_and_in_entry(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_services,
+    ) -> None:
+        """Force refresh must populate care on the live plant object AND
+        persist it in entry.data[FLOW_PLANT_INFO][ATTR_CARE].
+
+        Before the fix, refresh_plant_from_openplantbook mutated limits and
+        species but left plant.care untouched and never wrote ATTR_CARE to
+        plant_info — so the attributes were stale until a full reload.
+        """
+        entry = init_integration
+        plant = hass.data[DOMAIN][entry.entry_id]["plant"]
+
+        # The plant was created with empty care (default from conftest).
+        assert plant.care == {}
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "plant_properties"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SPECIES: "monstera deliciosa",
+                FLOW_FORCE_SPECIES_UPDATE: True,
+                OPB_DISPLAY_PID: "Monstera deliciosa",
+                ATTR_ENTITY_PICTURE: "https://example.com/monstera.jpg",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        # Live object must have care populated from OPB.
+        assert plant.care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+
+        # Entry.data must also have care persisted so it survives a reload.
+        stored = entry.data[FLOW_PLANT_INFO][ATTR_CARE]
+        assert stored["watering"] == CARE_MONSTERA_DELICIOSA["watering"]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.plant.const import (
+    ATTR_CARE,
     ATTR_SEARCH_FOR,
     ATTR_SPECIES,
     CONF_MAX_CONDUCTIVITY,
@@ -878,8 +879,6 @@ class TestConfigFlowFullFlow:
         mock_openplantbook_services,
     ) -> None:
         """Test that care data from OPB is persisted in the created entry."""
-        from custom_components.plant.const import ATTR_CARE
-
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from homeassistant import config_entries
 from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_NAME
 from homeassistant.core import HomeAssistant
@@ -41,7 +43,9 @@ from custom_components.plant.const import (
 from .conftest import create_plant_config_data
 from .fixtures.openplantbook_responses import (
     CARE_MONSTERA_DELICIOSA,
+    GET_RESULT_FICUS_LYRATA,
     GET_RESULT_MONSTERA_DELICIOSA,
+    SEARCH_RESULT_FICUS,
 )
 
 
@@ -936,6 +940,195 @@ class TestConfigFlowFullFlow:
 
         care = result["data"][FLOW_PLANT_INFO][ATTR_CARE]
         assert care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+
+    async def test_species_switch_via_wrong_plant_clears_stale_care(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Stale care from a previous species is cleared when the user switches
+        to a no-care species via the wrong-plant path.
+
+        Regression test for: async_step_limits used ``if care:`` before writing
+        to self.plant_info[ATTR_CARE], so switching to a no-OPB species left the
+        previous species' care dict behind in the created entry.
+
+        Uses a custom two-species mock:
+          - "monstera deliciosa": has OPB data + care (watering etc.)
+          - "ficus lyrata": has OPB threshold data but NO care fields
+        """
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+
+        # Custom mock that supports monstera (with care) and ficus (no care).
+        async def mock_service_call(
+            domain,
+            service,
+            service_data=None,
+            blocking=False,
+            return_response=False,
+        ):
+            if domain != DOMAIN_PLANTBOOK:
+                return None
+            if service == "search":
+                alias = (service_data or {}).get("alias", "").lower()
+                if "monstera" in alias:
+                    return {
+                        "monstera deliciosa": "Monstera deliciosa",
+                        "monstera adansonii": "Monstera adansonii",
+                    }
+                if "ficus" in alias:
+                    return SEARCH_RESULT_FICUS
+                return {}
+            if service == "get":
+                species = (service_data or {}).get("species", "").lower()
+                if species == "monstera deliciosa":
+                    result = dict(GET_RESULT_MONSTERA_DELICIOSA)
+                    if service_data.get("include") == "care":
+                        result.update(CARE_MONSTERA_DELICIOSA)
+                    return result
+                if species == "ficus lyrata":
+                    # OPB data exists but the API returned NO care fields.
+                    return dict(GET_RESULT_FICUS_LYRATA)
+            return None
+
+        async def mock_validate_image_url(self, url):
+            return url is not None and url != ""
+
+        with (
+            patch(
+                "homeassistant.core.ServiceRegistry.async_services",
+                return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+            ),
+            patch(
+                "homeassistant.core.ServiceRegistry.async_call",
+                side_effect=mock_service_call,
+            ),
+            patch(
+                "custom_components.plant.plant_helpers.PlantHelper.validate_image_url",
+                mock_validate_image_url,
+            ),
+        ):
+            # --- Step 1: name + species (monstera, which HAS care) ---
+            result = await hass.config_entries.flow.async_init(
+                DOMAIN, context={"source": config_entries.SOURCE_USER}
+            )
+            assert result["step_id"] == "user"
+
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    ATTR_NAME: "My Monstera",
+                    ATTR_SPECIES: "monstera",
+                },
+            )
+            assert result["step_id"] == "select_species"
+
+            # --- Step 2: select monstera deliciosa (has OPB care) ---
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    ATTR_SEARCH_FOR: "monstera",
+                    ATTR_SPECIES: "monstera deliciosa",
+                },
+            )
+            assert result["step_id"] == "sensors"
+
+            # --- Step 3: sensors (no sensors selected) ---
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {},
+            )
+            assert result["step_id"] == "limits"
+
+            # --- Step 4a: limits (1st visit) — reject with FLOW_RIGHT_PLANT=False ---
+            # This bounces the flow back to select_species.
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    FLOW_RIGHT_PLANT: False,
+                    OPB_DISPLAY_PID: "Monstera deliciosa",
+                    CONF_MAX_MOISTURE: 60,
+                    CONF_MIN_MOISTURE: 20,
+                    CONF_MAX_TEMPERATURE: 30,
+                    CONF_MIN_TEMPERATURE: 15,
+                    CONF_MAX_CONDUCTIVITY: 2000,
+                    CONF_MIN_CONDUCTIVITY: 350,
+                    CONF_MAX_ILLUMINANCE: 35000,
+                    CONF_MIN_ILLUMINANCE: 1500,
+                    CONF_MAX_HUMIDITY: 80,
+                    CONF_MIN_HUMIDITY: 50,
+                    CONF_MAX_DLI: 22,
+                    CONF_MIN_DLI: 5,
+                    CONF_MAX_VPD: 1.6,
+                    CONF_MIN_VPD: 0.4,
+                    ATTR_ENTITY_PICTURE: GET_RESULT_MONSTERA_DELICIOSA["image_url"],
+                },
+            )
+            assert result["step_id"] == "select_species"
+
+            # --- Step 4b: select_species — re-search for ficus ---
+            # Submit ATTR_SEARCH_FOR="ficus" (different from "monstera").
+            # The new-search branch fires, re-searches for "ficus", gets
+            # SEARCH_RESULT_FICUS, and shows the ficus dropdown.
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    ATTR_SEARCH_FOR: "ficus",
+                    ATTR_SPECIES: "monstera deliciosa",  # must pass schema; ignored
+                },
+            )
+            # After re-searching "ficus", the dropdown shows ficus species.
+            assert result["step_id"] == "select_species"
+
+            # --- Step 4c: select ficus lyrata from the dropdown ---
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    ATTR_SEARCH_FOR: "ficus",
+                    ATTR_SPECIES: "ficus lyrata",
+                },
+            )
+            assert result["step_id"] == "sensors"
+
+            # --- Step 5: sensors (2nd trip, no sensors selected) ---
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {},
+            )
+            assert result["step_id"] == "limits"
+
+            # --- Step 6: limits (2nd visit) — ficus lyrata has OPB data (no care)
+            # so the form DOES show FLOW_RIGHT_PLANT.  Accept it.
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {
+                    FLOW_RIGHT_PLANT: True,
+                    OPB_DISPLAY_PID: "Ficus lyrata",
+                    CONF_MAX_MOISTURE: 55,
+                    CONF_MIN_MOISTURE: 25,
+                    CONF_MAX_TEMPERATURE: 28,
+                    CONF_MIN_TEMPERATURE: 12,
+                    CONF_MAX_CONDUCTIVITY: 1800,
+                    CONF_MIN_CONDUCTIVITY: 400,
+                    CONF_MAX_ILLUMINANCE: 50000,
+                    CONF_MIN_ILLUMINANCE: 2500,
+                    CONF_MAX_HUMIDITY: 70,
+                    CONF_MIN_HUMIDITY: 40,
+                    CONF_MAX_DLI: 28,
+                    CONF_MIN_DLI: 7,
+                    CONF_MAX_VPD: 1.6,
+                    CONF_MIN_VPD: 0.4,
+                    ATTR_ENTITY_PICTURE: GET_RESULT_FICUS_LYRATA["image_url"],
+                },
+            )
+
+            assert result["type"] == FlowResultType.CREATE_ENTRY
+
+        # The stale monstera care must NOT appear in the created entry.
+        care = result["data"][FLOW_PLANT_INFO][ATTR_CARE]
+        assert care == {}, (
+            f"Expected empty care after species switch to ficus lyrata, got: {care!r}. "
+            "Stale care from monstera deliciosa was not cleared."
+        )
 
 
 class TestConfigFlowImport:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -18,6 +18,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from custom_components.plant import async_setup
 from custom_components.plant.const import (
     ATTR_PLANT,
+    CARE_FIELDS,
     DOMAIN,
     FLOW_PLANT_INFO,
     STATE_HIGH,
@@ -422,9 +423,10 @@ class TestPlantDevice:
         attrs = plant.extra_state_attributes
         assert attrs["care_watering"] == "Water weekly."
         assert attrs["care_sunlight"] == "Bright indirect light."
-        assert "care_soil" not in attrs
-        assert "care_pruning" not in attrs
-        assert "care_fertilization" not in attrs
+        present = {"watering", "sunlight"}
+        for field in CARE_FIELDS:
+            if field not in present:
+                assert f"care_{field}" not in attrs
 
     async def test_plant_device_device_info(
         self,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -428,6 +428,44 @@ class TestPlantDevice:
             if field not in present:
                 assert f"care_{field}" not in attrs
 
+    async def test_plant_device_care_is_copy_not_alias(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """plant.care must be a distinct copy of the entry's care dict.
+
+        Regression test for: PlantDevice.__init__ assigned self.care directly
+        from ConfigEntry.data (shared reference).  Mutating self.care would
+        silently corrupt the immutable entry data, and vice-versa.
+        """
+        from tests.conftest import create_plant_config_data
+
+        care = {
+            "watering": "Water every 7 days.",
+            "sunlight": "Full sun preferred.",
+        }
+        data = create_plant_config_data(care=care)
+        entry = MockConfigEntry(domain=DOMAIN, data=data, options={})
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][entry.entry_id][ATTR_PLANT]
+        entry_care = entry.data[FLOW_PLANT_INFO]["care"]
+
+        # The live attribute must be a DISTINCT object from the entry's dict.
+        assert plant.care is not entry_care, (
+            "plant.care shares the same object reference as "
+            "entry.data[FLOW_PLANT_INFO]['care']; it should be a copy."
+        )
+
+        # Mutating plant.care must not corrupt entry.data.
+        plant.care["watering"] = "MUTATED"
+        assert entry_care.get("watering") == "Water every 7 days.", (
+            "Mutating plant.care unexpectedly modified entry.data['care']; "
+            "the two objects are aliased."
+        )
+
     async def test_plant_device_device_info(
         self,
         hass: HomeAssistant,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -398,6 +398,34 @@ class TestPlantDevice:
         # First letter should be uppercase, rest preserved
         assert species == "Solanum lycopersicum"
 
+    async def test_plant_device_care_attributes(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Care fields are exposed as separate care_* attributes."""
+        from tests.conftest import create_plant_config_data
+
+        care = {
+            "watering": "Water weekly.",
+            "sunlight": "Bright indirect light.",
+            # soil/pruning/fertilization absent on purpose
+        }
+        data = create_plant_config_data(care=care)
+        entry = MockConfigEntry(domain=DOMAIN, data=data, options={})
+        entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][entry.entry_id][ATTR_PLANT]
+        plant.plant_complete = True
+
+        attrs = plant.extra_state_attributes
+        assert attrs["care_watering"] == "Water weekly."
+        assert attrs["care_sunlight"] == "Bright indirect light."
+        assert "care_soil" not in attrs
+        assert "care_pruning" not in attrs
+        assert "care_fertilization" not in attrs
+
     async def test_plant_device_device_info(
         self,
         hass: HomeAssistant,

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -111,6 +111,34 @@ class TestPlantHelperSearch:
 class TestPlantHelperGet:
     """Tests for OpenPlantbook get functionality."""
 
+    async def test_openplantbook_get_requests_care(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Every OPB get must request the care category via include=care."""
+        from unittest.mock import AsyncMock, patch
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+        from tests.fixtures.openplantbook_responses import (
+            GET_RESULT_MONSTERA_DELICIOSA,
+        )
+
+        helper = PlantHelper(hass)
+        mock_call = AsyncMock(return_value=GET_RESULT_MONSTERA_DELICIOSA)
+        with patch(
+            "homeassistant.core.ServiceRegistry.async_services",
+            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+        ):
+            with patch(
+                "homeassistant.core.ServiceRegistry.async_call",
+                new=mock_call,
+            ):
+                await helper.openplantbook_get("monstera deliciosa")
+
+        assert mock_call.await_count == 1
+        service_data = mock_call.await_args.kwargs["service_data"]
+        assert service_data["include"] == "care"
+
     async def test_openplantbook_get_success(
         self,
         hass: HomeAssistant,

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -188,6 +188,31 @@ class TestPlantHelperGet:
 
         assert result is None
 
+    async def test_openplantbook_get_timeout_returns_none(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """A timeout must return None, not raise UnboundLocalError.
+
+        Mirrors openplantbook_search's timeout handling.
+        """
+        from unittest.mock import AsyncMock, patch
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+
+        helper = PlantHelper(hass)
+        with patch(
+            "homeassistant.core.ServiceRegistry.async_services",
+            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+        ):
+            with patch(
+                "homeassistant.core.ServiceRegistry.async_call",
+                new=AsyncMock(side_effect=TimeoutError),
+            ):
+                result = await helper.openplantbook_get("monstera deliciosa")
+
+        assert result is None
+
 
 class TestPlantHelperGenerateConfigentry:
     """Tests for generate_configentry functionality."""

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -595,3 +595,29 @@ class TestImageValidation:
                 "https://unreachable.example.com/plant.jpg"
             )
         assert result is False
+
+
+class TestCareConstants:
+    """Tests for the care-field constants."""
+
+    def test_care_fields_canonical_list(self) -> None:
+        from custom_components.plant.const import CARE_FIELDS
+
+        assert CARE_FIELDS == [
+            "watering",
+            "sunlight",
+            "soil",
+            "pruning",
+            "fertilization",
+        ]
+
+    def test_include_constants(self) -> None:
+        from custom_components.plant.const import (
+            ATTR_CARE,
+            OPB_ATTR_INCLUDE,
+            OPB_INCLUDE_CARE,
+        )
+
+        assert OPB_ATTR_INCLUDE == "include"
+        assert OPB_INCLUDE_CARE == "care"
+        assert ATTR_CARE == "care"

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -9,6 +9,7 @@ from homeassistant.const import ATTR_ENTITY_PICTURE, ATTR_NAME
 from homeassistant.core import HomeAssistant
 
 from custom_components.plant.const import (
+    ATTR_CARE,
     ATTR_LIMITS,
     ATTR_SENSORS,
     ATTR_SPECIES,
@@ -31,6 +32,7 @@ from custom_components.plant.const import (
 from custom_components.plant.plant_helpers import PlantHelper
 
 from .fixtures.openplantbook_responses import (
+    CARE_MONSTERA_DELICIOSA,
     GET_RESULT_MONSTERA_DELICIOSA,
 )
 
@@ -378,6 +380,63 @@ class TestPlantHelperGenerateConfigentry:
 
         # min_dli = 12.6 → round(12.6, 1) = 12.6
         assert limits[CONF_MIN_DLI] == 12.6
+
+    async def test_generate_configentry_stores_care(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+    ) -> None:
+        """Care fields from OPB are stored under FLOW_PLANT_INFO['care']."""
+        helper = PlantHelper(hass)
+        config = {
+            ATTR_NAME: "My Monstera",
+            ATTR_SPECIES: "monstera deliciosa",
+            ATTR_SENSORS: {},
+        }
+
+        result = await helper.generate_configentry(config)
+
+        care = result[FLOW_PLANT_INFO][ATTR_CARE]
+        assert care["watering"] == CARE_MONSTERA_DELICIOSA["watering"]
+        assert care["sunlight"] == CARE_MONSTERA_DELICIOSA["sunlight"]
+        assert care["soil"] == CARE_MONSTERA_DELICIOSA["soil"]
+        assert care["pruning"] == CARE_MONSTERA_DELICIOSA["pruning"]
+        assert care["fertilization"] == CARE_MONSTERA_DELICIOSA["fertilization"]
+
+    async def test_generate_configentry_omits_absent_care_fields(
+        self,
+        hass: HomeAssistant,
+        mock_openplantbook_services,
+        monkeypatch,
+    ) -> None:
+        """Care fields OPB does not return are not stored (no empty strings)."""
+        import custom_components.plant.plant_helpers as ph
+
+        async def partial_care_get(self, species, cache=True):
+            return {
+                "pid": "monstera deliciosa",
+                "display_pid": "Monstera deliciosa",
+                "max_soil_moist": 60,
+                "min_soil_moist": 20,
+                "max_light_lux": 35000,
+                "min_light_lux": 1500,
+                "watering": "Water weekly.",
+                # sunlight/soil/pruning/fertilization deliberately absent
+            }
+
+        monkeypatch.setattr(ph.PlantHelper, "openplantbook_get", partial_care_get)
+
+        helper = ph.PlantHelper(hass)
+        config = {
+            ATTR_NAME: "My Monstera",
+            ATTR_SPECIES: "monstera deliciosa",
+            ATTR_SENSORS: {},
+        }
+
+        result = await helper.generate_configentry(config)
+
+        care = result[FLOW_PLANT_INFO][ATTR_CARE]
+        assert care == {"watering": "Water weekly."}
 
 
 class TestPlantHelperEdgeCases:


### PR DESCRIPTION
## Summary

Surfaces OpenPlantbook's `care` category (added in OPB integration v1.5.0) on the plant device. When OpenPlantbook has care info for a species, the plant exposes it as **separate, individually-named state attributes** — no new entities:

- `care_watering`
- `care_sunlight`
- `care_soil`
- `care_pruning`
- `care_fertilization`

Only the fields OpenPlantbook actually returns appear (no empty `care_*`). Attributes are individually named so users can pick exactly which to show on a dashboard or use in templates/automations.

### Why attributes, not entities
Care data is **static, free-text, per-species reference content**, not measured state — so it doesn't fit "Sensor". `EntityCategory.DIAGNOSTIC` is semantically for device health, not informational content. And HA caps entity *state* at 255 chars, which OPB care prose can exceed; state *attributes* have a much larger budget. This mirrors how `species`/`display_species` are already handled.

## How it works
`openplantbook_get` now requests `include: care`. `generate_configentry` extracts present care fields into `FLOW_PLANT_INFO["care"]`, persisted in the config entry. `PlantDevice.extra_state_attributes` spreads them as `care_*`. Care is wired through all three plant-build paths: YAML import, UI create flow, and forced species refresh (live object + persisted entry).

## Upgrade note
Care is fetched at config/refresh time and persisted (not re-fetched on startup), so **existing plants must be refreshed** (Force refresh, or change species) to populate care attributes — no auto-migration. Newly added plants get it automatically. Documented in the README under OpenPlantbook → Care Guidance.

## Test Plan
- [x] Full suite green: 275 passed
- [x] `ruff check custom_components/plant/` clean
- [x] `black --check` clean
- [x] OPB get sends `include: care` (`test_openplantbook_get_requests_care`)
- [x] Care persisted in config entry (`test_generate_configentry_stores_care`)
- [x] Absent fields omitted — no empty strings (`test_generate_configentry_omits_absent_care_fields`)
- [x] Attributes exposed, partial-field handling (`test_plant_device_care_attributes`)
- [x] UI-create flow persists care (`test_full_flow_with_opb_persists_care`)
- [x] Forced refresh updates live object + entry (`test_force_refresh_updates_care_on_plant_and_in_entry`)

No `strings.json`/`translations` changes — HA state attributes have no translation keys (unlike entity names).

🤖 Generated with [Claude Code](https://claude.com/claude-code)