### PR TITLE
fix: hysteresis band relative to the crossed threshold (#465)

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1094,8 +1094,11 @@ class PlantDevice(RestoreEntity):
         # 500 minimum, trapping clearly-recovered readings as a problem; see
         # issue #465). A threshold-relative band keeps a consistent ~5% margin
         # around each edge regardless of where the other bound sits.
-        band_low = min_val * HYSTERESIS_FRACTION
-        band_high = max_val * HYSTERESIS_FRACTION
+        # Use the magnitude of the threshold so a negative threshold (e.g. a
+        # sub-zero temperature minimum) still yields a positive band rather than
+        # removing/reversing the hysteresis.
+        band_low = abs(min_val) * HYSTERESIS_FRACTION
+        band_high = abs(max_val) * HYSTERESIS_FRACTION
 
         if value < min_val:
             new_status = STATE_LOW

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1087,15 +1087,23 @@ class PlantDevice(RestoreEntity):
                 max_entity.state,
             )
             return current_status
-        band = (max_val - min_val) * HYSTERESIS_FRACTION
+        # Band is relative to the threshold being crossed, not the full
+        # (max - min) span. A span-based band over-inflates the LOW margin for
+        # wide-range sensors with a small minimum (e.g. conductivity 500-3000:
+        # span band = 125, so a LOW would only clear above 625 -- far above the
+        # 500 minimum, trapping clearly-recovered readings as a problem; see
+        # issue #465). A threshold-relative band keeps a consistent ~5% margin
+        # around each edge regardless of where the other bound sits.
+        band_low = min_val * HYSTERESIS_FRACTION
+        band_high = max_val * HYSTERESIS_FRACTION
 
         if value < min_val:
             new_status = STATE_LOW
         elif value > max_val:
             new_status = STATE_HIGH
-        elif current_status == STATE_LOW and value <= min_val + band:
+        elif current_status == STATE_LOW and value <= min_val + band_low:
             new_status = STATE_LOW
-        elif current_status == STATE_HIGH and value >= max_val - band:
+        elif current_status == STATE_HIGH and value >= max_val - band_high:
             new_status = STATE_HIGH
         else:
             new_status = STATE_OK

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -1097,8 +1097,13 @@ class PlantDevice(RestoreEntity):
         # Use the magnitude of the threshold so a negative threshold (e.g. a
         # sub-zero temperature minimum) still yields a positive band rather than
         # removing/reversing the hysteresis.
-        band_low = abs(min_val) * HYSTERESIS_FRACTION
-        band_high = abs(max_val) * HYSTERESIS_FRACTION
+        # Cap each band at a span-based value so a wide threshold-relative band
+        # can't exceed a narrow OK range (e.g. min=98, max=100): otherwise a
+        # clear point would fall outside [min, max] and the state could never
+        # return to OK (it would stick or flip straight to the opposite state).
+        span_band = (max_val - min_val) * HYSTERESIS_FRACTION
+        band_low = min(abs(min_val) * HYSTERESIS_FRACTION, span_band)
+        band_high = min(abs(max_val) * HYSTERESIS_FRACTION, span_band)
 
         if value < min_val:
             new_status = STATE_LOW

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -215,9 +215,11 @@ OPB_DISPLAY_PID = "display_pid"
 OPB_ATTR_INCLUDE = "include"
 OPB_INCLUDE_CARE = "care"
 
-# Hysteresis: fraction of (max - min) range that the value must clear
-# before a problem state is removed. Prevents flapping when a sensor
-# value oscillates near a threshold.
+# Hysteresis: fraction of the crossed threshold (min or max) that the value
+# must clear by before a problem state is removed. Prevents flapping when a
+# sensor value oscillates near a threshold. Relative to the threshold itself
+# (not the max-min span) so wide-range sensors with a small minimum don't get
+# an over-inflated low-side margin (see issue #465).
 HYSTERESIS_FRACTION = 0.05
 
 # Grace period after watering: delay before reporting moisture "high" problem

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1880,6 +1880,35 @@ class TestHysteresis:
         assert plant.conductivity_status == STATE_OK
         assert plant.state == STATE_OK
 
