### PR TITLE
ci: expand ruff to HA-aligned ruleset + flow-translation coverage test

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -39,7 +39,7 @@ from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
-from . import group as group  # noqa: F401 - needed for HA group discovery
+from . import group as group
 from .config_flow import update_plant_options
 from .const import (
     ATTR_BRIGHTNESS,
@@ -158,6 +158,7 @@ def _async_find_matching_config_entry(hass: HomeAssistant) -> ConfigEntry | None
     for entry in hass.config_entries.async_entries(DOMAIN):
         if entry.source == SOURCE_IMPORT:
             return entry
+    return None
 
 
 async def async_migrate_plant(hass: HomeAssistant, plant_id: str, config: dict) -> None:
@@ -271,7 +272,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             try:
                 test = hass.states.get(new_sensor)
             except AttributeError:
-                _LOGGER.error("New sensor entity %s not found", new_sensor)
+                _LOGGER.exception("New sensor entity %s not found", new_sensor)
                 return False
             if test is None:
                 _LOGGER.error("New sensor entity %s not found", new_sensor)
@@ -285,7 +286,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             new_sensor,
         )
         matched_meter.replace_external_sensor(new_sensor)
-        return
+        return None
 
     hass.services.async_register(
         DOMAIN,
@@ -397,15 +398,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Skip internal settings keys
             if entry_id.startswith("_") or entry_id.endswith("_store"):
                 continue
-            if isinstance(hass.data[DOMAIN][entry_id], dict):
-                if len(hass.data[DOMAIN][entry_id]) == 0:
-                    _LOGGER.debug("Removing empty entry %s", entry_id)
-                    del hass.data[DOMAIN][entry_id]
+            if (
+                isinstance(hass.data[DOMAIN][entry_id], dict)
+                and len(hass.data[DOMAIN][entry_id]) == 0
+            ):
+                _LOGGER.debug("Removing empty entry %s", entry_id)
+                del hass.data[DOMAIN][entry_id]
 
         # Check if only settings keys remain (no actual plant entries)
         remaining_plant_entries = [
             k
-            for k in hass.data[DOMAIN].keys()
+            for k in hass.data[DOMAIN]
             if not k.startswith("_") and not k.endswith("_store")
         ]
         if len(remaining_plant_entries) == 0:
@@ -720,15 +723,16 @@ class PlantDevice(RestoreEntity):
             return False
         try:
             has_state = self.hass.states.get(sensor.entity_id) is not None
+        except (AttributeError, TypeError) as e:
+            _LOGGER.debug("Error checking sensor availability for %s: %s", sensor, e)
+            return False
+        else:
             if not has_state:
                 _LOGGER.debug(
                     "Sensor %s has no hass state (disabled or not loaded), skipping",
                     sensor.entity_id,
                 )
             return has_state
-        except (AttributeError, TypeError) as e:
-            _LOGGER.debug("Error checking sensor availability for %s: %s", sensor, e)
-            return False
 
     def _sensor_info(self, attr_name, sensor, max_entity, min_entity) -> dict | None:
         """Build websocket info dict for a single sensor, or None if unavailable."""

--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -259,24 +259,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             _LOGGER.warning(
                 "Refuse to update non-%s entities: %s", DOMAIN, meter_entity
             )
-            return False
+            return
         if (
             new_sensor
             and new_sensor != ""
             and not new_sensor.startswith(f"{SENSOR_DOMAIN}.")
         ):
             _LOGGER.warning("%s is not a sensor", new_sensor)
-            return False
+            return
 
         if new_sensor and new_sensor != "":
             try:
                 test = hass.states.get(new_sensor)
             except AttributeError:
                 _LOGGER.exception("New sensor entity %s not found", new_sensor)
-                return False
+                return
             if test is None:
                 _LOGGER.error("New sensor entity %s not found", new_sensor)
-                return False
+                return
         else:
             new_sensor = None
 
@@ -286,7 +286,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             new_sensor,
         )
         matched_meter.replace_external_sensor(new_sensor)
