### PR TITLE
Add fallback conductivity sensor detection using unit of measurement

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -16,6 +16,8 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_PICTURE,
     ATTR_NAME,
+    ATTR_UNIT_OF_MEASUREMENT,
+    UnitOfConductivity,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
@@ -106,8 +108,64 @@ SENSOR_SCHEMA_FIELDS = [
     (FLOW_SENSOR_SOIL_TEMPERATURE, SensorDeviceClass.TEMPERATURE),
 ]
 
+CONDUCTIVITY_UNITS = {
+    UnitOfConductivity.MICROSIEMENS_PER_CM,
+    "µS/cm",
+    "μS/cm",
+    "uS/cm",
+}
+CONDUCTIVITY_UNITS_NORMALIZED = {
+    unit.replace("μ", "µ").replace("u", "µ").lower()
+    for unit in CONDUCTIVITY_UNITS
+}
 
-def _build_sensor_schema(defaults: dict[str, Any] | None = None) -> dict:
+
+def _normalize_unit(unit: str | None) -> str:
+    """Normalize equivalent micro-siemens unit spellings for comparison."""
+    if unit is None:
+        return ""
+    return unit.replace("μ", "µ").replace("u", "µ").lower()
+
+
+def _is_conductivity_sensor(state) -> bool:
+    """Return true for conductivity sensors, including unit-only entities.
+
+    Some integrations expose soil conductivity with a valid conductivity unit,
+    but without a Home Assistant conductivity device class. Zigbee2MQTT's
+    Arteco ZS-SF00 soil_fertility entity is one example.
+    """
+    attrs = state.attributes
+    if attrs.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.CONDUCTIVITY:
+        return True
+
+    unit = attrs.get(ATTR_UNIT_OF_MEASUREMENT)
+    return _normalize_unit(unit) in CONDUCTIVITY_UNITS_NORMALIZED
+
+
+def _conductivity_entities(hass: HomeAssistant, current: str | None = None) -> list[str]:
+    """Return conductivity sensor entity IDs.
+
+    Home Assistant's entity selector cannot express "device class is
+    conductivity OR unit is µS/cm" using only selector filters. Build an explicit
+    include list instead, then still use the normal entity selector UI.
+    """
+    entities = {
+        state.entity_id
+        for state in hass.states.async_all(SENSOR_DOMAIN)
+        if _is_conductivity_sensor(state)
+    }
+
+    # Preserve the currently configured entity even if it is temporarily
+    # unavailable or no longer matches the relaxed conductivity filter.
+    if current:
+        entities.add(current)
+
+    return sorted(entities)
+
+
+def _build_sensor_schema(
+    hass: HomeAssistant, defaults: dict[str, Any] | None = None
+) -> dict:
     """Build sensor selection schema, optionally pre-filled with current values."""
     defaults = defaults or {}
     schema = {}
@@ -117,6 +175,20 @@ def _build_sensor_schema(defaults: dict[str, Any] | None = None) -> dict:
             vol_key = vol.Optional(key, description={"suggested_value": current})
         else:
             vol_key = vol.Optional(key)
+
+        if key == FLOW_SENSOR_CONDUCTIVITY:
+            conductivity_entities = _conductivity_entities(hass, current)
+            if conductivity_entities:
+                schema[vol_key] = selector(
+                    {
+                        ATTR_ENTITY: {
+                            ATTR_DOMAIN: SENSOR_DOMAIN,
+                            "include_entities": conductivity_entities,
+                        }
+                    }
+                )
+                continue
+
         schema[vol_key] = selector(
             {
                 ATTR_ENTITY: {
@@ -267,7 +339,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="sensors",
-            data_schema=vol.Schema(_build_sensor_schema()),
+            data_schema=vol.Schema(_build_sensor_schema(self.hass)),
         )
 
     async def async_step_limits(
@@ -762,7 +834,9 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         plant_info = self.config_entry.data.get(FLOW_PLANT_INFO, {})
         return self.async_show_form(
             step_id="replace_sensor",
-            data_schema=vol.Schema(_build_sensor_schema(defaults=plant_info)),
+            data_schema=vol.Schema(
+                _build_sensor_schema(self.hass, defaults=plant_info)
+            ),
             description_placeholders={"plant_name": self.plant.name},
         )
 

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -115,8 +115,7 @@ CONDUCTIVITY_UNITS = {
     "uS/cm",
 }
 CONDUCTIVITY_UNITS_NORMALIZED = {
-    unit.replace("μ", "µ").replace("u", "µ").lower()
-    for unit in CONDUCTIVITY_UNITS
+    unit.replace("μ", "µ").replace("u", "µ").lower() for unit in CONDUCTIVITY_UNITS
 }
 
 
@@ -142,7 +141,9 @@ def _is_conductivity_sensor(state) -> bool:
     return _normalize_unit(unit) in CONDUCTIVITY_UNITS_NORMALIZED
 
 
-def _conductivity_entities(hass: HomeAssistant, current: str | None = None) -> list[str]:
+def _conductivity_entities(
+    hass: HomeAssistant, current: str | None = None
+) -> list[str]:
     """Return conductivity sensor entity IDs.
 
     Home Assistant's entity selector cannot express "device class is

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -34,6 +34,7 @@ from custom_components.plant.const import (
     FLOW_PLANT_LIMITS,
     FLOW_RIGHT_PLANT,
     FLOW_SENSOR_CO2,
+    FLOW_SENSOR_CONDUCTIVITY,
     FLOW_SENSOR_ILLUMINANCE,
     FLOW_SENSOR_MOISTURE,
     FLOW_SENSOR_TEMPERATURE,
@@ -306,6 +307,47 @@ class TestConfigFlowSensorsStep:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {},
+        )
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "limits"
+
+    async def test_sensors_step_accepts_conductivity_unit_without_device_class(
+        self,
+        hass: HomeAssistant,
+        mock_no_openplantbook,
+    ) -> None:
+        """Test conductivity sensors are accepted when identified by unit only.
+
+        Regression test for soil_fertility sensors (e.g. Zigbee2MQTT Arteco ZS-SF00),
+        which expose μS/cm but do not set SensorDeviceClass.CONDUCTIVITY.
+        """
+
+        hass.states.async_set(
+            "sensor.soil_fertility",
+            "337",
+            {"unit_of_measurement": "µS/cm"},
+        )
+
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                ATTR_NAME: "My Plant",
+                ATTR_SPECIES: "ficus",
+            },
+        )
+
+        assert result["step_id"] == "sensors"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                FLOW_SENSOR_CONDUCTIVITY: "sensor.soil_fertility",
+            },
         )
 
         assert result["type"] == FlowResultType.FORM


### PR DESCRIPTION
Some integrations expose soil conductivity sensors using a valid conductivity
unit (µS/cm, mS/cm) but do not set Home Assistant's conductivity device class.

The Arteco ZS-SF00 sensor exposed through Zigbee2MQTT is one example.

As a result, these entities are not offered as conductivity sensors in the
Plant integration's sensor replacement flow, preventing conductivity monitoring
from being configured.

This change allows conductivity sensors to be selected when either:

- the entity exposes a conductivity device class, or
- the entity uses a recognized conductivity unit.

This restores compatibility with conductivity sensors that are otherwise valid
but lack a conductivity device class.

Fixes #455 