### PR TITLE
fix: add plant entity via a single shared EntityComponent (#487)

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -101,6 +101,11 @@ from .plant_helpers import PlantHelper
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.NUMBER, Platform.SENSOR]
 
+# Key under hass.data[DOMAIN] holding the single shared EntityComponent that
+# owns the plant.<name> entities. The leading underscore keeps it out of the
+# per-entry bookkeeping in async_unload_entry (which skips "_"-prefixed keys).
+DATA_COMPONENT = "_component"
+
 # Schema for native HA plant YAML configuration import
 # Matches format from https://www.home-assistant.io/integrations/plant/
 PLANT_SENSOR_SCHEMA = vol.Schema(
@@ -175,12 +180,39 @@ async def async_migrate_plant(hass: HomeAssistant, plant_id: str, config: dict) 
     )
 
 
+def _get_plant_component(hass: HomeAssistant) -> EntityComponent:
+    """Return the single shared EntityComponent for the plant domain.
+
+    The plant.<name> entities live on the ``plant`` domain, which this
+    integration owns because it shadows Home Assistant's built-in plant
+    component. Those entities must be added through one domain-level
+    EntityComponent so each gets a valid ``platform`` reference: HA Core
+    2026.7 warns for platform-less entities and removes the compatibility
+    guard in 2026.8. Previously a throwaway EntityComponent was created per
+    config entry, which left the entity without a stable platform on the
+    reload/teardown paths.
+
+    Created once and reused across all config entries. Recreated lazily if
+    the domain data was torn down after the last plant was removed.
+    """
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    component = domain_data.get(DATA_COMPONENT)
+    if component is None:
+        component = EntityComponent(_LOGGER, DOMAIN, hass)
+        domain_data[DATA_COMPONENT] = component
+    return component
+
+
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the plant integration from YAML configuration.
 
     This function handles importing plants from the native Home Assistant
     plant integration's YAML configuration format.
     """
+    # Create the shared domain-level EntityComponent up front, mirroring how
+    # HA's built-in plant component registers its domain in async_setup.
+    _get_plant_component(hass)
+
     if config.get(DOMAIN):
         # Only import if we haven't already imported
         config_entry = _async_find_matching_config_entry(hass)
@@ -220,10 +252,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         plant,
     ]
 
-    # Add all the entities to Hass
-    component = EntityComponent(_LOGGER, DOMAIN, hass)
+    # Add the entities to Hass via the single shared domain-level component
+    # (see _get_plant_component), so each entity has a valid platform.
+    component = _get_plant_component(hass)
     await component.async_add_entities(plant_entities)
-    hass.data[DOMAIN][entry.entry_id]["component"] = component
 
     # Add the entities to device registry and tie to config entry
     device_id = plant.device_id
@@ -379,10 +411,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if ATTR_PLANT in plant_data:
         plant_data[ATTR_PLANT].plant_complete = False
 
-    # Remove the plant entity from the EntityComponent so reloads don't
+    # Remove the plant entity from the shared EntityComponent so reloads don't
     # hit a duplicate unique_id error
     plant = plant_data.get(ATTR_PLANT)
-    component = plant_data.get("component")
+    component = hass.data.get(DOMAIN, {}).get(DATA_COMPONENT)
     if component and plant and plant.entity_id:
         await component.async_remove_entity(plant.entity_id)
 
@@ -414,7 +446,15 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         if len(remaining_plant_entries) == 0:
             _LOGGER.debug("Removing domain %s (no more plants)", DOMAIN)
             hass.services.async_remove(DOMAIN, SERVICE_REPLACE_SENSOR)
-            del hass.data[DOMAIN]
+            # Preserve the shared EntityComponent: it is domain-level
+            # infrastructure created in async_setup (which does not re-run on a
+            # reload or a later re-add). Tearing it down here would orphan its
+            # EntityPlatform and make the next add hit a duplicate unique_id.
+            component = hass.data[DOMAIN].get(DATA_COMPONENT)
+            if component is not None:
+                hass.data[DOMAIN] = {DATA_COMPONENT: component}
+            else:
+                del hass.data[DOMAIN]
     return unload_ok
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.plant import async_setup
+from custom_components.plant import DATA_COMPONENT, async_setup
 from custom_components.plant.const import (
     ATTR_PLANT,
     CARE_FIELDS,
@@ -84,6 +84,48 @@ class TestIntegrationSetup:
 
         # Entry should be removed from domain data
         assert init_integration.entry_id not in hass.data.get(DOMAIN, {})
+
+    async def test_plant_entity_added_via_shared_component(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """The plant.<name> entity must be added via the shared EntityComponent.
+
+        Regression test for issue #487: the entity was previously added through
+        a throwaway EntityComponent created per config entry and stored under the
+        entry's own data, which could leave it without a ``platform``. HA Core
+        2026.7 warns for platform-less entities ("does not have a platform ...")
+        and removes the compatibility guard in 2026.8. A single shared
+        domain-level component must own the entity so ``entity.platform`` is set.
+        """
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+
+        # The entity carries a valid platform reference...
+        assert plant.platform is not None
+        # ...and it is the single shared domain component (stored under
+        # DATA_COMPONENT), not a per-entry one under the entry's own data.
+        assert DATA_COMPONENT in hass.data[DOMAIN]
+        assert plant.platform is hass.data[DOMAIN][DATA_COMPONENT]._platforms[DOMAIN]
+        assert "component" not in hass.data[DOMAIN][init_integration.entry_id]
+
+    async def test_shared_component_survives_unload(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """The shared component persists after the last plant is unloaded.
+
+        It is domain-level infrastructure created in async_setup (which does not
+        re-run on a later re-add), so tearing it down would orphan its
+        EntityPlatform and make the next add hit a duplicate unique_id.
+        """
+        await hass.config_entries.async_unload(init_integration.entry_id)
+        await hass.async_block_till_done()
+
+        # Entry data is gone, but the shared component is retained.
+        assert init_integration.entry_id not in hass.data.get(DOMAIN, {})
+        assert DATA_COMPONENT in hass.data.get(DOMAIN, {})
 
     async def test_remove_entry(
         self,


### PR DESCRIPTION
## Summary

Fixes #487.

The `plant.<name>` domain entity was added through a **throwaway `EntityComponent` created fresh in every `async_setup_entry`** and stashed under the entry's own data. That non-standard pattern can leave the entity without a valid `platform`. HA Core 2026.7 logs `Entity plant.<name> (<class 'custom_components.plant.PlantDevice'>) does not have a platform ...` for such entities, and the compatibility guard behind that warning is **removed in HA Core 2026.8** — so this needs to be fixed before then.

This integration owns the `plant` domain (it shadows HA's built-in plant component), so it can register the domain the idiomatic way: a single domain-level `EntityComponent`, exactly as core's plant does.

## Change

- Add `_get_plant_component()`: creates one shared `EntityComponent` for the `plant` domain, stored under `hass.data[DOMAIN]["_component"]`, and reuses it for every config entry (get-or-create).
- Create it in `async_setup` (mirroring HA's built-in plant component), instead of one throwaway component per entry in `async_setup_entry`.
- Preserve the shared component through the last-plant-unloaded cleanup, so its `EntityPlatform` isn't orphaned (which would make the next add hit a duplicate unique_id).

## Test plan

- [x] `test_plant_entity_added_via_shared_component`: the entity's `platform` is the shared domain component, and no per-entry `component` is stored.
- [x] `test_shared_component_survives_unload`: the shared component persists after the last plant is unloaded.
- [x] Full suite passes (345 tests) against HA Core 2026.7.0b1.
- [x] `black --check` clean. (ruff was not available in my local venv — relying on CI for the lint check.)

## Notes / out of scope

While testing I found a **pre-existing** bug unrelated to this change: a manual UI reload (`hass.config_entries.async_reload`) fails with a duplicate-unique_id `SETUP_ERROR`, **identically on current `main`**. The `plant.<name>` entity is a `RestoreEntity`, so removing it on unload leaves a lingering restored state that collides on re-add. Options-flow changes reload in place (via `update_plant_options`) and are unaffected. Left out of this PR to keep it focused; happy to address separately.