-        return None
+        return
 
     hass.services.async_register(
         DOMAIN,

--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -542,7 +542,7 @@ class PlantConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             try:
                 entity_picture = f"{get_url(self.hass, require_current_request=True)}{urllib.parse.quote(entity_picture)}"
             except NoURLAvailableError:
-                _LOGGER.error(
+                _LOGGER.exception(
                     "No internal or external url found. Please configure these in HA General Settings"
                 )
                 entity_picture = ""

--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -246,14 +246,14 @@ class PlantHelper:
 
         try:
             session = async_get_clientsession(self.hass)
-            async with timeout(IMAGE_VALIDATION_TIMEOUT):
-                async with session.head(url, allow_redirects=True) as response:
-                    if response.status == 200:
-                        return True
-                    _LOGGER.warning(
-                        "Image URL %s returned status %s", url, response.status
-                    )
-                    return False
+            async with (
+                timeout(IMAGE_VALIDATION_TIMEOUT),
+                session.head(url, allow_redirects=True) as response,
+            ):
+                if response.status == 200:
+                    return True
+                _LOGGER.warning("Image URL %s returned status %s", url, response.status)
+                return False
         except TimeoutError:
             _LOGGER.warning("Image URL validation timed out for %s", url)
             return False

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -997,7 +997,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         # Check if unit contains 'mol' (covers µmol/s⋅m², mol/s⋅m², etc.)
         return "mol" in unit.lower()
 
-    def ppfd(self, value: float | int | str) -> float | str:
+    def ppfd(self, value: float | int | str | None) -> float | None:
         """
         Returns PPFD value - either passed through or converted from lux.
 

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -263,12 +263,10 @@ class PlantCurrentStatus(RestoreSensor):
     @property
     def extra_state_attributes(self) -> dict:
         if self._external_sensor:
-            attributes = {
+            return {
                 "external_sensor": self.external_sensor,
-                # "history_max": self._history.max,
-                # "history_min": self._history.min,
             }
-            return attributes
+        return {}
 
     @property
     def external_sensor(self) -> str:
@@ -881,18 +879,20 @@ class PlantCurrentVpd(RestoreSensor):
         """Restore state and subscribe to temperature and humidity changes."""
         await super().async_added_to_hass()
 
-        if state := await self.async_get_last_state():
-            if state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                try:
-                    self._attr_native_value = float(state.state)
-                except (ValueError, TypeError):
-                    _LOGGER.debug(
-                        "Ignoring non-numeric restored value for %s: %s",
-                        self.entity_id,
-                        state.state,
-                    )
-                else:
-                    self._restored_value_active = True
+        if (state := await self.async_get_last_state()) and state.state not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
+            try:
+                self._attr_native_value = float(state.state)
+            except (ValueError, TypeError):
+                _LOGGER.debug(
+                    "Ignoring non-numeric restored value for %s: %s",
+                    self.entity_id,
+                    state.state,
+                )
+            else:
+                self._restored_value_active = True
 
         # Track temperature sensor state changes
         if self._plant.sensor_temperature is not None:
@@ -1008,7 +1008,7 @@ class PlantCurrentPpfd(PlantCurrentStatus):
         The conversion factor is configurable per plant to account for different
         light sources (sunlight ~0.0185, LED grow lights ~0.014-0.020, HPS ~0.013).
         """
-        if value is None or value == STATE_UNAVAILABLE or value == STATE_UNKNOWN:
+        if value is None or value in (STATE_UNAVAILABLE, STATE_UNKNOWN):
             return None
 
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,15 +57,33 @@ target-version = "py312"
 line-length = 88
 
 [tool.ruff.lint]
+# Aligned with the rule groups Home Assistant core enforces via ruff. The
+# HA-specific *pylint* plugins (type-hint/layout/translation checks) live in
+# the core repo and aren't usable here, so this is the portable equivalent.
 select = [
     "E",      # pycodestyle errors
     "W",      # pycodestyle warnings
     "F",      # pyflakes
     "I",      # isort
     "UP",     # pyupgrade
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "SIM",    # flake8-simplify
+    "RET",    # flake8-return
+    "RUF",    # ruff-specific rules
+    "ASYNC",  # flake8-async (blocking calls in async code)
+    "PTH",    # flake8-use-pathlib
+    "LOG",    # flake8-logging
+    "G",      # flake8-logging-format
+    "T20",    # flake8-print
+    "INP",    # flake8-no-pep420 (missing __init__)
+    "TRY",    # tryceratops
 ]
 ignore = [
-    "E501",   # line too long (handled by black)
+    "E501",    # line too long (handled by black)
+    "TRY003",  # long messages in exceptions (HA core disables this too)
+    "RUF002",  # ambiguous unicode in docstrings (intentional, e.g. « » °)
+    "RUF003",  # ambiguous unicode in comments (intentional)
 ]
 
 [tool.ruff.lint.isort]
@@ -74,3 +92,4 @@ combine-as-imports = true
 
 [tool.ruff.lint.per-file-ignores]
 "tests/*" = ["E402"]  # Allow imports not at top of file in tests
+"scripts/*" = ["T201"]  # CLI helper scripts print to stdout by design

--- a/scripts/check_manifest_ha_compat.py
+++ b/scripts/check_manifest_ha_compat.py
@@ -51,7 +51,7 @@ def parse_constraints(text: str) -> dict[str, str]:
             continue
         try:
             req = Requirement(line)
-        except Exception:  # noqa: BLE001 - skip anything non-standard
+        except Exception:
             continue
         specs = list(req.specifier)
         if len(specs) == 1 and specs[0].operator == "==":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -277,7 +277,7 @@ def mock_openplantbook_services() -> Generator[MagicMock, None, None]:
                 return await mock_search(
                     domain, service, service_data, blocking, return_response
                 )
-            elif service == "get":
+            if service == "get":
                 return await mock_get(
                     domain, service, service_data, blocking, return_response
                 )
@@ -287,19 +287,21 @@ def mock_openplantbook_services() -> Generator[MagicMock, None, None]:
         """Mock image URL validation - always return True for test URLs."""
         return url is not None and url != ""
 
-    with patch(
-        "homeassistant.core.ServiceRegistry.async_services",
-        return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
-    ):
-        with patch(
+    with (
+        patch(
+            "homeassistant.core.ServiceRegistry.async_services",
+            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+        ),
+        patch(
             "homeassistant.core.ServiceRegistry.async_call",
             side_effect=mock_service_call,
-        ):
-            with patch(
-                "custom_components.plant.plant_helpers.PlantHelper.validate_image_url",
-                mock_validate_image_url,
-            ):
-                yield
+        ),
+        patch(
+            "custom_components.plant.plant_helpers.PlantHelper.validate_image_url",
+            mock_validate_image_url,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -326,7 +328,7 @@ def mock_openplantbook_with_dli() -> Generator[MagicMock, None, None]:
                 return await mock_search(
                     domain, service, service_data, blocking, return_response
                 )
-            elif service == "get":
+            if service == "get":
                 return await mock_get(
                     domain, service, service_data, blocking, return_response
                 )
@@ -335,19 +337,21 @@ def mock_openplantbook_with_dli() -> Generator[MagicMock, None, None]:
     async def mock_validate_image_url(self, url):
         return url is not None and url != ""
 
-    with patch(
-        "homeassistant.core.ServiceRegistry.async_services",
-        return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
-    ):
-        with patch(
+    with (
+        patch(
+            "homeassistant.core.ServiceRegistry.async_services",
+            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+        ),
+        patch(
             "homeassistant.core.ServiceRegistry.async_call",
             side_effect=mock_service_call,
-        ):
-            with patch(
-                "custom_components.plant.plant_helpers.PlantHelper.validate_image_url",
-                mock_validate_image_url,
-            ):
-                yield
+        ),
+        patch(
+            "custom_components.plant.plant_helpers.PlantHelper.validate_image_url",
+            mock_validate_image_url,
+        ),
+    ):
+        yield
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -621,7 +621,7 @@ class TestConfigFlowLimitsStep:
         assert result["step_id"] == "limits"
 
         # Check that the schema only contains moisture thresholds (not temperature, etc.)
-        schema_keys = [str(k) for k in result["data_schema"].schema.keys()]
+        schema_keys = [str(k) for k in result["data_schema"].schema]
         assert CONF_MAX_MOISTURE in schema_keys
         assert CONF_MIN_MOISTURE in schema_keys
         # Temperature thresholds should NOT be present
@@ -660,7 +660,7 @@ class TestConfigFlowLimitsStep:
 
         assert result["step_id"] == "limits"
 
-        schema_keys = [str(k) for k in result["data_schema"].schema.keys()]
+        schema_keys = [str(k) for k in result["data_schema"].schema]
         assert CONF_MAX_ILLUMINANCE in schema_keys
         assert CONF_MIN_ILLUMINANCE in schema_keys
         assert CONF_MAX_DLI in schema_keys
@@ -694,7 +694,7 @@ class TestConfigFlowLimitsStep:
 
         assert result["step_id"] == "limits"
 
-        schema_keys = [str(k) for k in result["data_schema"].schema.keys()]
+        schema_keys = [str(k) for k in result["data_schema"].schema]
         # All thresholds should be present
         assert CONF_MAX_MOISTURE in schema_keys
         assert CONF_MAX_TEMPERATURE in schema_keys

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1191,25 +1191,27 @@ class TestPlantDevice:
         # Mock DLI sensor to have a low last_period value
         # min_dli is 2, so set last_period to 1 (below threshold)
         mock_attrs = {"last_period": 1.0}
-        with patch.object(
-            type(plant.dli),
-            "extra_state_attributes",
-            new_callable=PropertyMock,
-            return_value=mock_attrs,
-        ):
-            with patch.object(
+        with (
+            patch.object(
+                type(plant.dli),
+                "extra_state_attributes",
+                new_callable=PropertyMock,
+                return_value=mock_attrs,
+            ),
+            patch.object(
                 type(plant.dli),
                 "native_value",
                 new_callable=PropertyMock,
                 return_value=1.0,
-            ):
-                with patch.object(
-                    type(plant.dli),
-                    "state",
-                    new_callable=PropertyMock,
-                    return_value="1.0",
-                ):
-                    plant.update()
+            ),
+            patch.object(
+                type(plant.dli),
+                "state",
+                new_callable=PropertyMock,
+                return_value="1.0",
+            ),
+        ):
+            plant.update()
 
         assert plant.dli_status == STATE_LOW
         assert plant.state == STATE_PROBLEM
@@ -1238,25 +1240,27 @@ class TestPlantDevice:
         # Mock DLI sensor to have a high last_period value
         # max_dli is 30, so set last_period to 40 (above threshold)
         mock_attrs = {"last_period": 40.0}
-        with patch.object(
-            type(plant.dli),
-            "extra_state_attributes",
-            new_callable=PropertyMock,
-            return_value=mock_attrs,
-        ):
-            with patch.object(
+        with (
+            patch.object(
+                type(plant.dli),
+                "extra_state_attributes",
+                new_callable=PropertyMock,
+                return_value=mock_attrs,
+            ),
+            patch.object(
                 type(plant.dli),
                 "native_value",
                 new_callable=PropertyMock,
                 return_value=40.0,
-            ):
-                with patch.object(
-                    type(plant.dli),
-                    "state",
-                    new_callable=PropertyMock,
-                    return_value="40.0",
-                ):
-                    plant.update()
+            ),
+            patch.object(
+                type(plant.dli),
+                "state",
+                new_callable=PropertyMock,
+                return_value="40.0",
+            ),
+        ):
+            plant.update()
 
         assert plant.dli_status == STATE_HIGH
         assert plant.state == STATE_PROBLEM
@@ -1285,25 +1289,27 @@ class TestPlantDevice:
         # Mock DLI sensor to have a normal last_period value
         # min_dli is 2, max_dli is 30, so set last_period to 15 (within threshold)
         mock_attrs = {"last_period": 15.0}
-        with patch.object(
-            type(plant.dli),
-            "extra_state_attributes",
-            new_callable=PropertyMock,
-            return_value=mock_attrs,
-        ):
-            with patch.object(
+        with (
+            patch.object(
+                type(plant.dli),
+                "extra_state_attributes",
+                new_callable=PropertyMock,
+                return_value=mock_attrs,
+            ),
+            patch.object(
                 type(plant.dli),
                 "native_value",
                 new_callable=PropertyMock,
                 return_value=15.0,
-            ):
-                with patch.object(
-                    type(plant.dli),
-                    "state",
-                    new_callable=PropertyMock,
-                    return_value="15.0",
-                ):
-                    plant.update()
+            ),
+            patch.object(
+                type(plant.dli),
+                "state",
+                new_callable=PropertyMock,
+                return_value="15.0",
+            ),
+        ):
+            plant.update()
 
         assert plant.dli_status == STATE_OK
         assert plant.state == STATE_OK
@@ -1397,25 +1403,27 @@ class TestPlantDevice:
 
         # Mock DLI sensor to trigger problem
         mock_attrs = {"last_period": 1.0}  # Below min_dli of 2
-        with patch.object(
-            type(plant.dli),
-            "extra_state_attributes",
-            new_callable=PropertyMock,
-            return_value=mock_attrs,
-        ):
-            with patch.object(
+        with (
+            patch.object(
+                type(plant.dli),
+                "extra_state_attributes",
+                new_callable=PropertyMock,
+                return_value=mock_attrs,
+            ),
+            patch.object(
                 type(plant.dli),
                 "native_value",
                 new_callable=PropertyMock,
                 return_value=1.0,
-            ):
-                with patch.object(
-                    type(plant.dli),
-                    "state",
-                    new_callable=PropertyMock,
-                    return_value="1.0",
-                ):
-                    plant.update()
+            ),
+            patch.object(
+                type(plant.dli),
+                "state",
+                new_callable=PropertyMock,
+                return_value="1.0",
+            ),
+        ):
+            plant.update()
 
         # Verify problem state
         assert plant.dli_status == STATE_LOW

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -127,15 +127,17 @@ class TestPlantHelperGet:
 
         helper = PlantHelper(hass)
         mock_call = AsyncMock(return_value=GET_RESULT_MONSTERA_DELICIOSA)
-        with patch(
-            "homeassistant.core.ServiceRegistry.async_services",
-            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
-        ):
-            with patch(
+        with (
+            patch(
+                "homeassistant.core.ServiceRegistry.async_services",
+                return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+            ),
+            patch(
                 "homeassistant.core.ServiceRegistry.async_call",
                 new=mock_call,
-            ):
-                await helper.openplantbook_get("monstera deliciosa")
+            ),
+        ):
+            await helper.openplantbook_get("monstera deliciosa")
 
         assert mock_call.await_count == 1
         service_data = mock_call.await_args.kwargs["service_data"]
@@ -201,15 +203,17 @@ class TestPlantHelperGet:
         from custom_components.plant.const import DOMAIN_PLANTBOOK
 
         helper = PlantHelper(hass)
-        with patch(
-            "homeassistant.core.ServiceRegistry.async_services",
-            return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
-        ):
-            with patch(
+        with (
+            patch(
+                "homeassistant.core.ServiceRegistry.async_services",
+                return_value={DOMAIN_PLANTBOOK: {"search": None, "get": None}},
+            ),
+            patch(
                 "homeassistant.core.ServiceRegistry.async_call",
                 new=AsyncMock(side_effect=TimeoutError),
-            ):
-                result = await helper.openplantbook_get("monstera deliciosa")
+            ),
+        ):
+            result = await helper.openplantbook_get("monstera deliciosa")
 
         assert result is None
 

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,97 @@
+"""Verify every config/options flow form field is translated.
+
+Mirrors Home Assistant core's flow-translation pylint checks
+(config-flow-field-not-translated / options-flow-field-not-translated): every
+voluptuous field in a flow step must have a ``<flow>.step.<step>.data.<field>``
+entry. We additionally require the same entry in ``translations/en.json`` (what
+HA actually reads at runtime), not just ``strings.json``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from homeassistant import config_entries
+from homeassistant.const import ATTR_NAME
+from homeassistant.core import HomeAssistant
+
+from custom_components.plant.const import ATTR_SEARCH_FOR, ATTR_SPECIES, DOMAIN
+
+COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "plant"
+
+
+def _load(name: str) -> dict:
+    return json.loads((COMPONENT / name).read_text(encoding="utf-8"))
+
+
+def _field_names(data_schema) -> set[str]:
+    """Return the field keys of a voluptuous schema (markers or plain keys)."""
+    return {str(getattr(marker, "schema", marker)) for marker in data_schema.schema}
+
+
+def _translated_keys(translations: dict, flow: str, step: str) -> set[str]:
+    node = translations.get(flow, {}).get("step", {}).get(step, {})
+    keys = set(node.get("data", {}).keys())
+    for section in node.get("sections", {}).values():
+        keys |= set(section.get("data", {}).keys())
+    return keys
+
+
+def _assert_step_translated(flow: str, step: str, data_schema) -> None:
+    fields = _field_names(data_schema)
+    for filename, data in (
+        ("strings.json", _load("strings.json")),
+        ("translations/en.json", _load("translations/en.json")),
+    ):
+        missing = fields - _translated_keys(data, flow, step)
+        assert not missing, (
+            f"{filename}: {flow}.step.{step} is missing data labels for "
+            f"{sorted(missing)}"
+        )
+
+
+async def test_config_flow_fields_translated(
+    hass: HomeAssistant,
+    mock_openplantbook_services,
+) -> None:
+    """Every config flow step's form fields are translated."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+    _assert_step_translated("config", "user", result["data_schema"])
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {ATTR_NAME: "My Monstera", ATTR_SPECIES: "monstera"}
+    )
+    assert result["step_id"] == "select_species"
+    _assert_step_translated("config", "select_species", result["data_schema"])
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {ATTR_SEARCH_FOR: "monstera", ATTR_SPECIES: "monstera deliciosa"},
+    )
+    assert result["step_id"] == "sensors"
+    _assert_step_translated("config", "sensors", result["data_schema"])
+
+    # No sensors selected -> limits step shows every threshold field.
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["step_id"] == "limits"
+    _assert_step_translated("config", "limits", result["data_schema"])
+
+
+async def test_options_flow_fields_translated(
+    hass: HomeAssistant,
+    mock_openplantbook_services,
+    init_integration,
+) -> None:
+    """Every options flow step's form fields are translated."""
+    for step in ("plant_properties", "replace_sensor"):
+        result = await hass.config_entries.options.async_init(init_integration.entry_id)
+        assert result["step_id"] == "init"  # menu, no data fields
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], {"next_step_id": step}
+        )
+        assert result["step_id"] == step
+        _assert_step_translated("options", step, result["data_schema"])


