### PR TITLE
Fix Fahrenheit double-conversion of temperature limits (supersedes #463)

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -327,8 +327,12 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_MIN_MOISTURE: DEFAULT_MIN_MOISTURE,
                     CONF_MAX_TEMPERATURE: convert_temp_default(DEFAULT_MAX_TEMPERATURE),
                     CONF_MIN_TEMPERATURE: convert_temp_default(DEFAULT_MIN_TEMPERATURE),
-                    CONF_MAX_SOIL_TEMPERATURE: convert_temp_default(DEFAULT_MAX_SOIL_TEMPERATURE),
-                    CONF_MIN_SOIL_TEMPERATURE: convert_temp_default(DEFAULT_MIN_SOIL_TEMPERATURE),
+                    CONF_MAX_SOIL_TEMPERATURE: convert_temp_default(
+                        DEFAULT_MAX_SOIL_TEMPERATURE
+                    ),
+                    CONF_MIN_SOIL_TEMPERATURE: convert_temp_default(
+                        DEFAULT_MIN_SOIL_TEMPERATURE
+                    ),
                     CONF_MAX_CONDUCTIVITY: DEFAULT_MAX_CONDUCTIVITY,
                     CONF_MIN_CONDUCTIVITY: DEFAULT_MIN_CONDUCTIVITY,
                     CONF_MAX_ILLUMINANCE: DEFAULT_MAX_ILLUMINANCE,
@@ -978,6 +982,13 @@ async def refresh_plant_from_openplantbook(
     plant_info = dict(data.get(FLOW_PLANT_INFO, {}))
     plant_info[FLOW_PLANT_LIMITS] = dict(limits)
     plant_info[ATTR_CARE] = dict(plant.care)
+    # Keep the temperature-unit marker coupled to the refreshed limits.
+    # generate_configentry converts temps to the system unit and stamps the
+    # marker; persisting the limits without the marker would let a later
+    # unit switch re-convert already-converted values (double conversion).
+    plant_info[FLOW_LIMITS_TEMPERATURE_UNIT] = plant_config[FLOW_PLANT_INFO].get(
+        FLOW_LIMITS_TEMPERATURE_UNIT, hass.config.units.temperature_unit
+    )
     data[FLOW_PLANT_INFO] = plant_info
     options = dict(entry.options)
     options[OPB_DISPLAY_PID] = plant.display_species

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -16,11 +16,13 @@ from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_PICTURE,
     ATTR_NAME,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.network import NoURLAvailableError, get_url
 from homeassistant.helpers.selector import selector
+from homeassistant.util.unit_conversion import TemperatureConverter
 
 from .const import (
     ATTR_CARE,
@@ -36,6 +38,7 @@ from .const import (
     CONF_MAX_HUMIDITY,
     CONF_MAX_ILLUMINANCE,
     CONF_MAX_MOISTURE,
+    CONF_MAX_SOIL_TEMPERATURE,
     CONF_MAX_TEMPERATURE,
     CONF_MAX_VPD,
     CONF_MIN_CONDUCTIVITY,
@@ -43,6 +46,7 @@ from .const import (
     CONF_MIN_HUMIDITY,
     CONF_MIN_ILLUMINANCE,
     CONF_MIN_MOISTURE,
+    CONF_MIN_SOIL_TEMPERATURE,
     CONF_MIN_TEMPERATURE,
     CONF_MIN_VPD,
     DATA_SOURCE,
@@ -52,6 +56,7 @@ from .const import (
     DEFAULT_MAX_HUMIDITY,
     DEFAULT_MAX_ILLUMINANCE,
     DEFAULT_MAX_MOISTURE,
+    DEFAULT_MAX_SOIL_TEMPERATURE,
     DEFAULT_MAX_TEMPERATURE,
     DEFAULT_MAX_VPD,
     DEFAULT_MIN_CONDUCTIVITY,
@@ -59,6 +64,7 @@ from .const import (
     DEFAULT_MIN_HUMIDITY,
     DEFAULT_MIN_ILLUMINANCE,
     DEFAULT_MIN_MOISTURE,
+    DEFAULT_MIN_SOIL_TEMPERATURE,
     DEFAULT_MIN_TEMPERATURE,
     DEFAULT_MIN_VPD,
     DEFAULT_MOISTURE_GRACE_PERIOD,
@@ -71,6 +77,7 @@ from .const import (
     FLOW_FORCE_SPECIES_UPDATE,
     FLOW_HUMIDITY_TRIGGER,
     FLOW_ILLUMINANCE_TRIGGER,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_MOISTURE_GRACE_PERIOD,
     FLOW_MOISTURE_TRIGGER,
     FLOW_PLANT_INFO,
@@ -301,11 +308,27 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 # Fill in default values for hidden thresholds to keep data structure complete
                 limits = dict(user_input)
+
+                # Temperature defaults are in Celsius - convert if system is imperial
+                temp_unit = self.hass.config.units.temperature_unit
+
+                def convert_temp_default(value_c: float) -> float:
+                    """Convert Celsius default to system unit."""
+                    if temp_unit == UnitOfTemperature.CELSIUS:
+                        return value_c
+                    return round(
+                        TemperatureConverter.convert(
+                            value_c, UnitOfTemperature.CELSIUS, temp_unit
+                        )
+                    )
+
                 all_threshold_defaults = {
                     CONF_MAX_MOISTURE: DEFAULT_MAX_MOISTURE,
                     CONF_MIN_MOISTURE: DEFAULT_MIN_MOISTURE,
-                    CONF_MAX_TEMPERATURE: DEFAULT_MAX_TEMPERATURE,
-                    CONF_MIN_TEMPERATURE: DEFAULT_MIN_TEMPERATURE,
+                    CONF_MAX_TEMPERATURE: convert_temp_default(DEFAULT_MAX_TEMPERATURE),
+                    CONF_MIN_TEMPERATURE: convert_temp_default(DEFAULT_MIN_TEMPERATURE),
+                    CONF_MAX_SOIL_TEMPERATURE: convert_temp_default(DEFAULT_MAX_SOIL_TEMPERATURE),
+                    CONF_MIN_SOIL_TEMPERATURE: convert_temp_default(DEFAULT_MIN_SOIL_TEMPERATURE),
                     CONF_MAX_CONDUCTIVITY: DEFAULT_MAX_CONDUCTIVITY,
                     CONF_MIN_CONDUCTIVITY: DEFAULT_MIN_CONDUCTIVITY,
                     CONF_MAX_ILLUMINANCE: DEFAULT_MAX_ILLUMINANCE,
@@ -322,6 +345,8 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         limits[key] = default_val
 
                 self.plant_info[FLOW_PLANT_LIMITS] = limits
+                # Record the unit that temperature limits are stored in
+                self.plant_info[FLOW_LIMITS_TEMPERATURE_UNIT] = temp_unit
                 _LOGGER.debug("Plant_info: %s", self.plant_info)
                 # Return the form of the next step
                 return await self.async_step_limits_done()

--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -174,6 +174,7 @@ FLOW_PLANT_SPECIES = "plant_species"
 FLOW_PLANT_NAME = "plant_name"
 FLOW_PLANT_IMAGE = "image_url"
 FLOW_PLANT_LIMITS = "limits"
+FLOW_LIMITS_TEMPERATURE_UNIT = "limits_temperature_unit"
 
 FLOW_SENSOR_TEMPERATURE = "temperature_sensor"
 FLOW_SENSOR_MOISTURE = "moisture_sensor"

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -298,9 +298,7 @@ def _get_temperature_default(
             if stored_unit == system_unit:
                 return stored
             # Convert from stored unit to system unit
-            return round(
-                TemperatureConverter.convert(stored, stored_unit, system_unit)
-            )
+            return round(TemperatureConverter.convert(stored, stored_unit, system_unit))
         # No stored value - convert fallback default from Celsius
         return _convert_default_temp(fallback_default, system_unit)
 

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -43,8 +43,6 @@ from .const import (
     ATTR_THRESHOLDS,
     ATTR_VPD,
     CONF_LUX_TO_PPFD,
-    DATA_SOURCE,
-    DOMAIN_PLANTBOOK,
     CONF_MAX_CO2,
     CONF_MAX_CONDUCTIVITY,
     CONF_MAX_DLI,
@@ -83,6 +81,7 @@ from .const import (
     DEFAULT_MIN_TEMPERATURE,
     DEFAULT_MIN_VPD,
     DOMAIN,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_INFO,
     FLOW_PLANT_LIMITS,
     FLOW_SENSOR_CO2,
@@ -268,11 +267,15 @@ def _get_temperature_default(
     config_key: str,
     fallback_default: float,
 ) -> float:
-    """Get the temperature default value, handling OpenPlantbook pre-conversion.
+    """Get the temperature default value, handling unit conversion.
 
-    OpenPlantbook values are already converted to the user's unit system by
-    generate_configentry. Other sources (manual entry, defaults) are in Celsius
-    and need conversion when the system uses Fahrenheit.
+    Config entries created with the updated flow store `limits_temperature_unit`
+    explicitly. When present, we compare it to the system unit and convert if
+    they differ.
+
+    Legacy entries (without `limits_temperature_unit`) assume stored values are
+    already in the user's system unit — both OpenPlantbook (pre-converted by
+    generate_configentry) and manual configs (user typed values in their unit).
 
     Args:
         hass: Home Assistant instance
@@ -283,18 +286,32 @@ def _get_temperature_default(
     Returns:
         Temperature value in the user's configured unit system
     """
-    data_source = config.data[FLOW_PLANT_INFO].get(DATA_SOURCE)
-    stored = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(config_key)
+    plant_info = config.data[FLOW_PLANT_INFO]
+    stored = plant_info[FLOW_PLANT_LIMITS].get(config_key)
+    system_unit = hass.config.units.temperature_unit
 
-    if stored is not None and data_source == DOMAIN_PLANTBOOK:
-        # OpenPlantbook values are already converted by generate_configentry
+    # Check for explicit unit marker (new config entries)
+    stored_unit = plant_info.get(FLOW_LIMITS_TEMPERATURE_UNIT)
+    if stored_unit is not None:
+        if stored is not None:
+            # Value exists - convert if units differ
+            if stored_unit == system_unit:
+                return stored
+            # Convert from stored unit to system unit
+            return round(
+                TemperatureConverter.convert(stored, stored_unit, system_unit)
+            )
+        # No stored value - convert fallback default from Celsius
+        return _convert_default_temp(fallback_default, system_unit)
+
+    # Legacy fallback: stored values are assumed to be in user's system unit
+    # - OpenPlantbook: pre-converted by generate_configentry via display_temp()
+    # - Manual: user typed values in their configured unit
+    if stored is not None:
         return stored
 
-    # Manual/default values are in Celsius - convert if needed
-    return _convert_default_temp(
-        stored if stored is not None else fallback_default,
-        hass.config.units.temperature_unit,
-    )
+    # No stored value - convert fallback default from Celsius
+    return _convert_default_temp(fallback_default, system_unit)
 
 
 class PlantMinMax(RestoreNumber):

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -43,6 +43,8 @@ from .const import (
     ATTR_THRESHOLDS,
     ATTR_VPD,
     CONF_LUX_TO_PPFD,
+    DATA_SOURCE,
+    DOMAIN_PLANTBOOK,
     CONF_MAX_CO2,
     CONF_MAX_CONDUCTIVITY,
     CONF_MAX_DLI,
@@ -257,6 +259,41 @@ def _convert_default_temp(value_c: float, target_unit: UnitOfTemperature) -> flo
         return value_c
     return round(
         TemperatureConverter.convert(value_c, UnitOfTemperature.CELSIUS, target_unit)
+    )
+
+
+def _get_temperature_default(
+    hass: HomeAssistant,
+    config: ConfigEntry,
+    config_key: str,
+    fallback_default: float,
+) -> float:
+    """Get the temperature default value, handling OpenPlantbook pre-conversion.
+
+    OpenPlantbook values are already converted to the user's unit system by
+    generate_configentry. Other sources (manual entry, defaults) are in Celsius
+    and need conversion when the system uses Fahrenheit.
+
+    Args:
+        hass: Home Assistant instance
+        config: Config entry containing plant data
+        config_key: The CONF_*_TEMPERATURE key to look up
+        fallback_default: The DEFAULT_*_TEMPERATURE value to use if not stored
+
+    Returns:
+        Temperature value in the user's configured unit system
+    """
+    data_source = config.data[FLOW_PLANT_INFO].get(DATA_SOURCE)
+    stored = config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(config_key)
+
+    if stored is not None and data_source == DOMAIN_PLANTBOOK:
+        # OpenPlantbook values are already converted by generate_configentry
+        return stored
+
+    # Manual/default values are in Celsius - convert if needed
+    return _convert_default_temp(
+        stored if stored is not None else fallback_default,
+        hass.config.units.temperature_unit,
     )
 
 
@@ -497,11 +534,8 @@ class PlantMaxTemperature(PlantMinMax):
     ) -> None:
         """Initialize the Plant component."""
         self._attr_unique_id = f"{config.entry_id}-max-temperature"
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MAX_TEMPERATURE, DEFAULT_MAX_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MAX_TEMPERATURE, DEFAULT_MAX_TEMPERATURE
         )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
@@ -595,13 +629,10 @@ class PlantMinTemperature(PlantMinMax):
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
         """Initialize the component."""
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MIN_TEMPERATURE, DEFAULT_MIN_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
-        )
         self._attr_unique_id = f"{config.entry_id}-min-temperature"
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MIN_TEMPERATURE, DEFAULT_MIN_TEMPERATURE
+        )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
             self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT
@@ -965,11 +996,8 @@ class PlantMaxSoilTemperature(PlantMinMax):
     ) -> None:
         """Initialize the Plant component."""
         self._attr_unique_id = f"{config.entry_id}-max-soil-temperature"
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MAX_SOIL_TEMPERATURE, DEFAULT_MAX_SOIL_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MAX_SOIL_TEMPERATURE, DEFAULT_MAX_SOIL_TEMPERATURE
         )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
@@ -1047,13 +1075,10 @@ class PlantMinSoilTemperature(PlantMinMax):
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
     ) -> None:
         """Initialize the component."""
-        self._default_value = _convert_default_temp(
-            config.data[FLOW_PLANT_INFO][FLOW_PLANT_LIMITS].get(
-                CONF_MIN_SOIL_TEMPERATURE, DEFAULT_MIN_SOIL_TEMPERATURE
-            ),
-            hass.config.units.temperature_unit,
-        )
         self._attr_unique_id = f"{config.entry_id}-min-soil-temperature"
+        self._default_value = _get_temperature_default(
+            hass, config, CONF_MIN_SOIL_TEMPERATURE, DEFAULT_MIN_SOIL_TEMPERATURE
+        )
         if hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             self._attr_native_max_value = TEMPERATURE_MAX_VALUE_FAHRENHEIT
             self._attr_native_min_value = TEMPERATURE_MIN_VALUE_FAHRENHEIT

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -76,6 +76,7 @@ from .const import (
     DEFAULT_MIN_TEMPERATURE,
     DOMAIN_PLANTBOOK,
     FLOW_FORCE_SPECIES_UPDATE,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_IMAGE,
     FLOW_PLANT_INFO,
     FLOW_SENSOR_CO2,
@@ -511,6 +512,9 @@ class PlantHelper:
                     CONF_MAX_DLI: config.get(CONF_MAX_DLI, max_dli),
                     CONF_MIN_DLI: config.get(CONF_MIN_DLI, min_dli),
                 },
+                # Record the unit that temperature limits are stored in.
+                # generate_configentry converts temps to the user's system unit.
+                FLOW_LIMITS_TEMPERATURE_UNIT: self.hass.config.units.temperature_unit,
                 FLOW_SENSOR_TEMPERATURE: config[ATTR_SENSORS].get(ATTR_TEMPERATURE),
                 FLOW_SENSOR_MOISTURE: config[ATTR_SENSORS].get(ATTR_MOISTURE),
                 FLOW_SENSOR_CONDUCTIVITY: config[ATTR_SENSORS].get(ATTR_CONDUCTIVITY),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,9 +103,9 @@ def create_plant_config_data(
 
     Args:
         limits_temperature_unit: The unit that temperature limits are stored in.
-            If None (legacy), the data_source is used to infer unit handling.
-            Pass UnitOfTemperature.FAHRENHEIT or UnitOfTemperature.CELSIUS
-            to explicitly specify the unit.
+            If None (legacy), stored values are used as-is — assumed to already
+            be in the user's system unit. Pass UnitOfTemperature.FAHRENHEIT or
+            UnitOfTemperature.CELSIUS to explicitly specify the unit.
     """
     if limits is None:
         limits = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_NAME,
+    UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import (
@@ -47,6 +48,7 @@ from custom_components.plant.const import (
     DATA_SOURCE_PLANTBOOK,
     DOMAIN,
     DOMAIN_PLANTBOOK,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_INFO,
     FLOW_SENSOR_CO2,
     FLOW_SENSOR_CONDUCTIVITY,
@@ -94,9 +96,17 @@ def create_plant_config_data(
     soil_temperature_sensor: str | None = "sensor.test_soil_temperature",
     data_source: str = DATA_SOURCE_DEFAULT,
     limits: dict | None = None,
+    limits_temperature_unit: str | None = None,
     care: dict | None = None,
 ) -> dict[str, Any]:
-    """Create plant configuration data for testing."""
+    """Create plant configuration data for testing.
+
+    Args:
+        limits_temperature_unit: The unit that temperature limits are stored in.
+            If None (legacy), the data_source is used to infer unit handling.
+            Pass UnitOfTemperature.FAHRENHEIT or UnitOfTemperature.CELSIUS
+            to explicitly specify the unit.
+    """
     if limits is None:
         limits = {
             CONF_MAX_MOISTURE: 60,
@@ -119,30 +129,39 @@ def create_plant_config_data(
             CONF_MIN_VPD: 0.4,
         }
 
-    return {
-        FLOW_PLANT_INFO: {
-            DATA_SOURCE: data_source,
-            ATTR_NAME: name,
-            ATTR_SPECIES: species,
-            OPB_DISPLAY_PID: display_species,
-            ATTR_ENTITY_PICTURE: entity_picture,
-            ATTR_LIMITS: limits,
-            ATTR_CARE: care or {},
-            FLOW_SENSOR_TEMPERATURE: temperature_sensor,
-            FLOW_SENSOR_MOISTURE: moisture_sensor,
-            FLOW_SENSOR_CONDUCTIVITY: conductivity_sensor,
-            FLOW_SENSOR_ILLUMINANCE: illuminance_sensor,
-            FLOW_SENSOR_HUMIDITY: humidity_sensor,
-            FLOW_SENSOR_CO2: co2_sensor,
-            FLOW_SENSOR_SOIL_TEMPERATURE: soil_temperature_sensor,
-        },
+    plant_info = {
+        DATA_SOURCE: data_source,
+        ATTR_NAME: name,
+        ATTR_SPECIES: species,
+        OPB_DISPLAY_PID: display_species,
+        ATTR_ENTITY_PICTURE: entity_picture,
+        ATTR_LIMITS: limits,
+        ATTR_CARE: care or {},
+        FLOW_SENSOR_TEMPERATURE: temperature_sensor,
+        FLOW_SENSOR_MOISTURE: moisture_sensor,
+        FLOW_SENSOR_CONDUCTIVITY: conductivity_sensor,
+        FLOW_SENSOR_ILLUMINANCE: illuminance_sensor,
+        FLOW_SENSOR_HUMIDITY: humidity_sensor,
+        FLOW_SENSOR_CO2: co2_sensor,
+        FLOW_SENSOR_SOIL_TEMPERATURE: soil_temperature_sensor,
     }
+
+    # Add explicit temperature unit if provided (new config entries)
+    if limits_temperature_unit is not None:
+        plant_info[FLOW_LIMITS_TEMPERATURE_UNIT] = limits_temperature_unit
+
+    return {FLOW_PLANT_INFO: plant_info}
 
 
 @pytest.fixture
 def plant_config_data() -> dict[str, Any]:
-    """Return standard plant configuration data."""
-    return create_plant_config_data()
+    """Return standard plant configuration data.
+
+    Simulates new config entries which always have limits_temperature_unit set.
+    """
+    return create_plant_config_data(
+        limits_temperature_unit=UnitOfTemperature.CELSIUS,
+    )
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,8 +120,8 @@ def create_plant_config_data(
         }
 
     return {
-        DATA_SOURCE: data_source,
         FLOW_PLANT_INFO: {
+            DATA_SOURCE: data_source,
             ATTR_NAME: name,
             ATTR_SPECIES: species,
             OPB_DISPLAY_PID: display_species,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,6 +30,7 @@ from custom_components.plant.const import (
     CONF_MIN_VPD,
     DOMAIN,
     FLOW_FORCE_SPECIES_UPDATE,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
     FLOW_PLANT_INFO,
     FLOW_PLANT_LIMITS,
     FLOW_RIGHT_PLANT,
@@ -1863,3 +1864,58 @@ class TestOptionsFlow:
         # Entry.data must also have care persisted so it survives a reload.
         stored = entry.data[FLOW_PLANT_INFO][ATTR_CARE]
         assert stored == CARE_MONSTERA_DELICIOSA
+
+    async def test_force_refresh_updates_temperature_unit_marker(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        mock_openplantbook_services,
+    ) -> None:
+        """Force refresh must keep the temperature-unit marker coupled to the
+        refreshed limits.
+
+        refresh_plant_from_openplantbook re-runs generate_configentry, which
+        converts the OPB Celsius limits to the system unit and stamps
+        FLOW_LIMITS_TEMPERATURE_UNIT. If the refresh persisted the limits but
+        left a stale marker, a later read would re-convert already-converted
+        values — the double conversion this fix prevents.
+
+        Here the plant was created under metric (marker=°C, from conftest) but
+        the system is switched to imperial before the refresh. The persisted
+        marker must end up as the *current* system unit (°F).
+        """
+        from homeassistant.const import UnitOfTemperature
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        entry = init_integration
+
+        # Plant was created on metric; marker is currently °C.
+        assert (
+            entry.data[FLOW_PLANT_INFO][FLOW_LIMITS_TEMPERATURE_UNIT]
+            == UnitOfTemperature.CELSIUS
+        )
+
+        # User switches HA to imperial, then forces a species refresh.
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": "plant_properties"}
+        )
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                ATTR_SPECIES: "monstera deliciosa",
+                FLOW_FORCE_SPECIES_UPDATE: True,
+                OPB_DISPLAY_PID: "Monstera deliciosa",
+                ATTR_ENTITY_PICTURE: "https://example.com/monstera.jpg",
+            },
+        )
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+
+        # The marker must now match the system unit the limits were converted to.
+        assert (
+            entry.data[FLOW_PLANT_INFO][FLOW_LIMITS_TEMPERATURE_UNIT]
+            == UnitOfTemperature.FAHRENHEIT
+        )

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import pytest
 from homeassistant.components.number import NumberMode
-from homeassistant.const import LIGHT_LUX, PERCENTAGE, UnitOfConductivity
+from homeassistant.const import (
+    LIGHT_LUX,
+    PERCENTAGE,
+    UnitOfConductivity,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityCategory
@@ -15,11 +23,19 @@ from pytest_homeassistant_custom_component.common import (
 from custom_components.plant.const import (
     ATTR_PLANT,
     ATTR_THRESHOLDS,
+    CONF_MIN_TEMPERATURE,
     DOMAIN,
+    FLOW_LIMITS_TEMPERATURE_UNIT,
+    FLOW_PLANT_INFO,
+    FLOW_PLANT_LIMITS,
     UNIT_DLI,
 )
+from custom_components.plant.number import _get_temperature_default
 
 from .conftest import TEST_PLANT_NAME
+
+_C = UnitOfTemperature.CELSIUS
+_F = UnitOfTemperature.FAHRENHEIT
 
 
 class TestThresholdEntitiesCreation:
@@ -1000,7 +1016,7 @@ class TestTemperatureLimitsUnitHandling:
     - The double-conversion bug where pre-converted Fahrenheit limits were converted again
     - Explicit unit marker behavior (limits_temperature_unit)
     - Cross-unit conversion when stored unit differs from system unit
-    - Legacy fallback behavior using data_source check
+    - Legacy fallback behavior (no unit marker → stored values used as-is)
 
     Example bug: OpenPlantbook returns min_temp=7°C, generate_configentry converts to 45°F,
     but the entity __init__ then treated 45 as Celsius and converted again to 113°F.
@@ -1142,9 +1158,8 @@ class TestTemperatureLimitsUnitHandling:
         hass: HomeAssistant,
     ) -> None:
         """Manual/non-OpenPlantbook Celsius values ARE converted to Fahrenheit."""
-        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
-
         from homeassistant.const import UnitOfTemperature
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
         from .conftest import (
             CONF_MAX_SOIL_TEMPERATURE,
@@ -1161,7 +1176,7 @@ class TestTemperatureLimitsUnitHandling:
         # These need to be converted to Fahrenheit for display
         celsius_limits = {
             CONF_MAX_TEMPERATURE: 32,  # 32°C → should become 90°F
-            CONF_MIN_TEMPERATURE: 7,   # 7°C → should become 45°F
+            CONF_MIN_TEMPERATURE: 7,  # 7°C → should become 45°F
             CONF_MAX_SOIL_TEMPERATURE: 30,  # 30°C → should become 86°F
             CONF_MIN_SOIL_TEMPERATURE: 10,  # 10°C → should become 50°F
             "max_moisture": 60,
@@ -1208,11 +1223,11 @@ class TestTemperatureLimitsUnitHandling:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    async def test_legacy_data_source_fallback(
+    async def test_legacy_no_unit_marker_uses_stored_as_is(
         self,
         hass: HomeAssistant,
     ) -> None:
-        """Legacy config entries without explicit unit marker use data_source fallback."""
+        """Legacy entries without a unit marker use stored values as-is."""
         from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
         from custom_components.plant.const import DOMAIN_PLANTBOOK
@@ -1226,7 +1241,7 @@ class TestTemperatureLimitsUnitHandling:
 
         hass.config.units = US_CUSTOMARY_SYSTEM
 
-        # Legacy config: no limits_temperature_unit, uses data_source=DOMAIN_PLANTBOOK
+        # Legacy config: no limits_temperature_unit marker.
         # Values are already in Fahrenheit (pre-converted by old generate_configentry)
         legacy_limits = {
             CONF_MAX_TEMPERATURE: 90,  # Already °F
@@ -1249,7 +1264,9 @@ class TestTemperatureLimitsUnitHandling:
             "min_vpd": 0.4,
         }
 
-        # No limits_temperature_unit - falls back to checking data_source
+        # No limits_temperature_unit marker - stored values are used as-is.
+        # data_source is set only to mimic a real legacy plantbook entry; the
+        # conversion logic never inspects it.
         config_data = create_plant_config_data(
             limits=legacy_limits,
             data_source=DOMAIN_PLANTBOOK,
@@ -1408,3 +1425,79 @@ class TestTemperatureLimitsUnitHandling:
 
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
+
+
+def _temp_default(marker, system_unit, stored, fallback=10):
+    """Call _get_temperature_default with lightweight fakes.
+
+    _get_temperature_default reads only ``hass.config.units.temperature_unit``
+    and ``config.data[FLOW_PLANT_INFO]``, so we can exercise the full C/F
+    truth table without standing up a config entry.
+
+    Args:
+        marker: value for FLOW_LIMITS_TEMPERATURE_UNIT, or None to omit it
+            (legacy entry).
+        system_unit: HA's configured temperature unit.
+        stored: the stored limit value, or None to omit it (fall back to
+            default).
+        fallback: the Celsius DEFAULT_* value used when nothing is stored.
+    """
+    plant_info = {FLOW_PLANT_LIMITS: {}}
+    if stored is not None:
+        plant_info[FLOW_PLANT_LIMITS][CONF_MIN_TEMPERATURE] = stored
+    if marker is not None:
+        plant_info[FLOW_LIMITS_TEMPERATURE_UNIT] = marker
+
+    hass = SimpleNamespace(
+        config=SimpleNamespace(units=SimpleNamespace(temperature_unit=system_unit))
+    )
+    config = SimpleNamespace(data={FLOW_PLANT_INFO: plant_info})
+    return _get_temperature_default(hass, config, CONF_MIN_TEMPERATURE, fallback)
+
+
+class TestGetTemperatureDefaultMatrix:
+    """Exhaustive C/F truth table for _get_temperature_default.
+
+    Three axes fully determine the result:
+      - marker:  None (legacy) | °C | °F   (the stored unit of the value)
+      - system:  °C | °F                    (HA's configured unit)
+      - stored:  present | absent           (absent → fall back to default)
+
+    Stored values are converted only when an explicit marker is present AND it
+    differs from the system unit. Defaults are always Celsius and are converted
+    to the system unit. Legacy entries (no marker) use stored values as-is.
+    """
+
+    # 50°C == 122°F, 50°F == 10°C — chosen so every conversion is a clean int.
+    @pytest.mark.parametrize(
+        ("marker", "system", "stored", "expected", "note"),
+        [
+            # --- stored value present ---
+            (_C, _C, 50, 50, "marker=sys: as-is"),
+            (_C, _F, 50, 122, "C stored, F system: 50C->122F"),
+            (_F, _C, 50, 10, "F stored, C system: 50F->10C"),
+            (_F, _F, 50, 50, "marker=sys: as-is"),
+            (None, _C, 50, 50, "legacy: as-is on metric"),
+            (None, _F, 50, 50, "legacy: as-is on imperial (pre-converted)"),
+            # --- stored value absent -> default (10C) converted to system ---
+            (_C, _C, None, 10, "default 10C on metric"),
+            (_C, _F, None, 50, "default 10C -> 50F"),
+            (_F, _C, None, 10, "default always Celsius -> 10C"),
+            (_F, _F, None, 50, "default 10C -> 50F"),
+            (None, _C, None, 10, "legacy default 10C on metric"),
+            (None, _F, None, 50, "legacy default 10C -> 50F"),
+        ],
+    )
+    def test_matrix(self, marker, system, stored, expected, note):
+        """Every (marker, system, stored) combination yields the right value."""
+        assert _temp_default(marker, system, stored) == expected, note
+
+    def test_round_trip_celsius_to_fahrenheit_and_back(self):
+        """A value stored as °C and read on °F, then re-stored as °F and read
+        on °C, must return to the original — no drift, no double conversion."""
+        # Created on metric (marker=°C), value 32°C.
+        on_imperial = _temp_default(_C, _F, 32)
+        assert on_imperial == 90  # 32°C -> 90°F
+        # Re-stamped as °F (e.g. after a refresh), read back on metric.
+        back_on_metric = _temp_default(_F, _C, on_imperial)
+        assert back_on_metric == 32  # 90°F -> 32°C

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -991,3 +991,220 @@ class TestThresholdImperialDefaults:
         ):
             assert threshold.native_max_value == 100
             assert threshold.native_min_value == -50
+
+
+class TestPreConvertedFahrenheitLimits:
+    """Tests that pre-converted Fahrenheit limits from generate_configentry are not double-converted.
+
+    Covers the double-conversion bug where temperature limits stored in FLOW_PLANT_LIMITS
+    (already converted to Fahrenheit by generate_configentry via display_temp()) were
+    being converted again by _convert_default_temp() in the threshold entity __init__.
+
+    Example bug: OpenPlantbook returns min_temp=7°C, generate_configentry converts to 45°F,
+    but the entity __init__ then treated 45 as Celsius and converted again to 113°F.
+    """
+
+    async def test_preconverted_fahrenheit_limits_not_double_converted(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Temperature thresholds with pre-converted °F values are used as-is."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+
+        from .conftest import (
+            CONF_MAX_SOIL_TEMPERATURE,
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_SOIL_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Simulate limits that are ALREADY in Fahrenheit (as generate_configentry would produce)
+        # OpenPlantbook: min=7°C, max=32°C  →  after display_temp(): min=45°F, max=90°F
+        preconverted_fahrenheit_limits = {
+            CONF_MAX_TEMPERATURE: 90,  # Already 90°F, not 90°C
+            CONF_MIN_TEMPERATURE: 45,  # Already 45°F, not 45°C
+            CONF_MAX_SOIL_TEMPERATURE: 86,  # Already 86°F (30°C)
+            CONF_MIN_SOIL_TEMPERATURE: 50,  # Already 50°F (10°C)
+            # Include other required limits
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # Specify data_source=DOMAIN_PLANTBOOK to indicate values are pre-converted
+        config_data = create_plant_config_data(
+            limits=preconverted_fahrenheit_limits,
+            data_source=DOMAIN_PLANTBOOK,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_preconverted_f",
+            unique_id="test_preconverted_f",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # The values should be used AS-IS, not converted again
+        # Bug behavior: 45°F treated as 45°C → converted to 113°F
+        # Fixed behavior: 45°F stays 45°F
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+        assert plant.max_soil_temperature.native_value == 86
+        assert plant.min_soil_temperature.native_value == 50
+
+        # Unit should still be Fahrenheit
+        assert plant.max_temperature._attr_native_unit_of_measurement == "°F"
+        assert plant.min_temperature._attr_native_unit_of_measurement == "°F"
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_missing_limits_fall_back_to_converted_defaults(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """When limits are missing, fallback defaults are converted from Celsius."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from .conftest import TEST_PLANT_NAME, create_plant_config_data
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Create limits WITHOUT temperature values to test fallback behavior
+        limits_without_temp = {
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+            # Explicitly omit temperature keys to test fallback
+        }
+
+        config_data = create_plant_config_data(limits=limits_without_temp)
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_missing_temp",
+            unique_id="test_missing_temp",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Fallback defaults are in Celsius (from const.py) and SHOULD be converted
+        # DEFAULT_MAX_TEMPERATURE = 40°C → 104°F
+        # DEFAULT_MIN_TEMPERATURE = 10°C → 50°F
+        # DEFAULT_MAX_SOIL_TEMPERATURE = 40°C → 104°F
+        # DEFAULT_MIN_SOIL_TEMPERATURE = 10°C → 50°F
+        assert plant.max_temperature.native_value == 104
+        assert plant.min_temperature.native_value == 50
+        assert plant.max_soil_temperature.native_value == 104
+        assert plant.min_soil_temperature.native_value == 50
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_manual_celsius_limits_converted_when_imperial(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Manual/non-OpenPlantbook Celsius values ARE converted to Fahrenheit."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DATA_SOURCE_MANUAL
+
+        from .conftest import (
+            CONF_MAX_SOIL_TEMPERATURE,
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_SOIL_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Manual entry: user types Celsius values (not pre-converted by generate_configentry)
+        manual_celsius_limits = {
+            CONF_MAX_TEMPERATURE: 32,  # 32°C → should become 90°F
+            CONF_MIN_TEMPERATURE: 7,   # 7°C → should become 45°F
+            CONF_MAX_SOIL_TEMPERATURE: 30,  # 30°C → should become 86°F
+            CONF_MIN_SOIL_TEMPERATURE: 10,  # 10°C → should become 50°F
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # data_source=DATA_SOURCE_MANUAL means values are NOT pre-converted
+        config_data = create_plant_config_data(
+            limits=manual_celsius_limits,
+            data_source=DATA_SOURCE_MANUAL,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_manual_celsius",
+            unique_id="test_manual_celsius",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Manual Celsius values SHOULD be converted to Fahrenheit
+        # 32°C → 90°F, 7°C → 45°F, 30°C → 86°F, 10°C → 50°F
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+        assert plant.max_soil_temperature.native_value == 86
+        assert plant.min_soil_temperature.native_value == 50
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -993,12 +993,14 @@ class TestThresholdImperialDefaults:
             assert threshold.native_min_value == -50
 
 
-class TestPreConvertedFahrenheitLimits:
-    """Tests that pre-converted Fahrenheit limits from generate_configentry are not double-converted.
+class TestTemperatureLimitsUnitHandling:
+    """Tests for temperature limits unit conversion and storage.
 
-    Covers the double-conversion bug where temperature limits stored in FLOW_PLANT_LIMITS
-    (already converted to Fahrenheit by generate_configentry via display_temp()) were
-    being converted again by _convert_default_temp() in the threshold entity __init__.
+    Covers:
+    - The double-conversion bug where pre-converted Fahrenheit limits were converted again
+    - Explicit unit marker behavior (limits_temperature_unit)
+    - Cross-unit conversion when stored unit differs from system unit
+    - Legacy fallback behavior using data_source check
 
     Example bug: OpenPlantbook returns min_temp=7°C, generate_configentry converts to 45°F,
     but the entity __init__ then treated 45 as Celsius and converted again to 113°F.
@@ -1009,9 +1011,8 @@ class TestPreConvertedFahrenheitLimits:
         hass: HomeAssistant,
     ) -> None:
         """Temperature thresholds with pre-converted °F values are used as-is."""
+        from homeassistant.const import UnitOfTemperature
         from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
-
-        from custom_components.plant.const import DOMAIN_PLANTBOOK
 
         from .conftest import (
             CONF_MAX_SOIL_TEMPERATURE,
@@ -1048,10 +1049,10 @@ class TestPreConvertedFahrenheitLimits:
             "min_vpd": 0.4,
         }
 
-        # Specify data_source=DOMAIN_PLANTBOOK to indicate values are pre-converted
+        # New config entries use explicit limits_temperature_unit
         config_data = create_plant_config_data(
             limits=preconverted_fahrenheit_limits,
-            data_source=DOMAIN_PLANTBOOK,
+            limits_temperature_unit=UnitOfTemperature.FAHRENHEIT,
         )
         config_entry = MockConfigEntry(
             domain=DOMAIN,
@@ -1066,9 +1067,7 @@ class TestPreConvertedFahrenheitLimits:
 
         plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
 
-        # The values should be used AS-IS, not converted again
-        # Bug behavior: 45°F treated as 45°C → converted to 113°F
-        # Fixed behavior: 45°F stays 45°F
+        # The values should be used AS-IS since stored unit matches system unit
         assert plant.max_temperature.native_value == 90
         assert plant.min_temperature.native_value == 45
         assert plant.max_soil_temperature.native_value == 86
@@ -1145,7 +1144,7 @@ class TestPreConvertedFahrenheitLimits:
         """Manual/non-OpenPlantbook Celsius values ARE converted to Fahrenheit."""
         from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
-        from custom_components.plant.const import DATA_SOURCE_MANUAL
+        from homeassistant.const import UnitOfTemperature
 
         from .conftest import (
             CONF_MAX_SOIL_TEMPERATURE,
@@ -1158,8 +1157,9 @@ class TestPreConvertedFahrenheitLimits:
 
         hass.config.units = US_CUSTOMARY_SYSTEM
 
-        # Manual entry: user types Celsius values (not pre-converted by generate_configentry)
-        manual_celsius_limits = {
+        # Config entry with Celsius limits and explicit Celsius unit marker
+        # These need to be converted to Fahrenheit for display
+        celsius_limits = {
             CONF_MAX_TEMPERATURE: 32,  # 32°C → should become 90°F
             CONF_MIN_TEMPERATURE: 7,   # 7°C → should become 45°F
             CONF_MAX_SOIL_TEMPERATURE: 30,  # 30°C → should become 86°F
@@ -1180,16 +1180,16 @@ class TestPreConvertedFahrenheitLimits:
             "min_vpd": 0.4,
         }
 
-        # data_source=DATA_SOURCE_MANUAL means values are NOT pre-converted
+        # Explicit Celsius unit - values will be converted to Fahrenheit
         config_data = create_plant_config_data(
-            limits=manual_celsius_limits,
-            data_source=DATA_SOURCE_MANUAL,
+            limits=celsius_limits,
+            limits_temperature_unit=UnitOfTemperature.CELSIUS,
         )
         config_entry = MockConfigEntry(
             domain=DOMAIN,
             data=config_data,
-            entry_id="test_manual_celsius",
-            unique_id="test_manual_celsius",
+            entry_id="test_celsius_to_f",
+            unique_id="test_celsius_to_f",
             title=TEST_PLANT_NAME,
         )
         config_entry.add_to_hass(hass)
@@ -1198,7 +1198,7 @@ class TestPreConvertedFahrenheitLimits:
 
         plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
 
-        # Manual Celsius values SHOULD be converted to Fahrenheit
+        # Celsius values converted to Fahrenheit since system is imperial
         # 32°C → 90°F, 7°C → 45°F, 30°C → 86°F, 10°C → 50°F
         assert plant.max_temperature.native_value == 90
         assert plant.min_temperature.native_value == 45
@@ -1208,3 +1208,203 @@ class TestPreConvertedFahrenheitLimits:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
 
+    async def test_legacy_data_source_fallback(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Legacy config entries without explicit unit marker use data_source fallback."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DOMAIN_PLANTBOOK
+
+        from .conftest import (
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Legacy config: no limits_temperature_unit, uses data_source=DOMAIN_PLANTBOOK
+        # Values are already in Fahrenheit (pre-converted by old generate_configentry)
+        legacy_limits = {
+            CONF_MAX_TEMPERATURE: 90,  # Already °F
+            CONF_MIN_TEMPERATURE: 45,  # Already °F
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_soil_temperature": 86,
+            "min_soil_temperature": 50,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # No limits_temperature_unit - falls back to checking data_source
+        config_data = create_plant_config_data(
+            limits=legacy_limits,
+            data_source=DOMAIN_PLANTBOOK,
+            # Note: no limits_temperature_unit - legacy behavior
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_legacy",
+            unique_id="test_legacy",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Legacy DOMAIN_PLANTBOOK values are used as-is (pre-converted)
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_metric_system_with_celsius_marker_unchanged(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Celsius values with explicit Celsius marker are unchanged on metric systems."""
+        from homeassistant.const import UnitOfTemperature
+        from homeassistant.util.unit_system import METRIC_SYSTEM
+
+        from .conftest import (
+            CONF_MAX_SOIL_TEMPERATURE,
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_SOIL_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = METRIC_SYSTEM
+
+        celsius_limits = {
+            CONF_MAX_TEMPERATURE: 32,
+            CONF_MIN_TEMPERATURE: 7,
+            CONF_MAX_SOIL_TEMPERATURE: 30,
+            CONF_MIN_SOIL_TEMPERATURE: 10,
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        config_data = create_plant_config_data(
+            limits=celsius_limits,
+            limits_temperature_unit=UnitOfTemperature.CELSIUS,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_metric_celsius",
+            unique_id="test_metric_celsius",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Celsius values unchanged on metric system
+        assert plant.max_temperature.native_value == 32
+        assert plant.min_temperature.native_value == 7
+        assert plant.max_soil_temperature.native_value == 30
+        assert plant.min_soil_temperature.native_value == 10
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_legacy_manual_values_used_as_system_unit(
+        self,
+        hass: HomeAssistant,
+    ) -> None:
+        """Legacy manual config entries use stored values as-is (assumed system unit)."""
+        from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
+
+        from custom_components.plant.const import DATA_SOURCE_DEFAULT
+
+        from .conftest import (
+            CONF_MAX_TEMPERATURE,
+            CONF_MIN_TEMPERATURE,
+            TEST_PLANT_NAME,
+            create_plant_config_data,
+        )
+
+        hass.config.units = US_CUSTOMARY_SYSTEM
+
+        # Legacy manual config: no limits_temperature_unit
+        # Values are assumed to be in the user's system unit (°F here)
+        manual_fahrenheit_limits = {
+            CONF_MAX_TEMPERATURE: 90,  # User typed 90°F, stays 90
+            CONF_MIN_TEMPERATURE: 45,  # User typed 45°F, stays 45
+            "max_moisture": 60,
+            "min_moisture": 20,
+            "max_conductivity": 2000,
+            "min_conductivity": 350,
+            "max_illuminance": 7000,
+            "min_illuminance": 2000,
+            "max_humidity": 85,
+            "min_humidity": 30,
+            "max_dli": 9.0,
+            "min_dli": 4.0,
+            "max_co2": 2000,
+            "min_co2": 400,
+            "max_soil_temperature": 86,  # User typed 86°F, stays 86
+            "min_soil_temperature": 50,  # User typed 50°F, stays 50
+            "max_vpd": 1.6,
+            "min_vpd": 0.4,
+        }
+
+        # No limits_temperature_unit - legacy behavior assumes system unit
+        config_data = create_plant_config_data(
+            limits=manual_fahrenheit_limits,
+            data_source=DATA_SOURCE_DEFAULT,
+        )
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=config_data,
+            entry_id="test_legacy_manual",
+            unique_id="test_legacy_manual",
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+
+        # Legacy manual values used as-is (assumed to be in user's system unit)
+        assert plant.max_temperature.native_value == 90
+        assert plant.min_temperature.native_value == 45
+        assert plant.max_soil_temperature.native_value == 86
+        assert plant.min_soil_temperature.native_value == 50
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
Takes over and completes #463 by @sirwolfgang, which fixed the Fahrenheit double-conversion of temperature limits but stalled on review. Zane's original commits are preserved with authorship, and he is credited as co-author on the follow-up fix.

## Problem

Temperature thresholds from OpenPlantbook were double-converted on imperial systems:
1. `generate_configentry` converts 7°C → 45°F via `display_temp()`
2. `number.py` treated 45 as Celsius and converted again → 113°F

## Solution (from #463)

Store the unit temperature limits are saved in (`limits_temperature_unit`) and convert on read only when the stored unit differs from the system unit. Legacy entries without the marker use stored values as-is.

## What this PR adds on top of #463

Resolves the two review findings and the lint failure:

- **Stale unit marker after an OpenPlantbook refresh.** `refresh_plant_from_openplantbook` re-runs `generate_configentry` (which converts limits to the system unit and stamps the marker) but previously persisted only the limits — leaving a stale marker. After a later unit switch this re-converted already-converted values, reintroducing the double conversion. The marker is now persisted alongside the limits, coupled to the value `generate_configentry` produced.
- **Misleading `data_source` comments.** Comments in `number.py` context, `conftest.py`, and `test_number.py` claimed the legacy fallback inspects `data_source`; it never does — it returns stored values as-is. Comments corrected and `test_legacy_data_source_fallback` renamed.
- **Lint.** Applied Black formatting (CI Lint was failing).

## Testing

All 326 tests pass.

- `TestGetTemperatureLimitsUnitHandling` (from #463) — end-to-end coverage of the original bug.
- **`TestGetTemperatureDefaultMatrix`** — exhaustive `marker × system × stored` truth table (12 cases) plus a C→F→C round-trip, exercising `_get_temperature_default` directly so every C/F permutation is locked down.
- **`test_force_refresh_updates_temperature_unit_marker`** — regression test for the refresh-marker fix (verified to fail without it).

Closes #463 (superseded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)