### PR TITLE
Release 2026.6.0

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.6.0-beta1"
+  "version": "2026.6.0"
 }


### PR DESCRIPTION
Promote `2026.6.0-beta1` to stable. Bundles care attributes (#451), restore-on-restart (#449), and structured problems/logbook (#439). manifest.json version only; CI publishes the stable release on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)