### PR TITLE
Release 2026.6.0-beta1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.5.2-beta1"
+  "version": "2026.6.0-beta1"
 }


### PR DESCRIPTION
Beta release bundling three feature sets merged since 2026.5.2-beta1.

## ✨ Highlights

### 🪴 OpenPlantbook care guidance (#451)
Plants now expose per-species care text from OpenPlantbook as separate state attributes — `care_watering`, `care_sunlight`, `care_soil`, `care_pruning`, `care_fertilization` — when the species has them. Use them in templates, automations, or dashboards.
> **Note:** existing plants must be refreshed (Force refresh / change species) to populate care data; new plants get it automatically.

### 🔄 Restore state across restarts (#449)
Plant and sensor entities keep their last known values across a Home Assistant restart instead of going `unknown` until the source sensors report again. Restored values are held during a startup grace window (10 min) and replaced as soon as live data arrives — important for push-only BLE sensors that broadcast irregularly.

### ⚠️ Structured problems + logbook (#439)
Each plant exposes a `problems` attribute: a list of every active threshold violation (`sensor_type`, `status`, `current`, `min`, `max`). Problem onset and recovery are written to the Home Assistant logbook (deduplicated — one entry on appearance, one on recovery), with the activity feed showing e.g. "conductivity low — current: 352, min: 400". A dashboard example is included.

## Version
`manifest.json` only: `2026.5.2-beta1` → `2026.6.0-beta1`. CI tags and publishes the pre-release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)