### PR TITLE
ci: guard manifest pins against HA-core constraints

### DIFF
--- a/scripts/check_manifest_ha_compat.py
+++ b/scripts/check_manifest_ha_compat.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Check manifest pins against Home Assistant core's pinned constraints.
+
+For any manifest requirement whose package is also pinned by Home Assistant
+core (``homeassistant/package_constraints.txt``), the manifest pin must be
+satisfied by HA's version — otherwise HA would override or reject our pin at
+runtime. Packages not present in HA core are ignored.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+# importlib.resources is the standard modern API; this project targets
+# Python 3.12+, so the 3.7-backcompat warning does not apply.
+from importlib.resources import (  # nosemgrep: python.lang.compatibility.python37.python37-compatibility-importlib2
+    files,
+)
+from pathlib import Path
+
+from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
+
+DEFAULT_MANIFEST = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components"
+    / "plant"
+    / "manifest.json"
+)
+
+
+@dataclass(frozen=True)
+class Mismatch:
+    """A manifest pin that conflicts with HA core's constraint."""
+
+    requirement: str
+    ha_version: str
+
+
+def parse_constraints(text: str) -> dict[str, str]:
+    """Parse ``name==version`` lines from an HA constraints file.
+
+    Comments, blank lines, and any line that is not a single ``==`` pin are
+    ignored. Names are canonicalised so lookups are normalisation-insensitive.
+    """
+    constraints: dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        try:
+            req = Requirement(line)
+        except Exception:  # noqa: BLE001 - skip anything non-standard
+            continue
+        specs = list(req.specifier)
+        if len(specs) == 1 and specs[0].operator == "==":
+            constraints[canonicalize_name(req.name)] = specs[0].version
+    return constraints
+
+
+def find_constraint_mismatches(
+    requirements: list[str],
+    constraints: dict[str, str],
+) -> list[Mismatch]:
+    """Return manifest requirements whose pin conflicts with HA core.
+
+    Only requirements whose canonical name appears in ``constraints`` are
+    considered; a conflict is when HA's pinned version does not satisfy our
+    specifier.
+    """
+    mismatches: list[Mismatch] = []
+    for raw in requirements:
+        req = Requirement(raw)
+        ha_version = constraints.get(canonicalize_name(req.name))
+        if ha_version is None:
+            continue
+        if not req.specifier.contains(ha_version, prereleases=True):
+            mismatches.append(Mismatch(requirement=raw, ha_version=ha_version))
+    return mismatches
+
+
+def ha_core_constraints() -> dict[str, str] | None:
+    """Return HA core's pinned constraints, or ``None`` if unavailable."""
+    try:
+        text = (
+            files("homeassistant")
+            .joinpath("package_constraints.txt")
+            .read_text(encoding="utf-8")
+        )
+    except (FileNotFoundError, ModuleNotFoundError, OSError):
+        return None
+    return parse_constraints(text)
+
+
+def manifest_requirements(manifest_path: Path = DEFAULT_MANIFEST) -> list[str]:
+    """Return the raw requirement strings from the manifest."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    return list(manifest.get("requirements", []))

--- a/tests/test_manifest_ha_compat.py
+++ b/tests/test_manifest_ha_compat.py
@@ -2,15 +2,9 @@
 
 from __future__ import annotations
 
-import sys
-from pathlib import Path
-
 import pytest
 
-# The checker lives in scripts/, which is not a package on the path.
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
-
-from check_manifest_ha_compat import (  # noqa: E402
+from scripts.check_manifest_ha_compat import (
     Mismatch,
     find_constraint_mismatches,
     ha_core_constraints,

--- a/tests/test_manifest_ha_compat.py
+++ b/tests/test_manifest_ha_compat.py
@@ -1,0 +1,95 @@
+"""Tests for the manifest <-> HA-core compatibility guard."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# The checker lives in scripts/, which is not a package on the path.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_manifest_ha_compat import (  # noqa: E402
+    Mismatch,
+    find_constraint_mismatches,
+    ha_core_constraints,
+    manifest_requirements,
+    parse_constraints,
+)
+
+
+def test_parse_constraints_extracts_exact_pins():
+    """Only single == pins are parsed; comments and blanks are ignored."""
+    text = (
+        "# generated, do not edit\n"
+        "aiohttp==3.13.5\n"
+        "\n"
+        "async-timeout==4.0.3\n"
+        "voluptuous>=0.12\n"  # not an exact pin -> skipped
+    )
+    assert parse_constraints(text) == {
+        "aiohttp": "3.13.5",
+        "async-timeout": "4.0.3",
+    }
+
+
+def test_no_mismatch_when_package_absent_from_ha():
+    """Packages HA core does not pin are ignored."""
+    mismatches = find_constraint_mismatches(
+        ["some-private-pkg==0.6.1"],
+        {"aiohttp": "3.13.5"},
+    )
+    assert mismatches == []
+
+
+def test_no_mismatch_when_ha_version_satisfies_specifier():
+    """A range that contains HA's pinned version is fine (the async-timeout case)."""
+    mismatches = find_constraint_mismatches(
+        ["async-timeout>=4.0.2"],
+        {"async-timeout": "4.0.3"},
+    )
+    assert mismatches == []
+
+
+def test_mismatch_detected_when_pin_conflicts_with_ha():
+    """An exact pin that differs from HA's pinned version is flagged."""
+    mismatches = find_constraint_mismatches(
+        ["async-timeout==4.0.2"],
+        {"async-timeout": "4.0.3"},
+    )
+    assert mismatches == [Mismatch("async-timeout==4.0.2", "4.0.3")]
+
+
+def test_mismatch_when_range_excludes_ha_version():
+    """A range that excludes HA's pinned version is flagged."""
+    mismatches = find_constraint_mismatches(
+        ["async-timeout<4.0.0"],
+        {"async-timeout": "4.0.3"},
+    )
+    assert mismatches == [Mismatch("async-timeout<4.0.0", "4.0.3")]
+
+
+def test_mismatch_uses_canonicalized_names():
+    """Name normalisation (underscore/case) does not hide a conflict."""
+    mismatches = find_constraint_mismatches(
+        ["Foo_Bar==1.0"],
+        {"foo-bar": "2.0"},
+    )
+    assert mismatches == [Mismatch("Foo_Bar==1.0", "2.0")]
+
+
+def test_real_manifest_pins_are_compatible_with_installed_ha():
+    """The actual manifest must not conflict with the installed HA core.
+
+    Runs against whatever HA the test matrix installed (the 'latest' leg checks
+    the latest HA release). Skips if the constraints file is unavailable.
+    """
+    constraints = ha_core_constraints()
+    if constraints is None:
+        pytest.skip("Home Assistant package_constraints.txt not available")
+    mismatches = find_constraint_mismatches(manifest_requirements(), constraints)
+    assert not mismatches, (
+        "manifest.json pins conflict with Home Assistant core constraints: "
+        + ", ".join(f"{m.requirement} (HA pins {m.ha_version})" for m in mismatches)
+    )


### PR DESCRIPTION
Replicates the HA-core compatibility guard from `home-assistant-openplantbook` (#89) into this repo. Unlike there, it's an **active** check here: the only runtime dep, `async-timeout`, is pinned by Home Assistant core.

## What it does
- `scripts/check_manifest_ha_compat.py` — reads HA core's shipped `package_constraints.txt` and, for each `manifest.json` requirement whose package HA core also pins, asserts HA's version satisfies our specifier. Packages not in HA core are ignored.
- `tests/test_manifest_ha_compat.py` — conflict-detection unit tests (exact-pin conflict, range-excludes-HA, name canonicalisation) plus a real test asserting the actual manifest is compatible with the installed HA. Runs in the existing test matrix, so the `latest` leg checks against the latest HA release.

Today: HA core pins `async-timeout==4.0.3`, which satisfies our `>=4.0.2` ✅. The guard will fail CI if a future manifest edit pins something HA core would override/reject.

## Testing
**333 tests pass** locally (7 new). No new workflow — the test runs in the existing test job. `importlib.resources` semgrep finding suppressed inline (3.12+ project).

Note: the PyPI-freshness half of #89 is intentionally omitted here — plant's only dep is a range, so there's nothing to watch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)