### PR TITLE
prototype: HA 2026.7 plant triggers & conditions (strawman, do not merge)

### DIFF
--- a/custom_components/plant/condition.py
+++ b/custom_components/plant/condition.py
@@ -1,0 +1,113 @@
+"""Condition platform for the plant integration (Home Assistant 2026.7+).
+
+PROTOTYPE / strawman for discussion — see the linked feedback issue.
+
+Mirrors the trigger families as conditions so automations can be *gated* on
+plant health, not only fired by it:
+  * ``plant.is_problem`` — the plant is currently in a problem state.
+  * ``plant.moisture_is_low`` — per-measurement, auto-thresholded (example).
+  * ``plant.sensor_is_stale`` — a plant source sensor is unavailable or has not
+    updated within the window (default 24h).
+
+Inert on Home Assistant < 2026.7 (the condition platform is never imported).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import (
+    CONF_FOR,
+    STATE_PROBLEM,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.condition import (
+    Condition,
+    ConditionConfig,
+    make_entity_state_condition,
+)
+from homeassistant.helpers.target import (
+    TargetSelection,
+    async_extract_referenced_entity_ids,
+)
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
+
+from .const import ATTR_MOISTURE, DOMAIN, STATE_LOW
+from .trigger import DEFAULT_STALE_FOR
+
+_EXCLUDED = {STATE_UNAVAILABLE, STATE_UNKNOWN}
+
+
+def _status_condition(measurement: str, state: str) -> type[Condition]:
+    """Condition on a plant's <measurement>_status attribute (auto-thresholded)."""
+    return make_entity_state_condition(
+        {DOMAIN: DomainSpec(value_source=f"{measurement}_status")},
+        state,
+    )
+
+
+class PlantSensorStaleCondition(Condition):
+    """True when a targeted plant source sensor is currently stale."""
+
+    _schema = vol.Schema(
+        {
+            vol.Required("target"): cv.TARGET_FIELDS,
+            vol.Optional("options", default=dict): vol.Schema(
+                {vol.Optional(CONF_FOR): cv.positive_time_period},
+                extra=vol.ALLOW_EXTRA,
+            ),
+        },
+        extra=vol.ALLOW_EXTRA,
+    )
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return cls._schema(config)
+
+    def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+        """Initialize the condition."""
+        super().__init__(hass, config)
+        self._target_selection = TargetSelection(config.target)
+        self._duration: timedelta = (config.options or {}).get(
+            CONF_FOR
+        ) or DEFAULT_STALE_FOR
+
+    def _async_check(self, **kwargs: Any) -> bool:
+        """Return True if any targeted plant sensor is unavailable or silent."""
+        selected = async_extract_referenced_entity_ids(
+            self._hass, self._target_selection, expand_group=False
+        )
+        entity_ids = selected.referenced | selected.indirectly_referenced
+        now = dt_util.utcnow()
+        for entity_id in entity_ids:
+            if entity_id.split(".", 1)[0] != SENSOR_DOMAIN:
+                continue
+            state = self._hass.states.get(entity_id)
+            if state is None or state.state in _EXCLUDED:
+                return True
+            if now - state.last_updated > self._duration:
+                return True
+        return False
+
+
+CONDITIONS: dict[str, type[Condition]] = {
+    "is_problem": make_entity_state_condition(DOMAIN, STATE_PROBLEM),
+    "moisture_is_low": _status_condition(ATTR_MOISTURE, STATE_LOW),
+    "sensor_is_stale": PlantSensorStaleCondition,
+}
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type[Condition]]:
+    """Return the conditions provided by the plant integration."""
+    return CONDITIONS

