### PR TITLE
chore: release 2026.6.1-beta1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.6.0"
+  "version": "2026.6.1-beta1"
 }


### PR DESCRIPTION
Beta release bumping `manifest.json` to **2026.6.1-beta1**. CI will tag and publish the pre-release on merge.

## ✨ What's new in 2026.6.1-beta1

### 🐛 Bug fixes

- **Fixed double-converted temperature limits on Fahrenheit systems (#470, #463).**
  OpenPlantbook thresholds were converted to °F twice — e.g. a 7 °C minimum became 113 °F instead of 45 °F. Limits now carry an explicit unit marker, are converted exactly once on read, and stay correct across a species/force refresh and even an HA unit-system switch. Legacy entries are unaffected. Thanks to @sirwolfgang for the report and original fix.

- **Fixed plants getting stuck in a "problem" state with wide-range sensors (#466, #465).**
  The problem-state hysteresis band was computed from the full min↔max span, which over-inflated the low-side margin for sensors like conductivity, CO₂ and illuminance — a reading that had clearly recovered above its minimum could stay flagged as a problem indefinitely (e.g. conductivity min 350, reading 386, but not clearing until 432). The band is now anchored to the threshold actually being crossed, capped by the OK span, and uses the threshold magnitude so sub-zero minimums behave correctly.

### 📝 Docs & maintenance

- Added `MISSING_SENSORS.md` and clarified the `*_status` / trigger / `problems` attributes and hysteresis behaviour in TIPS (#469).
- Bumped `codecov/codecov-action` v6 → v7 in CI (#459).

---

> ⚠️ **Imperial (°F) users:** as with the earlier threshold fix, temperature limits set before this release are not auto-migrated — verify your min/max temperature thresholds look right after upgrading, and refresh the species if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)