### PR TITLE
fix: guard threshold checks against entities without a live hass state

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -740,8 +740,12 @@ class PlantDevice(RestoreEntity):
             _LOGGER.debug("Skipping %s: sensor %s not available", attr_name, sensor)
             return None
         try:
-            max_val = self._safe_float(max_entity.state, max_entity.entity_id)
-            min_val = self._safe_float(min_entity.state, min_entity.entity_id)
+            max_val = self._safe_float(
+                self._entity_state(max_entity), max_entity.entity_id
+            )
+            min_val = self._safe_float(
+                self._entity_state(min_entity), min_entity.entity_id
+            )
             return {
                 ATTR_MAX: max_val if max_val is not None else max_entity._default_value,
                 ATTR_MIN: min_val if min_val is not None else min_entity._default_value,
@@ -809,8 +813,8 @@ class PlantDevice(RestoreEntity):
         # DLI uses its own entity (not a meter sensor)
         if self._sensor_available(self.dli):
             response[ATTR_DLI] = {
-                ATTR_MAX: self.max_dli.state,
-                ATTR_MIN: self.min_dli.state,
+                ATTR_MAX: self._entity_state(self.max_dli),
+                ATTR_MIN: self._entity_state(self.min_dli),
                 ATTR_CURRENT: STATE_UNAVAILABLE,
                 ATTR_ICON: self._get_entity_icon(self.dli),
                 ATTR_UNIT_OF_MEASUREMENT: self.dli.unit_of_measurement,
@@ -822,9 +826,10 @@ class PlantDevice(RestoreEntity):
 
         # Add rolling 24h DLI if available
         if self.dli_24h is not None and self._sensor_available(self.dli_24h):
+            # Same thresholds as regular DLI
             response[ATTR_DLI_24H] = {
-                ATTR_MAX: self.max_dli.state,  # Same thresholds as regular DLI
-                ATTR_MIN: self.min_dli.state,
+                ATTR_MAX: self._entity_state(self.max_dli),
+                ATTR_MIN: self._entity_state(self.min_dli),
                 ATTR_CURRENT: STATE_UNAVAILABLE,
                 ATTR_ICON: self._get_entity_icon(self.dli_24h),
                 ATTR_UNIT_OF_MEASUREMENT: self.dli_24h.unit_of_measurement,
@@ -1071,6 +1076,27 @@ class PlantDevice(RestoreEntity):
             _LOGGER.debug("Sensor %s has non-numeric value: %s", entity_id, value)
             return None
 
+    def _entity_state(self, entity) -> str | None:
+        """Safely read an entity's current state string.
+
+        Prefers the state machine (hass.states) over the entity's own
+        `.state` property: that property requires the entity to be fully
+        added to hass (self.hass set, entity_id assigned) and can raise
+        AttributeError while the entity is still being set up or is being
+        torn down (see issue #485). Falls back to the property directly,
+        guarded against that AttributeError, for entities not (yet) tracked
+        by the state machine.
+        """
+        entity_id = getattr(entity, "entity_id", None)
+        if entity_id is not None:
+            state = self.hass.states.get(entity_id)
+            if state is not None:
+                return state.state
+        try:
+            return entity.state
+        except AttributeError:
+            return None
+
     def _check_threshold(self, value, min_entity, max_entity, current_status):
         """Check a value against min/max thresholds with hysteresis.
 
@@ -1078,17 +1104,19 @@ class PlantDevice(RestoreEntity):
         When already in a problem state, require the value to cross back
         by a margin (hysteresis band) before clearing.
         """
+        min_state = self._entity_state(min_entity)
+        max_state = self._entity_state(max_entity)
         try:
-            min_val = float(min_entity.state)
-            max_val = float(max_entity.state)
+            min_val = float(min_state)
+            max_val = float(max_state)
         except (ValueError, TypeError):
             _LOGGER.warning(
                 "Threshold entity has non-numeric state "
                 "(min=%s [%s], max=%s [%s]) — skipping check",
-                min_entity.entity_id,
-                min_entity.state,
-                max_entity.entity_id,
-                max_entity.state,
+                getattr(min_entity, "entity_id", None),
+                min_state,
+                getattr(max_entity, "entity_id", None),
+                max_state,
             )
             return current_status
         # Band is relative to the threshold being crossed, not the full
@@ -1147,7 +1175,7 @@ class PlantDevice(RestoreEntity):
             A threshold entity can momentarily be unavailable/unknown; avoid
             writing a raw 'unavailable' into the problem entry or logbook.
             """
-            raw = threshold_entity.state
+            raw = self._entity_state(threshold_entity)
             try:
                 float(raw)
             except (ValueError, TypeError):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2013,6 +2013,52 @@ class TestHysteresis:
         await update_plant_sensors(hass, init_integration.entry_id)
         assert plant.moisture_status == STATE_LOW
 
+    async def test_threshold_entity_without_hass_preserves_status(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test a threshold entity with no hass reference doesn't crash _check_threshold.
+
+        Regression test for issue #485: accessing a NumberEntity's `.state`
+        property while its `hass` attribute is None (e.g. entity not yet
+        added to hass, or removed from it) raises AttributeError deep inside
+        Home Assistant core (unit_of_measurement -> self.hass.config...).
+        _check_threshold must treat this the same as an unavailable/unknown
+        threshold and preserve the current status instead of crashing.
+        """
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+
+        await set_external_sensor_states(
+            hass,
+            temperature=25.0,
+            moisture=5.0,  # Below min of 20
+            conductivity=1000.0,
+            illuminance=5000.0,
+            humidity=40.0,
+        )
+        await update_plant_sensors(hass, init_integration.entry_id)
+        assert plant.moisture_status == STATE_LOW
+
+        # Simulate the entity_id being tracked by an entity that has no live
+        # state in hass.states (e.g. not yet added) and whose `.state`
+        # property raises AttributeError, mirroring core's NumberEntity
+        # behavior when self.hass is None.
+        hass.states.async_remove(plant.max_moisture.entity_id)
+
+        class _NoHassEntity:
+            entity_id = plant.max_moisture.entity_id
+
+            @property
+            def state(self):
+                raise AttributeError("'NoneType' object has no attribute 'config'")
+
+        assert plant._entity_state(_NoHassEntity()) is None
+        assert (
+            plant._check_threshold(5.0, plant.min_moisture, _NoHassEntity(), STATE_LOW)
+            == STATE_LOW
+        )
+
 
 class TestYamlImport:
     """Tests for YAML configuration import (async_setup)."""


### PR DESCRIPTION
## Summary

Fixes #485.

`NumberEntity.state` (Home Assistant core) can raise `AttributeError` when the entity's `hass` reference isn't set yet — e.g. while a min/max threshold number entity is still being added to `hass`, or is being torn down. `_check_threshold()` only guarded against `ValueError`/`TypeError`, so this exception propagated out of `update()` on every update cycle for affected plants, filling logs with thousands of `AttributeError: 'NoneType' object has no attribute 'config'` errors and `Error building websocket info` warnings, and exhausting the executor pool (update duration >10-15s per plant).

This surfaced after upgrading to HA Core 2026.7, per the traceback in #485.

## Change

- Added `_entity_state()`: reads a threshold entity's state via `hass.states` first (the stable state machine), falling back to the entity's own `.state` property guarded against `AttributeError`.
- Applied it everywhere threshold entities were read directly via `.state`: `_check_threshold`, `_sensor_info` (websocket info), the DLI/DLI-24h websocket attributes, and `_threshold_str` in `_log_problem_changes` (logbook formatting).
- When a threshold entity's state can't be read, behavior now matches the existing "non-numeric state" path: log a warning and keep the current status, instead of crashing.

## Test plan

- [x] Added `test_threshold_entity_without_hass_preserves_status` (regression test for #485): simulates a threshold entity whose `.state` property raises `AttributeError`, asserts `_check_threshold` preserves the current status instead of crashing.
- [x] Full test suite passes (344 tests).
- [x] `black --check` / `ruff check` clean.
- [x] Verified against a live HA instance previously hitting this bug: after the fix, all plant entities recovered, the `AttributeError` and executor-timeout warnings disappeared entirely, and the integration now logs the intended "Threshold entity has non-numeric state ... skipping check" warning instead.