--- a/custom_components/plant/conditions.yaml
+++ b/custom_components/plant/conditions.yaml
@@ -1,0 +1,39 @@
+# Condition descriptions for the plant integration (Home Assistant 2026.7+).
+# PROTOTYPE — shapes may change based on feedback.
+
+.plant_behavior: &plant_behavior
+  required: true
+  default: any
+  selector:
+    automation_behavior:
+      mode: condition
+
+.plant_for: &plant_for
+  required: true
+  default: 00:00:00
+  selector:
+    duration:
+
+.plant_state_condition: &plant_state_condition
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior: *plant_behavior
+    for: *plant_for
+
+is_problem: *plant_state_condition
+moisture_is_low: *plant_state_condition
+
+sensor_is_stale:
+  target:
+    device:
+      integration: plant
+    entity:
+      domain: sensor
+  fields:
+    for:
+      required: true
+      default: "24:00:00"
+      selector:
+        duration:

--- a/custom_components/plant/trigger.py
+++ b/custom_components/plant/trigger.py
@@ -1,0 +1,220 @@
+"""Trigger platform for the plant integration (Home Assistant 2026.7+).
+
+PROTOTYPE / strawman for discussion — see the linked feedback issue.
+
+Exposes purpose-specific ``plant.*`` triggers that build on the integration's
+existing, species-threshold-aware problem detection. Nothing here is imported
+on Home Assistant versions without the trigger platform (< 2026.7), so the file
+is inert on older installs and does not raise the integration's minimum version.
+
+Three families:
+  * Aggregate plant state — ``plant.became_problem`` / ``plant.became_ok``.
+  * Per-measurement (auto-threshold) — e.g. ``plant.moisture_became_low``,
+    firing off the plant's own ``<measurement>_status`` attribute. The threshold
+    is the plant's configured min/max (with hysteresis); the user never supplies
+    a number. Only moisture is wired here as the representative example.
+  * Stale source sensor — ``plant.sensor_became_stale``: a plant's source sensor
+    is unavailable or has not produced an update within a (default 24h) window.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_FOR,
+    STATE_OK,
+    STATE_PROBLEM,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.target import (
+    TargetStateChangedData,
+    async_track_target_selector_state_change_event,
+)
+from homeassistant.helpers.trigger import (
+    Trigger,
+    TriggerActionRunner,
+    TriggerConfig,
+    make_entity_target_state_trigger,
+)
+from homeassistant.helpers.typing import ConfigType
+
+from .const import ATTR_MOISTURE, DOMAIN, STATE_HIGH, STATE_LOW
+
+# Some plant sensors update very infrequently; default the staleness window high
+# so the trigger flags genuinely dead/silent sensors, not slow ones.
+DEFAULT_STALE_FOR = timedelta(hours=24)
+
+_EXCLUDED = {STATE_UNAVAILABLE, STATE_UNKNOWN}
+
+
+def _status_trigger(measurement: str, to_state: str) -> type[Trigger]:
+    """Trigger that fires when a plant's <measurement>_status attribute reaches a state.
+
+    Reuses the core entity-target-state machinery, but tracks the plant's own
+    per-measurement status attribute (Low/High/ok) instead of the entity state.
+    The plant computes that status from its configured min/max thresholds with
+    hysteresis — so this fires on the plant's threshold, with no user input.
+    """
+    return make_entity_target_state_trigger(
+        {DOMAIN: DomainSpec(value_source=f"{measurement}_status")},
+        to_state,
+    )
+
+
+class PlantSensorStaleTrigger(Trigger):
+    """Fire when a plant's source sensor goes stale.
+
+    "Stale" = the sensor is unavailable/unknown, OR it has not produced any
+    update within the configured ``for`` window (default 24h). Target the plant
+    device; it expands to the plant's sensors, which are filtered to here.
+    """
+
+    _schema = vol.Schema(
+        {
+            vol.Required("target"): cv.TARGET_FIELDS,
+            vol.Optional("options", default=dict): vol.Schema(
+                {vol.Optional(CONF_FOR): cv.positive_time_period},
+                extra=vol.ALLOW_EXTRA,
+            ),
+        },
+        extra=vol.ALLOW_EXTRA,
+    )
+
+    @classmethod
+    async def async_validate_config(
+        cls, hass: HomeAssistant, config: ConfigType
+    ) -> ConfigType:
+        """Validate config."""
+        return cls._schema(config)
+
+    def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+        """Initialize the stale-sensor trigger."""
+        super().__init__(hass, config)
+        self._target = config.target
+        self._duration: timedelta = (config.options or {}).get(
+            CONF_FOR
+        ) or DEFAULT_STALE_FOR
+
+    @callback
+    def _only_sensors(self, entities: set[str]) -> set[str]:
+        """Restrict the expanded target to plant source-sensor entities."""
+        return {e for e in entities if e.split(".", 1)[0] == SENSOR_DOMAIN}
+
+    async def async_attach_runner(
+        self,
+        run_action: TriggerActionRunner,
+        did_not_trigger: Any | None = None,
+    ) -> CALLBACK_TYPE:
+        """Attach the trigger."""
+        timers: dict[str, CALLBACK_TYPE] = {}
+        stale: set[str] = set()
+
+        @callback
+        def _fire(entity_id: str, reason: str) -> None:
+            run_action(
+                {
+                    ATTR_ENTITY_ID: entity_id,
+                    "reason": reason,  # "unavailable" | "no_update"
+                    "for": self._duration,
+                },
+                f"{entity_id} stale ({reason})",
+                None,
+            )
+
+        @callback
+        def _mark_stale(entity_id: str, reason: str) -> None:
+            timer = timers.pop(entity_id, None)
+            if timer is not None:
+                timer()
+            if entity_id not in stale:
+                stale.add(entity_id)
+                _fire(entity_id, reason)
+
+        @callback
+        def _arm(entity_id: str) -> None:
+            """(Re)start the freshness countdown for a healthy sensor."""
+            stale.discard(entity_id)
+            timer = timers.pop(entity_id, None)
+            if timer is not None:
+                timer()
+
+            @callback
+            def _expired(_now: datetime) -> None:
+                timers.pop(entity_id, None)
+                if entity_id not in stale:
+                    stale.add(entity_id)
+                    _fire(entity_id, "no_update")
+
+            timers[entity_id] = async_call_later(self._hass, self._duration, _expired)
+
+        @callback
+        def _consider(entity_id: str, state: State | None) -> None:
+            if state is None or state.state in _EXCLUDED:
+                _mark_stale(entity_id, "unavailable")
+            else:
+                _arm(entity_id)
+
+        @callback
+        def _on_state_change(data: TargetStateChangedData) -> None:
+            event = data.state_change_event
+            _consider(event.data["entity_id"], event.data["new_state"])
+
+        @callback
+        def _on_entities_update(
+            added: set[str],
+            removed: set[str],
+            entity_states: Mapping[str, State | None],
+        ) -> None:
+            for entity_id in removed:
+                timer = timers.pop(entity_id, None)
+                if timer is not None:
+                    timer()
+                stale.discard(entity_id)
+            for entity_id in added:
+                _consider(entity_id, entity_states.get(entity_id))
+
+        unsub = await async_track_target_selector_state_change_event(
+            self._hass,
+            self._target,
+            _on_state_change,
+            self._only_sensors,
+            _on_entities_update,
+        )
+
+        @callback
+        def _remove() -> None:
+            unsub()
+            for timer in timers.values():
+                timer()
+            timers.clear()
+            stale.clear()
+
+        return _remove
+
+
+TRIGGERS: dict[str, type[Trigger]] = {
+    # Aggregate plant health (entity state problem/ok).
+    "became_problem": make_entity_target_state_trigger(DOMAIN, STATE_PROBLEM),
+    "became_ok": make_entity_target_state_trigger(DOMAIN, STATE_OK),
+    # Per-measurement, auto-thresholded (representative example: moisture).
+    "moisture_became_low": _status_trigger(ATTR_MOISTURE, STATE_LOW),
+    "moisture_became_high": _status_trigger(ATTR_MOISTURE, STATE_HIGH),
+    # Source-sensor staleness.
+    "sensor_became_stale": PlantSensorStaleTrigger,
+}
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type[Trigger]]:
+    """Return the triggers provided by the plant integration."""
+    return TRIGGERS

--- a/custom_components/plant/triggers.yaml
+++ b/custom_components/plant/triggers.yaml
@@ -1,0 +1,45 @@
+# Trigger descriptions for the plant integration (Home Assistant 2026.7+).
+# PROTOTYPE — shapes may change based on feedback.
+
+.plant_behavior: &plant_behavior
+  required: true
+  default: each
+  selector:
+    automation_behavior:
+      mode: trigger
+
+.plant_for: &plant_for
+  required: true
+  default: 00:00:00
+  selector:
+    duration:
+
+# Aggregate plant health + per-measurement (auto-thresholded) triggers target
+# the plant entity itself; the threshold is the plant's own configured min/max.
+.plant_state_trigger: &plant_state_trigger
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior: *plant_behavior
+    for: *plant_for
+
+became_problem: *plant_state_trigger
+became_ok: *plant_state_trigger
+moisture_became_low: *plant_state_trigger
+moisture_became_high: *plant_state_trigger
+
+# Staleness targets the plant device (expands to its source sensors) or specific
+# sensors. Default window is high because some plant sensors update infrequently.
+sensor_became_stale:
+  target:
+    device:
+      integration: plant
+    entity:
+      domain: sensor
+  fields:
+    for:
+      required: true
+      default: "24:00:00"
+      selector:
+        duration:

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,199 @@
+"""Tests for the plant trigger/condition platforms (HA 2026.7+ prototype)."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import homeassistant.helpers.trigger as ha_trigger
+import pytest
+
+# The trigger/condition platform API only exists on HA 2026.7+. On older cores
+# (the integration still supports 2025.8+) the platform files are never imported,
+# so skip the whole module rather than fail at collection.
+if not hasattr(ha_trigger, "make_entity_target_state_trigger"):
+    pytest.skip(
+        "plant triggers require the HA 2026.7+ trigger platform",
+        allow_module_level=True,
+    )
+
+import homeassistant.util.dt as dt_util
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import (
+    async_capture_events,
+    async_fire_time_changed,
+)
+
+from custom_components.plant.condition import async_get_conditions
+from custom_components.plant.trigger import async_get_triggers
+
+
+async def test_async_get_triggers(hass: HomeAssistant) -> None:
+    """The platform advertises the expected trigger keys."""
+    triggers = await async_get_triggers(hass)
+    assert set(triggers) == {
+        "became_problem",
+        "became_ok",
+        "moisture_became_low",
+        "moisture_became_high",
+        "sensor_became_stale",
+    }
+
+
+async def test_async_get_conditions(hass: HomeAssistant) -> None:
+    """The platform advertises the expected condition keys."""
+    conditions = await async_get_conditions(hass)
+    assert set(conditions) == {"is_problem", "moisture_is_low", "sensor_is_stale"}
+
+
+async def test_became_problem_fires(hass: HomeAssistant) -> None:
+    """plant.became_problem fires when the plant transitions ok -> problem."""
+    hass.states.async_set("plant.test", "ok")
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "plant_problem")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.became_problem",
+                    "target": {"entity_id": "plant.test"},
+                },
+                "action": {"event": "plant_problem"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("plant.test", "problem")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_became_low_uses_status_attribute(hass: HomeAssistant) -> None:
+    """plant.moisture_became_low fires off the plant's own moisture_status (no threshold)."""
+    hass.states.async_set("plant.test", "ok", {"moisture_status": "ok"})
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "moisture_low")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_became_low",
+                    "target": {"entity_id": "plant.test"},
+                },
+                "action": {"event": "moisture_low"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("plant.test", "problem", {"moisture_status": "Low"})
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_sensor_became_stale_on_no_update(hass: HomeAssistant) -> None:
+    """plant.sensor_became_stale fires when a targeted sensor goes silent for `for`."""
+    hass.states.async_set("sensor.test_moisture", "20")
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "sensor_stale")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.sensor_became_stale",
+                    "target": {"entity_id": "sensor.test_moisture"},
+                    "options": {"for": {"seconds": 30}},
+                },
+                "action": {
+                    "event": "sensor_stale",
+                    "event_data": {"reason": "{{ trigger.reason }}"},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    # No update within the window -> stale.
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["reason"] == "no_update"
+
+
+async def test_sensor_became_stale_on_unavailable(hass: HomeAssistant) -> None:
+    """plant.sensor_became_stale fires immediately when a sensor goes unavailable."""
+    hass.states.async_set("sensor.test_moisture", "20")
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "sensor_stale")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.sensor_became_stale",
+                    "target": {"entity_id": "sensor.test_moisture"},
+                    "options": {"for": {"hours": 24}},
+                },
+                "action": {
+                    "event": "sensor_stale",
+                    "event_data": {"reason": "{{ trigger.reason }}"},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["reason"] == "unavailable"
+
+
+@pytest.mark.parametrize(
+    ("plant_state", "expected"),
+    [("problem", True), ("ok", False)],
+)
+async def test_is_problem_condition(
+    hass: HomeAssistant, plant_state: str, expected: bool
+) -> None:
+    """plant.is_problem reflects the plant's current state."""
+    hass.states.async_set("plant.test", plant_state)
+    await hass.async_block_till_done()
+
+    events = async_capture_events(hass, "cond_passed")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {"platform": "event", "event_type": "plant_cond_probe"},
+                "condition": {
+                    "condition": "plant.is_problem",
+                    "target": {"entity_id": "plant.test"},
+                },
+                "action": {"event": "cond_passed"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "automation",
+        "trigger",
+        {"entity_id": "automation.automation_0", "skip_condition": False},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert (len(events) == 1) is expected

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-import homeassistant.helpers.trigger as ha_trigger
 import pytest
+from homeassistant.const import __version__ as HA_VERSION
 
-# The trigger/condition platform API only exists on HA 2026.7+. On older cores
-# (the integration still supports 2025.8+) the platform files are never imported,
-# so skip the whole module rather than fail at collection.
-if not hasattr(ha_trigger, "make_entity_target_state_trigger"):
+# The trigger/condition platform settled into its current shape in HA 2026.7; an
+# earlier Labs form existed in 2026.2-2026.6 with a different API. The integration
+# still supports 2025.8+, and the platform files are never imported on older cores,
+# so skip the whole module below 2026.7 rather than fail at collection/runtime.
+_ha_parts = HA_VERSION.split(".")
+if (int(_ha_parts[0]), int(_ha_parts[1])) < (2026, 7):
     pytest.skip(
         "plant triggers require the HA 2026.7+ trigger platform",
         allow_module_level=True,


### PR DESCRIPTION
**Prototype / strawman — do not merge.** Feedback: #480.

Adds `plant.*` triggers & conditions for the new Home Assistant 2026.7 purpose-specific automation platform. Gated so it's inert on HA < 2026.7 (min stays 2025.8).

## What's here
- `trigger.py` / `condition.py` (+ `triggers.yaml` / `conditions.yaml`)
- Triggers: `plant.became_problem`, `plant.became_ok`, `plant.moisture_became_low/high` (auto-thresholded off the plant's own `*_status`), `plant.sensor_became_stale` (unavailable or no update within `for`, default 24h)
- Conditions: `plant.is_problem`, `plant.moisture_is_low`, `plant.sensor_is_stale`
- `tests/test_triggers.py` — end-to-end (fires real automations on 2026.7.0b1); **skips on HA < 2026.7**

## Key design point
Per-measurement triggers fire off the integration's **existing** species-threshold + hysteresis detection, so the user never supplies a threshold — that's what core's generic `temperature.*` / `humidity.*` purpose triggers can't do. See #480 for the full sensor-coverage table and open questions (naming, per-measurement scope, stale semantics, device classes).

## Status
- Built & tested against **HA 2026.7.0b1** (RC) — API may still change.
- Representative slice (one of each pattern) is wired & tested; the full per-measurement set is described in #480, not all implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)