### PR TITLE
docs: dedicated MISSING_SENSORS.md for the missing-device_class issue

### DIFF
--- a/MISSING_SENSORS.md
+++ b/MISSING_SENSORS.md
@@ -1,0 +1,88 @@
+# 🔍 A Sensor Is Missing From the Dropdown (Wrong or Missing `device_class`)
+
+This is the most common issue users run into.
+
+The sensor dropdowns in the config flow filter by Home Assistant **`device_class`**. Many integrations — especially **Zigbee2MQTT** and some BLE sensors — create the entity with the correct *unit* (e.g. `µS/cm`) but **without** a `device_class` (e.g. `conductivity`) or `state_class`. Home Assistant still creates the entity, but Plant Monitor — and any selector that filters by device class — won't list it. A humidity sensor reporting soil moisture, or a soil sensor with no `device_class` at all, hits the same problem.
+
+> [!IMPORTANT]
+> **The real fix is upstream — please report it there first.**
+> Plant Monitor intentionally does **not** work around missing device classes; doing so would mask a metadata bug in the integration that owns the hardware. If a sensor is missing its `device_class`/`state_class`, **open an issue with that integration** (e.g. Zigbee2MQTT, the BLE integration, the device's quirk/converter). Once they publish the correct metadata the sensor appears automatically — for you **and** for everyone else with that device. The workarounds below are personal stopgaps until that fix lands; they are not a substitute for the upstream report.
+
+---
+
+## Workarounds (until the upstream fix lands)
+
+### Zigbee2MQTT: override in `devices.yaml` *(recommended for Z2M)*
+
+Fixes the entity at the source — no extra entity, and it mirrors what the proper upstream fix will do. Add `device_class`/`state_class` under the device's `homeassistant:` block:
+
+```yaml
+# /config/zigbee2mqtt/devices.yaml
+'0xa4c138b46e1ffa5b':        # your device's IEEE address
+  friendly_name: Flamingo Lily Sensor
+  homeassistant:
+    soil_fertility:           # the exposed property (e.g. soil_fertility -> conductivity)
+      device_class: conductivity
+      state_class: measurement
+```
+
+Restart/reload Zigbee2MQTT. The entity gets the correct `device_class` and appears in the dropdown.
+
+### Option: `customize.yaml` *(simplest, any integration)*
+
+Override the device class directly in your HA configuration. No new entities created.
+
+```yaml
+# In customize.yaml
+sensor.my_zigbee_soil_sensor:
+  device_class: moisture
+```
+
+Restart Home Assistant after editing.
+
+### Option: Create a Template Sensor
+
+Create a new sensor with the correct `device_class`. Useful when you also want to rename the sensor or add processing.
+
+```yaml
+# In configuration.yaml (or a templates/ file)
+template:
+  - sensor:
+      - name: "Garden Soil Moisture"
+        unique_id: "garden_soil_moisture_fixed"
+        state: "{{ states('sensor.zigbee_soil_sensor_humidity') }}"
+        unit_of_measurement: "%"
+        device_class: moisture
+        state_class: measurement
+```
+
+### Option: Use `replace_sensor` After Setup
+
+The `plant.replace_sensor` action has **more relaxed** validation than the setup flow and the **Configure** → **Replace sensors** UI — it does not filter by `device_class`, so it accepts any `sensor.*` entity. You can:
+
+1. Set up the plant **without** the problematic sensor
+2. Use **Developer Tools** → **Actions** → `plant.replace_sensor` to assign it
+
+```yaml
+action: plant.replace_sensor
+data:
+  meter_entity: sensor.my_plant_soil_moisture
+  new_sensor: sensor.zigbee_sensor_with_wrong_device_class
+```
+
+> [!NOTE]
+> If the plant sensor entity is disabled (because no source was configured during setup), you must **enable** it first on the device page before it appears in the entity picker. See [Adding a sensor to an existing plant](README.md#adding-a-sensor-to-an-existing-plant).
+
+---
+
+## Which Workaround to Choose?
+
+| Workaround | Pros | Cons |
+|--------|------|------|
+| Z2M `devices.yaml` | Fixes at source, no extra entity, mirrors the real fix | Zigbee2MQTT only |
+| `customize.yaml` | Simple, any integration, no extra entities | Affects the sensor globally |
+| Template sensor | Full control, can rename/process | Extra entity to maintain |
+| `replace_sensor` | No config changes, available from the UI | Sensor must be enabled first |
+
+> [!TIP]
+> Whichever you pick, it only fixes *your* setup. Reporting the missing `device_class` to the upstream integration is the only thing that fixes it permanently for everyone.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A comprehensive plant monitoring integration for Home Assistant that treats each
   - [🌻 OpenPlantbook Integration](#-openplantbook-integration)
   - [🃏 Lovelace Card](#-lovelace-card)
   - [💡 Tips & Tricks](TIPS.md)
+  - [🔍 Missing Sensor in Dropdown?](MISSING_SENSORS.md)
   - [❓ FAQ](#-faq)
   - [☕ Support](#-support)
 
@@ -335,7 +336,10 @@ The card supports both °C and °F:
 
 ## 💡 Tips & Tricks
 
-For practical tips, template examples, and workarounds — including fixing sensors with wrong `device_class`, auto-watering automations, problem notifications, and battery/stuck sensor monitoring — see **[TIPS.md](TIPS.md)**.
+> [!IMPORTANT]
+> **A sensor doesn't show up in a dropdown?** This is the most common problem, and it's almost always a missing `device_class` on the *source* integration (often Zigbee2MQTT or BLE) — not a Plant Monitor bug. **Please report it to that integration** (the only permanent fix); local workarounds are in **[MISSING_SENSORS.md](MISSING_SENSORS.md)**.
+
+For other practical tips, template examples, and workarounds — auto-watering, problem notifications, battery/stuck sensor monitoring — see **[TIPS.md](TIPS.md)**.
 
 ---
 
@@ -348,24 +352,13 @@ Home Assistant remembers old entity configurations. Instead of removing and re-a
 </details>
 
 <details>
-<summary><strong>I can't select the correct sensor type (e.g. Moisture, Humidity) from the dropdown</strong></summary>
+<summary><strong>A sensor is missing from the dropdown (e.g. conductivity, moisture, humidity)</strong></summary>
 
-The sensor dropdowns filter by `device_class`. Some integrations don't set the correct device class on their sensors.
+The dropdowns filter by `device_class`, and some integrations (often Zigbee2MQTT or BLE sensors) create the entity without one — so it isn't listed.
 
-**Solutions:**
-1. Report the issue to the physical sensor's integration maintainer
-2. Add the plant without that sensor, then use the `plant.replace_sensor` action (it doesn't filter by `device_class`)
-3. Create a template sensor with the correct device class:
+**The permanent fix is upstream:** report the missing `device_class`/`state_class` to the integration that owns the sensor (e.g. Zigbee2MQTT). Once fixed there, the sensor appears automatically — for you and everyone else with that device. Plant Monitor deliberately does not work around missing device classes.
 
-```yaml
-template:
-  - sensor:
-      - name: "Soil Moisture"
-        unique_id: "soil_sensor_moisture"
-        state: "{{ states('sensor.soil_sensor_soil_moisture') }}"
-        unit_of_measurement: "%"
-        device_class: "moisture"
-```
+Local workarounds (Zigbee2MQTT `devices.yaml` override, `customize.yaml`, a template sensor, or `plant.replace_sensor`) are documented in **[MISSING_SENSORS.md](MISSING_SENSORS.md)**.
 </details>
 
 <details>

--- a/TIPS.md
+++ b/TIPS.md
@@ -7,7 +7,7 @@ Practical tips, template examples, and workarounds for common situations with th
 ## 📑 Table of Contents
 
 - [💡 Tips & Tricks](#-tips--tricks)
-  - [🔧 Fixing Sensors with Wrong or Missing Device Class](#-fixing-sensors-with-wrong-or-missing-device-class)
+  - [🔍 A sensor is missing from the dropdown? → MISSING_SENSORS.md](MISSING_SENSORS.md)
   - [💧 Auto-Watering with Averaged Moisture](#-auto-watering-with-averaged-moisture)
   - [🚨 Problem Notification Automation](#-problem-notification-automation)
   - [🌤️ Weather Forecast Warnings for Outdoor Plants](#️-weather-forecast-warnings-for-outdoor-plants)
@@ -17,70 +17,11 @@ Practical tips, template examples, and workarounds for common situations with th
 
 ---
 
-## 🔧 Fixing Sensors with Wrong or Missing Device Class
+## 🔍 A Sensor Is Missing From the Dropdown? (Wrong/Missing `device_class`)
 
-This is the most common issue users run into. The sensor dropdowns in the config flow filter by `device_class`, and many integrations (especially Zigbee and BLE sensors) don't set it correctly. A humidity sensor might report soil moisture, or a soil sensor might have no `device_class` at all.
+The most common issue: a sensor exists but isn't listed in a config-flow dropdown because the source integration (often Zigbee2MQTT or a BLE sensor) didn't set its `device_class`. **The permanent fix is to report it to that integration**; several local workarounds are also available.
 
-There are three ways to work around this:
-
-### Option 1: Use `customize.yaml` *(simplest)*
-
-Override the device class directly in your HA configuration. No new entities created.
-
-```yaml
-# In customize.yaml
-sensor.my_zigbee_soil_sensor:
-  device_class: moisture
-
-sensor.my_humidity_sensor_used_for_soil:
-  device_class: moisture
-```
-
-Restart Home Assistant after editing. The sensor will now appear in the correct dropdown.
-
-### Option 2: Create a Template Sensor
-
-Create a new sensor with the correct `device_class`. Useful when you also want to rename the sensor or add processing.
-
-```yaml
-# In configuration.yaml (or a templates/ file)
-template:
-  - sensor:
-      - name: "Garden Soil Moisture"
-        unique_id: "garden_soil_moisture_fixed"
-        state: "{{ states('sensor.zigbee_soil_sensor_humidity') }}"
-        unit_of_measurement: "%"
-        device_class: moisture
-        state_class: measurement
-```
-
-### Option 3: Use `replace_sensor` After Setup
-
-The `plant.replace_sensor` action has **more relaxed** validation than the setup flow and the **Configure** → **Replace sensors** UI — it does not filter by `device_class`, so it accepts any `sensor.*` entity. You can:
-
-1. Set up the plant **without** the problematic sensor
-2. Use **Developer Tools** → **Actions** → `plant.replace_sensor` to assign it
-
-```yaml
-action: plant.replace_sensor
-data:
-  meter_entity: sensor.my_plant_soil_moisture
-  new_sensor: sensor.zigbee_sensor_with_wrong_device_class
-```
-
-> [!NOTE]
-> If the plant sensor entity is disabled (because no source was configured during setup), you must **enable** it first on the device page before it appears in the entity picker. See [Adding a sensor to an existing plant](README.md#adding-a-sensor-to-an-existing-plant).
-
-### Which Option to Choose?
-
-| Option | Pros | Cons |
-|--------|------|------|
-| `customize.yaml` | Simple, no extra entities | Affects the sensor globally |
-| Template sensor | Full control, can rename/process | Extra entity to maintain |
-| `replace_sensor` | No config changes needed, available from UI | Sensor must be enabled first |
-
-> [!TIP]
-> Regardless of the workaround, **report the missing `device_class` to the integration that owns the physical sensor**. That's the only way to fix it permanently for everyone.
+➡️ Full explanation and workarounds: **[MISSING_SENSORS.md](MISSING_SENSORS.md)**
 
 ---
 


### PR DESCRIPTION
Recurring problem (#455, #457, #464): hardware integrations (often Zigbee2MQTT/BLE) expose conductivity/humidity entities without a `device_class`/`state_class`, so the config-flow dropdowns don't list them.

- New **MISSING_SENSORS.md**: upstream-first callout (report it to the source integration — the only permanent fix; Plant Monitor deliberately doesn't work around missing device classes) + 4 workarounds (Zigbee2MQTT `devices.yaml` override [new], `customize.yaml`, template sensor, `replace_sensor`).
- README: prominent `[!IMPORTANT]` callout in Tips, upstream-first FAQ answer linking the new doc, TOC entry.
- TIPS.md: long section replaced by a stub linking to the new doc.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)