### PR TITLE
fix: add missing strings.json label for moisture_grace_period

### DIFF
--- a/custom_components/plant/strings.json
+++ b/custom_components/plant/strings.json
@@ -161,6 +161,7 @@
           "humidity_trigger": "Use air humidity as problem trigger",
           "conductivity_trigger": "Use conductivity as problem trigger",
           "moisture_trigger": "Use soil moisture as problem trigger",
+          "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Use temperature as problem trigger",
           "co2_trigger": "Use CO2 as problem trigger",
           "soil_temperature_trigger": "Use soil temperature as problem trigger",


### PR DESCRIPTION
Audit prompted by the HA epic on missing flow-form translations ([home-assistant/epics#76], pylint checker [core#171705]).

## Finding
The new HA core pylint rule (`config-flow-field-not-translated` / `options-flow-field-not-translated`) requires every voluptuous field in a config/options flow step to have a `…step.<step>.data.<field>` entry in **`strings.json`**.

The options `plant_properties` flow includes a `moisture_grace_period` field whose label existed **only in `translations/en.json`**, not in `strings.json`. So the runtime label worked, but the source-of-truth file the checker reads was missing it — it would be flagged.

## Fix
Added `moisture_grace_period` to `strings.json` (`options.step.plant_properties.data`), mirroring the existing en.json label. After the fix, strings.json and en.json have **identical** field coverage across every step.

## Full audit (no other gaps)
Checked every flow step in both integrations against the rule:

- **plant** — config: `user`, `select_species`, `sensors`, `limits`; options: `plant_properties`, `replace_sensor` (init is a menu). All fields covered after this fix.
- **openplantbook** — config: `user`, `upload`; options: `init`. **All fields already covered, no change needed.**
- No subentry flows in either integration.

(`check_days` remains in the options translations intentionally — it's a native HA option accepted-but-ignored in `__init__.py`, not a flow field, so it's outside the rule.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)