### PR TITLE
Enhance Fahrenheit temperature limit handling and prevent double conversion

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -16,11 +16,13 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_PICTURE,
     ATTR_NAME,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.selector import selector
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
     ATTR_CARE,
@@ -36,6 +38,7 @@ from .const import (
     CONF_MAX_HUMIDITY,
     CONF_MAX_ILLUMINANCE,
     CONF_MAX_MOISTURE,
+    CONF_MAX_SOIL_TEMPERATURE,
     CONF_MAX_TEMPERATURE,
     CONF_MAX_VPD,
     CONF_MIN_CONDUCTIVITY,
@@ -43,6 +46,7 @@ from .const import (
     CONF_MIN_HUMIDITY,
     CONF_MIN_ILLUMINANCE,
     CONF_MIN_MOISTURE,
+    CONF_MIN_SOIL_TEMPERATURE,
     CONF_MIN_TEMPERATURE,
     CONF_MIN_VPD,
     DATA_SOURCE,
@@ -52,6 +56,7 @@ from .const import (
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MAX_ILLUMINANCE,
     DEFAULT_MAX_MOISTURE,
+    DEFAULT_MAX_SOIL_TEMPERATURE,
     DEFAULT_MAX_TEMPERATURE,
     DEFAULT_MAX_VPD,
     DEFAULT_MIN_CONDUCTIVITY,
@@ -59,6 +64,7 @@ from .const import (
     DEFAULT_MIN_HUMIDITY,
     DEFAULT_MIN_ILLUMINANCE,
     DEFAULT_MIN_MOISTURE,
+    DEFAULT_MIN_SOIL_TEMPERATURE,
     DEFAULT_MIN_TEMPERATURE,
     DEFAULT_MIN_VPD,
     DEFAULT_MOISTURE_GRACE_PERIOD,
@@ -71,6 +77,7 @@ from .const import (
     FLOW_FORCE_SPECIES_UPDATE,
     FLOW_HUMIDITY_TRIGGER,
     FLOW_ILLUMINANCE_TRIGGER,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_MOISTURE_GRACE_PERIOD,
     FLOW_MOISTURE_TRIGGER,
     FLOW_PLANT_INFO,
@@ -301,11 +308,27 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 # Fill in default values for hidden thresholds to keep data structure complete
                 limits = dict(user_input)
+
+                # Temperature defaults are in Celsius - convert if system is imperial
+                temp_unit = self.hass.config.units.temperature_unit
+
+                def convert_temp_default(value_c: float) -> float:
+                    """Convert Celsius default to system unit."""
+                    if temp_unit == UnitOfTemperature.CELSIUS:
+                        return value_c
+                    return round(
+                        TemperatureConverter.convert(
+                            value_c, UnitOfTemperature.CELSIUS, temp_unit
+                        )
+                    )
+
                 all_threshold_defaults = {
                     CONF_MAX_MOISTURE: DEFAULT_MAX_MOISTURE,
                     CONF_MIN_MOISTURE: DEFAULT_MIN_MOISTURE,
-                    CONF_MAX_TEMPERATURE: DEFAULT_MAX_TEMPERATURE,
-                    CONF_MIN_TEMPERATURE: DEFAULT_MIN_TEMPERATURE,
+                    CONF_MAX_TEMPERATURE: convert_temp_default(DEFAULT_MAX_TEMPERATURE),
+                    CONF_MIN_TEMPERATURE: convert_temp_default(DEFAULT_MIN_TEMPERATURE),
+                    CONF_MAX_SOIL_TEMPERATURE: convert_temp_default(DEFAULT_MAX_SOIL_TEMPERATURE),
+                    CONF_MIN_SOIL_TEMPERATURE: convert_temp_default(DEFAULT_MIN_SOIL_TEMPERATURE),
                     CONF_MAX_CONDUCTIVITY: DEFAULT_MAX_CONDUCTIVITY,
                     CONF_MIN_CONDUCTIVITY: DEFAULT_MIN_CONDUCTIVITY,
                     CONF_MAX_ILLUMINANCE: DEFAULT_MAX_ILLUMINANCE,
@@ -322,6 +345,8 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         limits[key] = default_val
 
                 self.plant_info[FLOW_PLANT_LIMITS] = limits
+                # Record the unit that temperature limits are stored in
+                self.plant_info[FLOW_LIMITS_TEMPERATURE_UNIT] = temp_unit
                 _LOGGER.debug("Plant_info: %s", self.plant_info)
                 # Return the form of the next step
                 return await self.async_step_limits_done()

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -174,6 +174,7 @@ FLOW_PLANT_SPECIES = "plant_species"
 FLOW_PLANT_NAME = "plant_name"
 FLOW_PLANT_IMAGE = "image_url"
 FLOW_PLANT_LIMITS = "limits"
+FLOW_LIMITS_TEMPERATURE_UNIT = "limits_temperature_unit"
 
 FLOW_SENSOR_TEMPERATURE = "temperature_sensor"
 FLOW_SENSOR_MOISTURE = "moisture_sensor"

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -43,8 +43,6 @@ from .const import (
     ATTR_THRESHOLDS,
     ATTR_VPD,
     CONF_LUX_TO_PPFD,
-    DATA_SOURCE,
-    DOMAIN_PLANTBOOK,
     CONF_MAX_CO2,
     CONF_MAX_CONDUCTIVITY,
     CONF_MAX_DLI,
@@ -83,6 +81,7 @@ from .const import (
     DEFAULT_MIN_TEMPERATURE,
     DEFAULT_MIN_VPD,
     DOMAIN,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_INFO,
     FLOW_PLANT_LIMITS,
     FLOW_SENSOR_CO2,
@@ -268,11 +267,15 @@ def _get_temperature_default(
     config_key: str,
     fallback_default: float,
 ) -> float:
-    """Get the temperature default value, handling OpenPlantbook pre-conversion.
+    """Get the temperature default value, handling unit conversion.
 
-    OpenPlantbook values are already converted to the user's unit system by
-    generate_configentry. Other sources (manual entry, defaults) are in Celsius
-    and need conversion when the system uses Fahrenheit.
+    Config entries created with the updated flow store `limits_temperature_unit`
+    explicitly. When present, we compare it to the system unit and convert if
+    they differ.
+
+    Legacy entries (without `limits_temperature_unit`) assume stored values are
+    already in the user's system unit — both OpenPlantbook (pre-converted by
+    generate_configentry) and manual configs (user typed values in their unit).
 
     Args:
         hass: Home Assistant instance
@@ -283,18 +286,32 @@ def _get_temperature_default(
     Returns:
         Temperature value in the user's configured unit system
     """
-    data_source = config.data[FLOW_PLANT_INFO].get(DATA_SOURCE)
-    stored = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(config_key)
+    plant_info = config.data[FLOW_PLANT_INFO]
+    stored = plant_info[FLOW_PLANT_LIMITS].get(config_key)
+    system_unit = hass.config.units.temperature_unit
 
-    if stored is not None and data_source == DOMAIN_PLANTBOOK:
-        # OpenPlantbook values are already converted by generate_configentry
+    # Check for explicit unit marker (new config entries)
+    stored_unit = plant_info.get(FLOW_LIMITS_TEMPERATURE_UNIT)
+    if stored_unit is not None:
+        if stored is not None:
+            # Value exists - convert if units differ
+            if stored_unit == system_unit:
+                return stored
+            # Convert from stored unit to system unit
+            return round(
+                TemperatureConverter.convert(stored, stored_unit, system_unit)
+            )
+        # No stored value - convert fallback default from Celsius
+        return _convert_default_temp(fallback_default, system_unit)
+
+    # Legacy fallback: stored values are assumed to be in user's system unit
+    # - OpenPlantbook: pre-converted by generate_configentry via display_temp()
+    # - Manual: user typed values in their configured unit
+    if stored is not None:
         return stored
 
-    # Manual/default values are in Celsius - convert if needed
-    return _convert_default_temp(
-        stored if stored is not None else fallback_default,
-        hass.config.units.temperature_unit,
-    )
+    # No stored value - convert fallback default from Celsius
+    return _convert_default_temp(fallback_default, system_unit)
 
 
 class PlantMinMax(RestoreNumber):

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -43,6 +43,8 @@ from .const import (
     ATTR_THRESHOLDS,
     ATTR_VPD,
     CONF_LUX_TO_PPFD,
+    DATA_SOURCE,
+    DOMAIN_PLANTBOOK,
     CONF_MAX_CO2,
     CONF_MAX_CONDUCTIVITY,
     CONF_MAX_DLI,
@@ -257,6 +259,41 @@ def _convert_default_temp(value_c: float, target_unit: UnitOfTemperature) -> flo
         return value_c
     return round(
         TemperatureConverter.convert(value_c, UnitOfTemperature.CELSIUS, target_unit)
+    )
+
+
+def _get_temperature_default(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    config_key: str,
+    fallback_default: float,
+) -> float:
+    """Get the temperature default value, handling OpenPlantbook pre-conversion.
+
+    OpenPlantbook values are already converted to the user's unit system by
+    generate_configentry. Other sources (manual entry, defaults) are in Celsius
+    and need conversion when the system uses Fahrenheit.
+
+    Args:
+        hass: Home Assistant instance
+        config: Config entry containing plant data
+        config_key: The CONF_*_TEMPERATURE key to look up
+        fallback_default: The DEFAULT_*_TEMPERATURE value to use if not stored
+
+    Returns:
+        Temperature value in the user's configured unit system
+    """
+    data_source = config.data[FLOW_PLANT_INFO].get(DATA_SOURCE)
+    stored = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(config_key)
+
+    if stored is not None and data_source == DOMAIN_PLANTBOOK:
+        # OpenPlantbook values are already converted by generate_configentry
+        return stored
+
+    # Manual/default values are in Celsius - convert if needed
+    return _convert_default_temp(
+        stored if stored is not None else fallback_default,
+        hass.config.units.temperature_unit,
     )
 
 
@@ -497,11 +534,8 @@ class PlantMaxTemperature(PlantMinMax):
     ) -> None:
         """Initialize the Plant component."""
         self._attr_unique_id = f"{config.entry_id}-max-temperature"
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MAX_TEMPERATURE, DEFAULT_MAX_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MAX_TEMPERATURE, DEFAULT_MAX_TEMPERATURE
         )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
@@ -595,13 +629,10 @@ class PlantMinTemperature(PlantMinMax):
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
         """Initialize the component."""
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MIN_TEMPERATURE, DEFAULT_MIN_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
-        )
         self._attr_unique_id = f"{config.entry_id}-min-temperature"
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MIN_TEMPERATURE, DEFAULT_MIN_TEMPERATURE
+        )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
             self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT
@@ -965,11 +996,8 @@ class PlantMaxSoilTemperature(PlantMinMax):
     ) -> None:
         """Initialize the Plant component."""
         self._attr_unique_id = f"{config.entry_id}-max-soil-temperature"
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MAX_SOIL_TEMPERATURE, DEFAULT_MAX_SOIL_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MAX_SOIL_TEMPERATURE, DEFAULT_MAX_SOIL_TEMPERATURE
         )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
@@ -1047,13 +1075,10 @@ class PlantMinSoilTemperature(PlantMinMax):
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
         """Initialize the component."""
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MIN_SOIL_TEMPERATURE, DEFAULT_MIN_SOIL_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
-        )
         self._attr_unique_id = f"{config.entry_id}-min-soil-temperature"
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MIN_SOIL_TEMPERATURE, DEFAULT_MIN_SOIL_TEMPERATURE
+        )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
             self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -76,6 +76,7 @@ from .const import (
     DEFAULT_MIN_TEMPERATURE,
     DOMAIN_PLANTBOOK,
     FLOW_FORCE_SPECIES_UPDATE,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_IMAGE,
     FLOW_PLANT_INFO,
     FLOW_SENSOR_CO2,
@@ -511,6 +512,9 @@ class PlantHelper:
                     CONF_MAX_DLI: config.get(CONF_MAX_DLI, max_dli),
                     CONF_MIN_DLI: config.get(CONF_MIN_DLI, min_dli),
                 },
+                # Record the unit that temperature limits are stored in.
+                # generate_configentry converts temps to the user's system unit.
+                FLOW_LIMITS_TEMPERATURE_UNIT: self.hass.config.units.temperature_unit,
                 FLOW_SENSOR_TEMPERATURE: config[ATTR_SENSORS].get(ATTR_TEMPERATURE),
                 FLOW_SENSOR_MOISTURE: config[ATTR_SENSORS].get(ATTR_MOISTURE),
                 FLOW_SENSOR_CONDUCTIVITY: config[ATTR_SENSORS].get(ATTR_CONDUCTIVITY),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_NAME,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import (
@@ -47,6 +48,7 @@ from custom_components.plant.const import (
     DATA_SOURCE_PLANTBOOK,
     DOMAIN,
     DOMAIN_PLANTBOOK,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_INFO,
     FLOW_SENSOR_CO2,
     FLOW_SENSOR_CONDUCTIVITY,
@@ -94,9 +96,17 @@ def create_plant_config_data(
     soil_temperature_sensor: str | None = "sensor.test_soil_temperature",
     data_source: str = DATA_SOURCE_DEFAULT,
     limits: dict | None = None,
+    limits_temperature_unit: str | None = None,
     care: dict | None = None,
 ) -> dict[str, Any]:
-    """Create plant configuration data for testing."""
+    """Create plant configuration data for testing.
+
+    Args:
+        limits_temperature_unit: The unit that temperature limits are stored in.
+            If None (legacy), the data_source is used to infer unit handling.
+            Pass UnitOfTemperature.FAHRENHEIT or UnitOfTemperature.CELSIUS
+            to explicitly specify the unit.
+    """
     if limits is None:
         limits = {
             CONF_MAX_MOISTURE: 60,
@@ -119,30 +129,39 @@ def create_plant_config_data(
             CONF_MIN_VPD: 0.4,
         }
 
-    return {
-        FLOW_PLANT_INFO: {
-            DATA_SOURCE: data_source,
-            ATTR_NAME: name,
-            ATTR_SPECIES: species,
-            OPB_DISPLAY_PID: display_species,
-            ATTR_ENTITY_PICTURE: entity_picture,
-            ATTR_LIMITS: limits,
-            ATTR_CARE: care or {},
-            FLOW_SENSOR_TEMPERATURE: temperature_sensor,
-            FLOW_SENSOR_MOISTURE: moisture_sensor,
-            FLOW_SENSOR_CONDUCTIVITY: conductivity_sensor,
-            FLOW_SENSOR_ILLUMINANCE: illuminance_sensor,
-            FLOW_SENSOR_HUMIDITY: humidity_sensor,
-            FLOW_SENSOR_CO2: co2_sensor,
-            FLOW_SENSOR_SOIL_TEMPERATURE: soil_temperature_sensor,
-        },
+    plant_info = {
+        DATA_SOURCE: data_source,
+        ATTR_NAME: name,
+        ATTR_SPECIES: species,
+        OPB_DISPLAY_PID: display_species,
+        ATTR_ENTITY_PICTURE: entity_picture,
+        ATTR_LIMITS: limits,
+        ATTR_CARE: care or {},
+        FLOW_SENSOR_TEMPERATURE: temperature_sensor,
+        FLOW_SENSOR_MOISTURE: moisture_sensor,
+        FLOW_SENSOR_CONDUCTIVITY: conductivity_sensor,
+        FLOW_SENSOR_ILLUMINANCE: illuminance_sensor,
+        FLOW_SENSOR_HUMIDITY: humidity_sensor,
+        FLOW_SENSOR_CO2: co2_sensor,
+        FLOW_SENSOR_SOIL_TEMPERATURE: soil_temperature_sensor,
     }
+
+    # Add explicit temperature unit if provided (new config entries)
+    if limits_temperature_unit is not None:
+        plant_info[FLOW_LIMITS_TEMPERATURE_UNIT] = limits_temperature_unit
+
+    return {FLOW_PLANT_INFO: plant_info}
 
 
 @pytest.fixture
 def plant_config_data() -> dict[str, Any]:
-    """Return standard plant configuration data."""
-    return create_plant_config_data()
+    """Return standard plant configuration data.
+
+    Simulates new config entries which always have limits_temperature_unit set.
+    """
+    return create_plant_config_data(
+        limits_temperature_unit=UnitOfTemperature.CELSIUS,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,8 +120,8 @@ def create_plant_config_data(
         }
 
     return {
-        DATA_SOURCE: data_source,
         FLOW_PLANT_INFO: {
+            DATA_SOURCE: data_source,
             ATTR_NAME: name,
             ATTR_SPECIES: species,
             OPB_DISPLAY_PID: display_species,

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -991,3 +991,220 @@ class TestThresholdImperialDefaults:
         ):
             assert threshold.native_max_value == 100
             assert threshold.native_min_value == -50
+
+
+class TestPreConvertedFahrenheitLimits:
+    """Tests that pre-converted Fahrenheit limits from generate_configentry are not double-converted.
+
+    Covers the double-conversion bug where temperature limits stored in FLOW_PLANT_LIMITS
+    (already converted to Fahrenheit by generate_configentry via display_temp()) were
+    being converted again by _convert_default_temp() in the threshold entity __init__.
+
+    Example bug: OpenPlantbook returns min_temp=7°C, generate_configentry converts to 45°F,
+    but the entity __init__ then treated 45 as Celsius and converted again to 113°F.
+    """
+
+    async def test_preconverted_fahrenheit_limits_not_double_converted(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Temperature thresholds with pre-converted °F values are used as-is."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+
+        from .conftest import (
+            CONF_MAX_SOIL_TEMPERATURE,
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_SOIL_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Simulate limits that are ALREADY in Fahrenheit (as generate_configentry would produce)
+        # OpenPlantbook: min=7°C, max=32°C  →  after display_temp(): min=45°F, max=90°F
+        preconverted_fahrenheit_limits = {
+            CONF_MAX_TEMPERATURE: 90,  # Already 90°F, not 90°C
+            CONF_MIN_TEMPERATURE: 45,  # Already 45°F, not 45°C
+            CONF_MAX_SOIL_TEMPERATURE: 86,  # Already 86°F (30°C)
+            CONF_MIN_SOIL_TEMPERATURE: 50,  # Already 50°F (10°C)
+            # Include other required limits
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # Specify data_source=DOMAIN_PLANTBOOK to indicate values are pre-converted
+        config_data = create_plant_config_data(
+            limits=preconverted_fahrenheit_limits,
+            data_source=DOMAIN_PLANTBOOK,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_preconverted_f",
+            unique_id="test_preconverted_f",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # The values should be used AS-IS, not converted again
+        # Bug behavior: 45°F treated as 45°C → converted to 113°F
+        # Fixed behavior: 45°F stays 45°F
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+        assert plant.max_soil_temperature.native_value == 86
+        assert plant.min_soil_temperature.native_value == 50
+
+        # Unit should still be Fahrenheit
+        assert plant.max_temperature._attr_native_unit_of_measurement == "°F"
+        assert plant.min_temperature._attr_native_unit_of_measurement == "°F"
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_missing_limits_fall_back_to_converted_defaults(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """When limits are missing, fallback defaults are converted from Celsius."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from .conftest import TEST_PLANT_NAME, create_plant_config_data
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Create limits WITHOUT temperature values to test fallback behavior
+        limits_without_temp = {
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+            # Explicitly omit temperature keys to test fallback
+        }
+
+        config_data = create_plant_config_data(limits=limits_without_temp)
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_missing_temp",
+            unique_id="test_missing_temp",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Fallback defaults are in Celsius (from const.py) and SHOULD be converted
+        # DEFAULT_MAX_TEMPERATURE = 40°C → 104°F
+        # DEFAULT_MIN_TEMPERATURE = 10°C → 50°F
+        # DEFAULT_MAX_SOIL_TEMPERATURE = 40°C → 104°F
+        # DEFAULT_MIN_SOIL_TEMPERATURE = 10°C → 50°F
+        assert plant.max_temperature.native_value == 104
+        assert plant.min_temperature.native_value == 50
+        assert plant.max_soil_temperature.native_value == 104
+        assert plant.min_soil_temperature.native_value == 50
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_manual_celsius_limits_converted_when_imperial(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Manual/non-OpenPlantbook Celsius values ARE converted to Fahrenheit."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DATA_SOURCE_MANUAL
+
+        from .conftest import (
+            CONF_MAX_SOIL_TEMPERATURE,
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_SOIL_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Manual entry: user types Celsius values (not pre-converted by generate_configentry)
+        manual_celsius_limits = {
+            CONF_MAX_TEMPERATURE: 32,  # 32°C → should become 90°F
+            CONF_MIN_TEMPERATURE: 7,   # 7°C → should become 45°F
+            CONF_MAX_SOIL_TEMPERATURE: 30,  # 30°C → should become 86°F
+            CONF_MIN_SOIL_TEMPERATURE: 10,  # 10°C → should become 50°F
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # data_source=DATA_SOURCE_MANUAL means values are NOT pre-converted
+        config_data = create_plant_config_data(
+            limits=manual_celsius_limits,
+            data_source=DATA_SOURCE_MANUAL,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_manual_celsius",
+            unique_id="test_manual_celsius",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Manual Celsius values SHOULD be converted to Fahrenheit
+        # 32°C → 90°F, 7°C → 45°F, 30°C → 86°F, 10°C → 50°F
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+        assert plant.max_soil_temperature.native_value == 86
+        assert plant.min_soil_temperature.native_value == 50
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -993,12 +993,14 @@ class TestThresholdImperialDefaults:
             assert threshold.native_min_value == -50
 
 
-class TestPreConvertedFahrenheitLimits:
-    """Tests that pre-converted Fahrenheit limits from generate_configentry are not double-converted.
+class TestTemperatureLimitsUnitHandling:
+    """Tests for temperature limits unit conversion and storage.
 
-    Covers the double-conversion bug where temperature limits stored in FLOW_PLANT_LIMITS
-    (already converted to Fahrenheit by generate_configentry via display_temp()) were
-    being converted again by _convert_default_temp() in the threshold entity __init__.
+    Covers:
+    - The double-conversion bug where pre-converted Fahrenheit limits were converted again
+    - Explicit unit marker behavior (limits_temperature_unit)
+    - Cross-unit conversion when stored unit differs from system unit
+    - Legacy fallback behavior using data_source check
 
     Example bug: OpenPlantbook returns min_temp=7°C, generate_configentry converts to 45°F,
     but the entity __init__ then treated 45 as Celsius and converted again to 113°F.
@@ -1009,9 +1011,8 @@ class TestPreConvertedFahrenheitLimits:
         hass: HomeAssistant,
     ) -> None:
         """Temperature thresholds with pre-converted °F values are used as-is."""
+        from homeassistant.const import UnitOfTemperature
         from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
-
-        from custom_components.plant.const import DOMAIN_PLANTBOOK
 
         from .conftest import (
             CONF_MAX_SOIL_TEMPERATURE,
@@ -1048,10 +1049,10 @@ class TestPreConvertedFahrenheitLimits:
             "min_vpd": 0.4,
         }
 
-        # Specify data_source=DOMAIN_PLANTBOOK to indicate values are pre-converted
+        # New config entries use explicit limits_temperature_unit
         config_data = create_plant_config_data(
             limits=preconverted_fahrenheit_limits,
-            data_source=DOMAIN_PLANTBOOK,
+            limits_temperature_unit=UnitOfTemperature.FAHRENHEIT,
         )
         config_entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1066,9 +1067,7 @@ class TestPreConvertedFahrenheitLimits:
 
         plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
 
-        # The values should be used AS-IS, not converted again
-        # Bug behavior: 45°F treated as 45°C → converted to 113°F
-        # Fixed behavior: 45°F stays 45°F
+        # The values should be used AS-IS since stored unit matches system unit
         assert plant.max_temperature.native_value == 90
         assert plant.min_temperature.native_value == 45
         assert plant.max_soil_temperature.native_value == 86
@@ -1145,7 +1144,7 @@ class TestPreConvertedFahrenheitLimits:
         """Manual/non-OpenPlantbook Celsius values ARE converted to Fahrenheit."""
         from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-        from custom_components.plant.const import DATA_SOURCE_MANUAL
+        from homeassistant.const import UnitOfTemperature
 
         from .conftest import (
             CONF_MAX_SOIL_TEMPERATURE,
@@ -1158,8 +1157,9 @@ class TestPreConvertedFahrenheitLimits:
 
         hass.config.units = US_CUSTOMARY_SYSTEM
 
-        # Manual entry: user types Celsius values (not pre-converted by generate_configentry)
-        manual_celsius_limits = {
+        # Config entry with Celsius limits and explicit Celsius unit marker
+        # These need to be converted to Fahrenheit for display
+        celsius_limits = {
             CONF_MAX_TEMPERATURE: 32,  # 32°C → should become 90°F
             CONF_MIN_TEMPERATURE: 7,   # 7°C → should become 45°F
             CONF_MAX_SOIL_TEMPERATURE: 30,  # 30°C → should become 86°F
@@ -1180,16 +1180,16 @@ class TestPreConvertedFahrenheitLimits:
             "min_vpd": 0.4,
         }
 
-        # data_source=DATA_SOURCE_MANUAL means values are NOT pre-converted
+        # Explicit Celsius unit - values will be converted to Fahrenheit
         config_data = create_plant_config_data(
-            limits=manual_celsius_limits,
-            data_source=DATA_SOURCE_MANUAL,
+            limits=celsius_limits,
+            limits_temperature_unit=UnitOfTemperature.CELSIUS,
         )
         config_entry = MockConfigEntry(
             domain=DOMAIN,
             data=config_data,
-            entry_id="test_manual_celsius",
-            unique_id="test_manual_celsius",
+            entry_id="test_celsius_to_f",
+            unique_id="test_celsius_to_f",
             title=TEST_PLANT_NAME,
         )
         config_entry.add_to_hass(hass)
@@ -1198,7 +1198,7 @@ class TestPreConvertedFahrenheitLimits:
 
         plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
 
-        # Manual Celsius values SHOULD be converted to Fahrenheit
+        # Celsius values converted to Fahrenheit since system is imperial
         # 32°C → 90°F, 7°C → 45°F, 30°C → 86°F, 10°C → 50°F
         assert plant.max_temperature.native_value == 90
         assert plant.min_temperature.native_value == 45
@@ -1208,3 +1208,203 @@ class TestPreConvertedFahrenheitLimits:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
 
+    async def test_legacy_data_source_fallback(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Legacy config entries without explicit unit marker use data_source fallback."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+
+        from .conftest import (
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Legacy config: no limits_temperature_unit, uses data_source=DOMAIN_PLANTBOOK
+        # Values are already in Fahrenheit (pre-converted by old generate_configentry)
+        legacy_limits = {
+            CONF_MAX_TEMPERATURE: 90,  # Already °F
+            CONF_MIN_TEMPERATURE: 45,  # Already °F
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_soil_temperature": 86,
+            "min_soil_temperature": 50,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # No limits_temperature_unit - falls back to checking data_source
+        config_data = create_plant_config_data(
+            limits=legacy_limits,
+            data_source=DOMAIN_PLANTBOOK,
+            # Note: no limits_temperature_unit - legacy behavior
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_legacy",
+            unique_id="test_legacy",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Legacy DOMAIN_PLANTBOOK values are used as-is (pre-converted)
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_metric_system_with_celsius_marker_unchanged(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Celsius values with explicit Celsius marker are unchanged on metric systems."""
+        from homeassistant.const import UnitOfTemperature
+        from homeassistant.util.unit_system import METRIC_SYSTEM
+
+        from .conftest import (
+            CONF_MAX_SOIL_TEMPERATURE,
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_SOIL_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = METRIC_SYSTEM
+
+        celsius_limits = {
+            CONF_MAX_TEMPERATURE: 32,
+            CONF_MIN_TEMPERATURE: 7,
+            CONF_MAX_SOIL_TEMPERATURE: 30,
+            CONF_MIN_SOIL_TEMPERATURE: 10,
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        config_data = create_plant_config_data(
+            limits=celsius_limits,
+            limits_temperature_unit=UnitOfTemperature.CELSIUS,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_metric_celsius",
+            unique_id="test_metric_celsius",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Celsius values unchanged on metric system
+        assert plant.max_temperature.native_value == 32
+        assert plant.min_temperature.native_value == 7
+        assert plant.max_soil_temperature.native_value == 30
+        assert plant.min_soil_temperature.native_value == 10
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_legacy_manual_values_used_as_system_unit(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Legacy manual config entries use stored values as-is (assumed system unit)."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DATA_SOURCE_DEFAULT
+
+        from .conftest import (
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Legacy manual config: no limits_temperature_unit
+        # Values are assumed to be in the user's system unit (°F here)
+        manual_fahrenheit_limits = {
+            CONF_MAX_TEMPERATURE: 90,  # User typed 90°F, stays 90
+            CONF_MIN_TEMPERATURE: 45,  # User typed 45°F, stays 45
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_soil_temperature": 86,  # User typed 86°F, stays 86
+            "min_soil_temperature": 50,  # User typed 50°F, stays 50
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # No limits_temperature_unit - legacy behavior assumes system unit
+        config_data = create_plant_config_data(
+            limits=manual_fahrenheit_limits,
+            data_source=DATA_SOURCE_DEFAULT,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_legacy_manual",
+            unique_id="test_legacy_manual",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Legacy manual values used as-is (assumed to be in user's system unit)
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+        assert plant.max_soil_temperature.native_value == 86
+        assert plant.min_soil_temperature.native_value == 50
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
## Problem

Temperature thresholds from OpenPlantbook were double-converted on imperial systems:
1. `generate_configentry` converts 7°C → 45°F via `display_temp()`
2. `number.py` treats 45 as Celsius, converts again → 113°F

## Solution

Store the unit that temperature limits are saved in (`limits_temperature_unit`) and convert on read only when stored unit differs from system unit.

**Changes:**
- Add `FLOW_LIMITS_TEMPERATURE_UNIT` constant
- Set it in `generate_configentry()` and `config_flow.py` when storing limits
- Add `_get_temperature_default()` helper that checks explicit unit first, converts if needed
- Legacy entries (no unit marker) use stored values as-is (assumed to be in user's system unit)

## Why this approach

**Self-describing data:** The explicit unit marker means we don't have to infer what unit the stored value is in based on context.

**Handles system unit changes:** If a user switches their HA instance from metric to imperial (or vice versa), the stored values convert correctly on next load since we know the original unit.

**Backwards compatible:** Existing config entries without `limits_temperature_unit` use values as-is — both OpenPlantbook (pre-converted by `display_temp()`) and manual configs (user typed values in their system unit).

## Testing

Added `TestTemperatureLimitsUnitHandling` with 6 test cases covering:
- Pre-converted °F values used as-is
- Missing limits fall back to converted defaults
- Cross-unit conversion (°C stored, °F system)
- Legacy plantbook fallback
- Metric system no-op
- Legacy manual values used as system unit