### PR TITLE
fix: clear stale plant state on reload to avoid duplicate unique_id

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -255,6 +255,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Add the entities to Hass via the single shared domain-level component
     # (see _get_plant_component), so each entity has a valid platform.
     component = _get_plant_component(hass)
+    # On a reload the previous plant.<name> entity leaves a stale, non-restored
+    # state behind that keeps the entity_id "in use"; core would then abort the
+    # re-add with a duplicate unique_id. Clear any such orphan (no live entity
+    # backing it) right before adding so the id can be reclaimed.
+    erreg = er.async_get(hass)
+    existing_entity_id = erreg.async_get_entity_id(DOMAIN, DOMAIN, entry.entry_id)
+    if existing_entity_id and not hass.states.async_available(existing_entity_id):
+        existing_state = hass.states.get(existing_entity_id)
+        if existing_state is not None and not existing_state.attributes.get("restored"):
+            hass.states.async_remove(existing_entity_id)
     await component.async_add_entities(plant_entities)
 
     # Add the entities to device registry and tie to config entry

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
 from homeassistant.const import (
     STATE_OK,
     STATE_PROBLEM,
@@ -126,6 +126,33 @@ class TestIntegrationSetup:
         # Entry data is gone, but the shared component is retained.
         assert init_integration.entry_id not in hass.data.get(DOMAIN, {})
         assert DATA_COMPONENT in hass.data.get(DOMAIN, {})
+
+    async def test_reload_entry(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Reloading a config entry succeeds (regression test).
+
+        The plant.<name> entity is a RestoreEntity added directly to an
+        EntityComponent. On reload it left a stale, non-restored state behind
+        that kept its entity_id "in use", so the re-add aborted with a
+        duplicate unique_id and the entry ended up in SETUP_ERROR. Setup now
+        clears that orphan state before re-adding.
+        """
+        plant_entity_id = er.async_get(hass).async_get_entity_id(
+            DOMAIN, DOMAIN, init_integration.entry_id
+        )
+        assert plant_entity_id is not None
+
+        await hass.config_entries.async_reload(init_integration.entry_id)
+        await hass.async_block_till_done()
+
+        entry = hass.config_entries.async_get_entry(init_integration.entry_id)
+        assert entry.state is ConfigEntryState.LOADED
+        # The plant entity is live again (not a stale/unknown orphan)
+        assert hass.states.get(plant_entity_id) is not None
+        assert ATTR_PLANT in hass.data[DOMAIN][init_integration.entry_id]
 
     async def test_remove_entry(
         self,


### PR DESCRIPTION
## Summary

A manual integration reload (Settings → Devices & Services → ⋮ → Reload, i.e. `hass.config_entries.async_reload`) left the config entry in **`SETUP_ERROR`** with:

```
Platform plant does not generate unique IDs. ID <entry_id> is already used by plant.<name> - ignoring plant.<name>
Plant entity plant.<name> was not added to Home Assistant (possible duplicate unique_id). Aborting setup for <name>
```

## Root cause

The `plant.<name>` domain entity is a `RestoreEntity` added directly to an `EntityComponent`. On unload it is removed via `async_remove_entity`, but by the time the immediate re-setup runs, a **stale, non-restored** `unknown` state for its `entity_id` is present in the state machine. Core's `_entity_id_already_exists()` treats a lingering non-restored state as a live collision, so the re-add is aborted with a duplicate unique_id.

(Confirmed by instrumenting the re-add: `reg_eid=plant.<name>`, `in_platform=False`, `state=unknown` with **no** `restored` attribute, `avail=False`.)

## Change

Before re-adding the entity in `async_setup_entry`, drop any orphaned state for the plant's registered `entity_id` that (a) has no live entity backing it and (b) is not a legitimate restore placeholder — so the id can be reclaimed. Restore placeholders (`restored=True`) are left untouched so state restoration still works.

## Test plan

- [x] `test_reload_entry` (regression): reload leaves the entry `LOADED` with a live `plant.<name>` state, instead of `SETUP_ERROR`.
- [x] Full suite passes (345 tests) against HA Core 2026.7.0b1.
- [x] `black --check` clean.

## Note on #488

This touches the same add-path in `async_setup_entry` as #488 (shared EntityComponent). The `async_reload` failure reproduces on that branch too, so this fix is complementary. If #488 merges first, I'll rebase this on `main` and re-verify the two compose cleanly.