+    async def test_hysteresis_band_positive_for_negative_threshold(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Negative thresholds must still yield a positive hysteresis band.
+
+        Temperature minimums can be sub-zero. The band is the magnitude of the
+        crossed threshold times the fraction; without abs() a negative min would
+        produce a negative band, removing low-side hysteresis entirely (a LOW
+        would clear the instant it crossed back above min). See PR #466 review.
+
+        min=-10 → band_low = |-10| * 5% = 0.5 → LOW clears at > -9.5.
+        """
+        from types import SimpleNamespace
+
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        min_entity = SimpleNamespace(state="-10", entity_id="number.min")
+        max_entity = SimpleNamespace(state="40", entity_id="number.max")
+
+        # Recovered just above min but within the band (-9.8 <= -10 + 0.5 = -9.5)
+        assert (
+            plant._check_threshold(-9.8, min_entity, max_entity, STATE_LOW) == STATE_LOW
+        )
+        # Above the band (-9.4 > -9.5) → clears
+        assert (
+            plant._check_threshold(-9.4, min_entity, max_entity, STATE_LOW) == STATE_OK
+        )
+
     async def test_threshold_unavailable_preserves_status(
         self,
         hass: HomeAssistant,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1890,7 +1890,7 @@ class TestHysteresis:
         Temperature minimums can be sub-zero. The band is the magnitude of the
         crossed threshold times the fraction; without abs() a negative min would
         produce a negative band, removing low-side hysteresis entirely (a LOW
-        would clear the instant it crossed back above min). See PR #466 review.
+        would clear the instant it crossed back above min).
 
         min=-10 → band_low = |-10| * 5% = 0.5 → LOW clears at > -9.5.
         """
@@ -1907,6 +1907,41 @@ class TestHysteresis:
         # Above the band (-9.4 > -9.5) → clears
         assert (
             plant._check_threshold(-9.4, min_entity, max_entity, STATE_LOW) == STATE_OK
+        )
+
+    async def test_hysteresis_band_capped_by_span_for_tight_range(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """The band must not exceed the span for tight ranges at large values.
+
+        A threshold-relative band can be wider than the whole OK range when the
+        range is narrow but the values are large (e.g. min=98, max=100:
+        band_high = 100 * 5% = 5, but the span is only 2). Without a span cap a
+        HIGH could never clear to OK -- its clear point (95) sits below the min,
+        so an in-range value (99) stays HIGH or flips straight to LOW. Capping
+        each band at span * fraction (0.1 here) keeps clear points inside the
+        OK range.
+        """
+        from types import SimpleNamespace
+
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        min_entity = SimpleNamespace(state="98", entity_id="number.min")
+        max_entity = SimpleNamespace(state="100", entity_id="number.max")
+
+        # In-range value below max must clear a HIGH (99 < 100 - 0.1 = 99.9)
+        assert (
+            plant._check_threshold(99.0, min_entity, max_entity, STATE_HIGH) == STATE_OK
+        )
+        # In-range value above min must clear a LOW (98.5 > 98 + 0.1 = 98.1)
+        assert (
+            plant._check_threshold(98.5, min_entity, max_entity, STATE_LOW) == STATE_OK
+        )
+        # Just inside the (capped) band still holds: 99.95 >= 99.9 → HIGH
+        assert (
+            plant._check_threshold(99.95, min_entity, max_entity, STATE_HIGH)
+            == STATE_HIGH
         )
 
     async def test_threshold_unavailable_preserves_status(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1497,8 +1497,9 @@ class TestHysteresis:
     ) -> None:
         """Test that moisture HIGH state holds when value is within hysteresis band.
 
-        Default moisture: min=20, max=60, range=40, band=2.0.
-        Enters PROBLEM at >60, should stay PROBLEM until <58.
+        Default moisture: min=20, max=60. Band is relative to the threshold
+        being crossed: band_high = 60 * 5% = 3.0.
+        Enters PROBLEM at >60, should stay PROBLEM until <57.
         """
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
@@ -1515,7 +1516,7 @@ class TestHysteresis:
         assert plant.moisture_status == STATE_HIGH
         assert plant.state == STATE_PROBLEM
 
-        # Step 2: Drop to just below max but within band (59.0 >= 60 - 2 = 58)
+        # Step 2: Drop to just below max but within band (59.0 >= 60 - 3 = 57)
         await set_external_sensor_states(
             hass,
             temperature=25.0,
@@ -1528,11 +1529,11 @@ class TestHysteresis:
         assert plant.moisture_status == STATE_HIGH  # Still held
         assert plant.state == STATE_PROBLEM
 
-        # Step 3: Drop below band (57.0 < 58) → clears to OK
+        # Step 3: Drop below band (56.0 < 57) → clears to OK
         await set_external_sensor_states(
             hass,
             temperature=25.0,
-            moisture=57.0,
+            moisture=56.0,
             conductivity=1000.0,
             illuminance=5000.0,
             humidity=40.0,
@@ -1548,8 +1549,9 @@ class TestHysteresis:
     ) -> None:
         """Test temperature LOW hysteresis.
 
-        Default temperature: min=10, max=40, range=30, band=1.5.
-        Enters at <10, clears at >11.5.
+        Default temperature: min=10, max=40. Band is relative to the threshold
+        being crossed: band_low = 10 * 5% = 0.5.
+        Enters at <10, clears at >10.5.
         """
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
@@ -1565,10 +1567,10 @@ class TestHysteresis:
         await update_plant_sensors(hass, init_integration.entry_id)
         assert plant.temperature_status == STATE_LOW
 
-        # Rise within band (11.0 <= 10 + 1.5 = 11.5)
+        # Rise within band (10.3 <= 10 + 0.5 = 10.5)
         await set_external_sensor_states(
             hass,
-            temperature=11.0,
+            temperature=10.3,
             moisture=40.0,
             conductivity=1000.0,
             illuminance=5000.0,
@@ -1577,7 +1579,7 @@ class TestHysteresis:
         await update_plant_sensors(hass, init_integration.entry_id)
         assert plant.temperature_status == STATE_LOW  # held
 
-        # Rise above band (12.0 > 11.5)
+        # Rise above band (12.0 > 10.5)
         await set_external_sensor_states(
             hass,
             temperature=12.0,
@@ -1719,8 +1721,9 @@ class TestHysteresis:
     ) -> None:
         """Test DLI LOW hysteresis.
 
-        Default DLI: min=2, max=30, range=28, band=1.4.
-        Enters at <2, clears at >3.4.
+        Default DLI: min=2, max=30. Band is relative to the threshold being
+        crossed: band_low = 2 * 5% = 0.1.
+        Enters at <2, clears at >2.1.
         """
         from unittest.mock import PropertyMock, patch
 
@@ -1768,14 +1771,14 @@ class TestHysteresis:
         assert plant.dli_status == STATE_LOW
         assert plant.state == STATE_PROBLEM
 
-        # Step 2: Rise within band (2.5 <= 2 + 1.4 = 3.4) → still LOW
-        p1, p2, p3 = mock_dli(2.5)
+        # Step 2: Rise within band (2.05 <= 2 + 0.1 = 2.1) → still LOW
+        p1, p2, p3 = mock_dli(2.05)
         with p1, p2, p3:
             plant.update()
         assert plant.dli_status == STATE_LOW
         assert plant.state == STATE_PROBLEM
 
-        # Step 3: Rise above band (4.0 > 3.4) → clears
+        # Step 3: Rise above band (4.0 > 2.1) → clears
         p1, p2, p3 = mock_dli(4.0)
         with p1, p2, p3:
             plant.update()
@@ -1789,8 +1792,9 @@ class TestHysteresis:
     ) -> None:
         """Test conductivity hysteresis.
 
-        Default conductivity: min=500, max=3000, range=2500, band=125.
-        Enters LOW at <500, clears at >625.
+        Default conductivity: min=500, max=3000. Band is relative to the
+        threshold being crossed: band_low = 500 * 5% = 25.
+        Enters LOW at <500, clears at >525.
         """
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
@@ -1806,19 +1810,19 @@ class TestHysteresis:
         await update_plant_sensors(hass, init_integration.entry_id)
         assert plant.conductivity_status == STATE_LOW
 
-        # Rise within band (600 <= 500 + 125 = 625)
+        # Rise within band (510 <= 500 + 25 = 525)
         await set_external_sensor_states(
             hass,
             temperature=25.0,
             moisture=40.0,
-            conductivity=600.0,
+            conductivity=510.0,
             illuminance=5000.0,
             humidity=40.0,
         )
         await update_plant_sensors(hass, init_integration.entry_id)
         assert plant.conductivity_status == STATE_LOW  # held
 
-        # Rise above band (650 > 625)
+        # Rise above band (650 > 525)
         await set_external_sensor_states(
             hass,
             temperature=25.0,
@@ -1829,6 +1833,52 @@ class TestHysteresis:
         )
         await update_plant_sensors(hass, init_integration.entry_id)
         assert plant.conductivity_status == STATE_OK
+
+    async def test_low_recovery_clears_near_threshold(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Regression test for issue #465.
+
+        The hysteresis band must be relative to the threshold being crossed,
+        not the full (max - min) span. With conductivity min=500, max=3000 a
+        span-based 5% band is 125, which would hold a LOW problem until the
+        reading climbs above 625 -- far above the 500 minimum. A value that has
+        clearly recovered above the minimum then stays stuck as a problem.
+
+        This mirrors the issue's real numbers (min=350, max=2000, current=386:
+        above the min, but trapped in the old span-based band). With a
+        threshold-relative band (min * 5%), conductivity clears at >525.
+        """
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+
+        # Drop below min → PROBLEM
+        await set_external_sensor_states(
+            hass,
+            temperature=25.0,
+            moisture=40.0,
+            conductivity=400.0,
+            illuminance=5000.0,
+            humidity=40.0,
+        )
+        await update_plant_sensors(hass, init_integration.entry_id)
+        assert plant.conductivity_status == STATE_LOW
+        assert plant.state == STATE_PROBLEM
+
+        # Recover to clearly above the minimum (560 > 525), but within the old
+        # span-based band (560 <= 625). Must clear under the threshold-relative band.
+        await set_external_sensor_states(
+            hass,
+            temperature=25.0,
+            moisture=40.0,
+            conductivity=560.0,
+            illuminance=5000.0,
+            humidity=40.0,
+        )
+        await update_plant_sensors(hass, init_integration.entry_id)
+        assert plant.conductivity_status == STATE_OK
+        assert plant.state == STATE_OK
 
     async def test_threshold_unavailable_preserves_status(
         self,

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -176,7 +176,7 @@ class TestProblemsAttribute:
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
         assert len(plant._problems) == 1
 
-        # Fix it (clear hysteresis: min=20, band=2.0, so need > 22)
+        # Fix it (clear hysteresis: min=20, band_low=1.0, so need > 21)
         await set_external_sensor_states(hass, moisture=50.0)
         await update_plant_sensors(hass, init_integration.entry_id)
 


### PR DESCRIPTION
## Problem

Plant problem states (e.g. `conductivity Low`) did not clear after a sensor recovered, even with no restart — reported in #465.

The hysteresis band in `_check_threshold` was computed as a fraction of the full `(max - min)` span and applied to **both** edges:

```python
band = (max_val - min_val) * HYSTERESIS_FRACTION   # 0.05
```

For wide-range sensors with a small minimum (conductivity, CO₂, illuminance), this over-inflates the **low-side** margin. With the reporter's thresholds **min=350, max=2000**:

- band = (2000 − 350) × 0.05 = **82.5**
- a `LOW` problem only cleared once the reading exceeded **350 + 82.5 = 432.5**
- the actual reading was **386** — above the 350 minimum (looks fully recovered) but trapped below the clear point, so it stayed flagged as a problem indefinitely.

## Fix

Anchor the band to the threshold being crossed rather than the span:

```python
band_low  = min_val * HYSTERESIS_FRACTION
band_high = max_val * HYSTERESIS_FRACTION
```

This keeps a predictable ~5% margin past each limit regardless of where the other bound sits. For the reported plant, `LOW` now clears at **350 × 1.05 = 367.5**, so 386 clears with margin. The high side is essentially unchanged for these sensors (`max × 0.05 ≈ (max − min) × 0.05` when `min ≪ max`), so the blast radius is limited to the over-sticky low behavior. `min=0` sensors (illuminance) get `band_low=0`, which is harmless — a `LOW` is impossible when the floor is 0.

## Testing

- New regression test `test_low_recovery_clears_near_threshold` reproducing the issue (RED before, GREEN after).
- Updated the 4 existing hysteresis tests + comments that hard-coded the old span-based band.
- Full suite: **304 passed**; ruff + black clean.

Fixes #465

🤖 Generated with [Claude Code](https://claude.com/claude-code)