### PR DESCRIPTION
Mirrors the openplantbook change ([#90]) for the plant integration. HA's HA-specific checks are **pylint plugins internal to `homeassistant/core`** (not packaged/usable here), and HA core has migrated most linting to **ruff** — so this adopts the portable equivalent.

## 1. Expanded ruff ruleset (`pyproject.toml`)
Added `B, C4, SIM, RET, RUF, ASYNC, PTH, LOG, G, T20, INP, TRY` (on top of `E,W,F,I,UP`); ignored the noisy ones HA itself disables (`TRY003`) and intentional unicode (`RUF002/003`). `T201` ignored for `scripts/` (CLI tools).

Fixed all resulting findings (mechanical/safe — plant's flows do no file I/O, so no `ASYNC`/`PTH` hotspots like openplantbook had):
- `TRY400`: `_LOGGER.error` → `_LOGGER.exception` in except blocks
- `TRY300`: move the success-path return into an `else` block
- `SIM102/109/117/118` simplifications; `RET503/504` returns; plus auto-fixed `RET505/502/RUF100`
- a few nested-`with` combines in tests (auto-fix)

## 2. Flow-translation coverage test (`tests/test_translations.py`)
Drives the full config flow (`user → select_species → sensors → limits`, with the OPB mock) and both options sub-steps (`plant_properties`, `replace_sensor`), extracts each step's voluptuous fields, and asserts every one has a `data` label in **both `strings.json` and `translations/en.json`**. Verified it fails on a missing field and passes on the real schemas — this is the guard that would have caught the earlier `moisture_grace_period` gap.

## Testing
**335 tests pass** (333 + 2 new). ruff + black clean repo-wide (CI parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)