### PR TITLE
fix: update DLI conversion from mmol to mol for accurate calculations

### DIFF
--- a/custom_components/plant/plant_helpers.py
+++ b/custom_components/plant/plant_helpers.py
@@ -91,7 +91,6 @@ from .const import (
     OPB_INCLUDE_CARE,
     OPB_SEARCH,
     PLANTBOOK_DOMAIN,
-    PPFD_DLI_FACTOR,
     REQUEST_TIMEOUT,
 )
 
@@ -398,14 +397,18 @@ class PlantHelper:
                 0,
             )
             # Prefer pre-computed DLI from openplantbook integration (includes
-            # ratio-based detection). Fall back to mmol × PPFD_DLI_FACTOR.
+            # ratio-based detection). Fall back to mmol / 1000 to convert
+            # daily mmol/m²/d → mol/m²/d.
+            # NOTE: PPFD_DLI_FACTOR is for instantaneous PPFD→hourly DLI
+            # (µmol/s/m² × 3600 / 1000000) and is NOT correct for daily mmol
+            # values which only need a mmol→mol unit conversion (/1000).
             opb_max_dli = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_DLI])
             if opb_max_dli is not None:
                 max_dli = round(float(opb_max_dli), 1)
             else:
                 opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MAX_MMOL])
                 if opb_mmol:
-                    max_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR, 1)
+                    max_dli = round(float(opb_mmol) / 1000, 1)
                 else:
                     max_dli = DEFAULT_MAX_DLI
             opb_min_dli = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_DLI])
@@ -414,7 +417,7 @@ class PlantHelper:
             else:
                 opb_mmol = opb_plant.get(CONF_PLANTBOOK_MAPPING[CONF_MIN_MMOL])
                 if opb_mmol:
-                    min_dli = round(float(opb_mmol) * PPFD_DLI_FACTOR, 1)
+                    min_dli = round(float(opb_mmol) / 1000, 1)
                 else:
                     min_dli = DEFAULT_MIN_DLI
             max_conductivity = _to_int(

--- a/tests/test_plant_helpers.py
+++ b/tests/test_plant_helpers.py
@@ -377,13 +377,12 @@ class TestPlantHelperGenerateConfigentry:
         limits = result[FLOW_PLANT_INFO][ATTR_LIMITS]
 
         # DLI should be calculated from mmol with one decimal place.
-        # max_light_mmol = 6000, PPFD_DLI_FACTOR = 0.0036
-        # expected_max_dli = round(6000 * 0.0036, 1) = 21.6
-        assert limits[CONF_MAX_DLI] == 21.6
+        # Conversion: mmol/m²/d → mol/m²/d by dividing by 1000.
+        # max_light_mmol = 6000 → round(6000 / 1000, 1) = 6.0
+        assert limits[CONF_MAX_DLI] == 6.0
 
-        # min_light_mmol = 1500
-        # expected_min_dli = round(1500 * 0.0036, 1) = 5.4
-        assert limits[CONF_MIN_DLI] == 5.4
+        # min_light_mmol = 1500 → round(1500 / 1000, 1) = 1.5
+        assert limits[CONF_MIN_DLI] == 1.5
 
     async def test_generate_configentry_dli_from_opb_precomputed(
         self,


### PR DESCRIPTION
## Summary
Fix DLI threshold inflation when importing from OpenPlantbook mmol values.

## Problem
`PPFD_DLI_FACTOR` (0.0036) converts **instantaneous** PPFD (µmol/s·m²) to **hourly** DLI — but OpenPlantbook's `min_light_mmol` and `max_light_mmol` are **daily** integrals (mmol/m²/d). Applying the hourly factor to a daily value inflates DLI thresholds by **3.6×**.

Example for _Aspidistra elatior_ (cast iron plant):
- OpenPlantbook reports: 1100–2500 mmol/m²/d
- Incorrect: 1100 × 0.0036 = **4.0** mol → HA shows "low DLI" at healthy light levels
- Correct: 1100 / 1000 = **1.1** mol → matches measurement-based sources (e.g. House Plant Journal: 0.9–1.7 mol)

## Fix
Replace `mmol × PPFD_DLI_FACTOR` with `mmol / 1000` — mmol/m²/d → mol/m²/d is a simple unit conversion. `PPFD_DLI_FACTOR` is still correct for its use in `sensor.py` (converting instantaneous PPFD measurements). No changes to `const.py`.

## Changes
- **`plant_helpers.py`**: `* PPFD_DLI_FACTOR` → `/ 1000` in both `max_dli` and `min_dli` fallback paths, plus explanatory comment
- **`plant_helpers.py`**: Remove unused `PPFD_DLI_FACTOR` import
- **`test_plant_helpers.py`**: Update expected DLI values per corrected conversion