### PR TITLE
feat: plant.* triggers & conditions for HA 2026.7 (#480, supersedes #481)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,10 +46,13 @@ jobs:
           # Latest HA version - uses current pytest-homeassistant-custom-component
           - ha-version: "latest"
             pytest-ha-version: ""
-          # Minimum HA version from hacs.json (2025.8.0)
-          # pytest-homeassistant-custom-component 0.13.270 supports HA 2025.8.x
-          - ha-version: "2025.8"
-            pytest-ha-version: "==0.13.270"
+          # Lowest TESTED HA version. hacs.json still declares support for 2025.8+
+          # (the plant.* triggers stay inert below 2026.7 — see trigger.py), but CI
+          # only tests 2026.3+: it is the first HA requiring Python 3.14, and older
+          # HA needs an aiodns/pycares workaround we no longer carry.
+          # pytest-homeassistant-custom-component 0.13.320 -> HA 2026.3.4.
+          - ha-version: "2026.3"
+            pytest-ha-version: "==0.13.320"
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -57,7 +60,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: "3.13"
+          # HA 2026.3+ requires Python 3.14
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,11 +70,16 @@ jobs:
         run: |
           rm -f uv.lock  # Prevent editable install from lock file
           uv venv
-          # Install test dependencies except pytest-homeassistant-custom-component
+          # Install the integration's runtime deps AND test deps, except
+          # pytest-homeassistant-custom-component (pinned separately below). The
+          # runtime deps (e.g. async-timeout) must be installed explicitly: newer
+          # HA no longer pulls them transitively, so relying on HA to provide them
+          # breaks on the latest HA.
           # Use --no-cache to ensure clean dependency resolution
           uv pip install --no-cache $(python -c "
           import tomllib
-          deps = tomllib.load(open('pyproject.toml', 'rb'))['project']['optional-dependencies']['test']
+          proj = tomllib.load(open('pyproject.toml', 'rb'))['project']
+          deps = proj.get('dependencies', []) + proj['optional-dependencies']['test']
           filtered = [d for d in deps if not d.startswith('pytest-homeassistant-custom-component')]
           print(' '.join(filtered))
           ")

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -76,8 +76,6 @@ jobs:
           ")
           # Install pytest-homeassistant-custom-component with version constraint
           uv pip install --no-cache "pytest-homeassistant-custom-component${{ matrix.pytest-ha-version }}"
-          # Pin aiodns/pycares to known working versions to avoid compatibility issues
-          uv pip install --no-cache "aiodns==3.5.0" "pycares==4.11.0"
 
       - name: Show installed versions
         run: |

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A comprehensive plant monitoring integration for Home Assistant that treats each
   - [💧 Vapour Pressure Deficit (VPD)](#-vapour-pressure-deficit-vpd)
   - [🖼️ Plant Images](#️-plant-images)
   - [⚠️ Problem Reports](#️-problem-reports)
+  - [🔔 Automations: Triggers \& Conditions](#-automations-triggers--conditions)
   - [🔄 Replacing Sensors](#-replacing-sensors)
   - [🌻 OpenPlantbook Integration](#-openplantbook-integration)
   - [🃏 Lovelace Card](#-lovelace-card)
@@ -234,6 +235,72 @@ The band is relative to each threshold, so the margin stays proportional whether
 
 > [!NOTE]
 > When a sensor becomes unavailable, the hysteresis state resets. The next valid reading is evaluated fresh against the thresholds.
+
+---
+
+## 🔔 Automations: Triggers & Conditions
+
+**Home Assistant 2026.7+.** That release introduced purpose-specific triggers and conditions — reusable automation building blocks that an integration registers under its own domain. Plant Monitor teaches Home Assistant a set of `plant.*` triggers and conditions built directly on the status and problem detection described above. They appear automatically once you're on HA 2026.7 or later; on older supported versions (2025.8+) nothing changes and nothing is registered.
+
+Core Home Assistant ships generic purpose triggers too, like `temperature.crossed_threshold` — but you have to type in the number yourself. The `plant.*` per-measurement triggers instead fire off the plant's *own* status, which this integration already computes from the species-configured min/max **with hysteresis** (see above). There's no threshold to enter, and nothing to keep in sync with the plant's dashboard.
+
+### The trigger & condition families
+
+- **Whole-plant:** `plant.problem_detected` / `plant.problem_cleared` — the plant entered / left a problem state. Condition: `plant.has_problem`.
+- **Per-measurement status:** `plant.<measurement>_became_low` / `_became_high` / `_became_ok`, for `moisture`, `conductivity`, `temperature`, `soil_temperature`, `humidity`, `illuminance`, `co2`, `dli`, `vpd`. Conditions: `plant.<measurement>_is_low` / `_is_high` / `_is_ok`.
+- **Stale source sensor:** `plant.<measurement>_sensor_became_stale` / `_became_fresh`, for the externally-sourced measurements only — `moisture`, `conductivity`, `temperature`, `soil_temperature`, `humidity`, `illuminance`, `co2` (not `dli`/`vpd`, which are derived rather than sensor-backed). Condition: `plant.<measurement>_sensor_is_stale`.
+
+  "Stale" means the source sensor is `unavailable`/`unknown`, or simply hasn't updated within a window (`for`, default **24 hours**). A grace period means it does **not** false-alarm at restart, when a sensor briefly reads `unknown` before its own integration populates it — staleness only fires once the source is genuinely still dead after the full window elapses.
+
+### Targeting
+
+Every trigger and condition targets the **plant** entity — you pick which plant, nothing else. For the stale family, the integration resolves that measurement's configured external source sensor itself; you never reference the sensor directly.
+
+### Examples
+
+```yaml
+# Notify when a plant's moisture drops below its configured minimum
+triggers:
+  - trigger: plant.moisture_became_low
+    target:
+      entity_id: plant.my_fern
+actions:
+  - action: notify.mobile_app_phone
+    data:
+      message: "My Fern needs water"
+```
+
+```yaml
+# Do something whenever a plant enters a problem state
+triggers:
+  - trigger: plant.problem_detected
+    target:
+      entity_id: plant.my_fern
+actions:
+  - action: light.turn_on
+    target:
+      entity_id: light.plant_shelf
+    data:
+      color_name: red
+```
+
+```yaml
+# Alert if the source sensor feeding a plant's temperature has gone stale for 6 hours
+triggers:
+  - trigger: plant.temperature_sensor_became_stale
+    target:
+      entity_id: plant.my_fern
+    options:
+      for:
+        hours: 6
+actions:
+  - action: notify.mobile_app_phone
+    data:
+      message: "{{ trigger.entity_id }} hasn't reported in 6 hours"
+```
+
+> [!NOTE]
+> For the standard-device-class measurements (`temperature`, `humidity`, `illuminance`, `soil_temperature`) you can alternatively use core's generic purpose triggers pointed at the plant's published `number.<plant>_min_*` / `_max_*` threshold entities — but the `plant.*` triggers above need no threshold wiring at all.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ actions:
 ```
 
 > [!NOTE]
-> For the standard-device-class measurements (`temperature`, `humidity`, `illuminance`, `soil_temperature`) you can alternatively use core's generic purpose triggers pointed at the plant's published `number.<plant>_min_*` / `_max_*` threshold entities — but the `plant.*` triggers above need no threshold wiring at all.
+> For measurements whose **source sensor** carries a standard Home Assistant device class (temperature, humidity, illuminance, soil temperature), Home Assistant's own generic `temperature.*` / `humidity.*` / `illuminance.*` purpose triggers also apply to that sensor — and their `crossed_threshold` form can optionally read the limit from the plant's published `number.<plant>_min_*` / `_max_*` entities. The `plant.*` triggers above need no such wiring.
 
 ---
 

--- a/custom_components/plant/automation_meta.py
+++ b/custom_components/plant/automation_meta.py
@@ -1,0 +1,43 @@
+"""Shared metadata for the plant.* trigger/condition surface.
+
+Pure data — safe to import on any Home Assistant version. The 2026.7-only
+trigger/condition helper APIs are imported lazily inside trigger.py /
+condition.py, never here.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class Measurement(NamedTuple):
+    """One plant measurement and how the automation surface reaches it."""
+
+    key: str
+    """Name fragment and status-attribute prefix, e.g. "moisture"."""
+    status_attr: str
+    """Plant entity attribute holding Low/High/ok, e.g. "moisture_status"."""
+    device_sensor_attr: str | None
+    """PlantDevice attribute holding the external source sensor entity, or
+    None for derived measurements (dli, vpd) that have no source of their own."""
+
+
+# The 9 measurements that expose a <key>_status attribute (Low / High / ok).
+STATUS_MEASUREMENTS: tuple[Measurement, ...] = (
+    Measurement("moisture", "moisture_status", "sensor_moisture"),
+    Measurement("conductivity", "conductivity_status", "sensor_conductivity"),
+    Measurement("temperature", "temperature_status", "sensor_temperature"),
+    Measurement(
+        "soil_temperature", "soil_temperature_status", "sensor_soil_temperature"
+    ),
+    Measurement("humidity", "humidity_status", "sensor_humidity"),
+    Measurement("illuminance", "illuminance_status", "sensor_illuminance"),
+    Measurement("co2", "co2_status", "sensor_co2"),
+    Measurement("dli", "dli_status", None),
+    Measurement("vpd", "vpd_status", None),
+)
+
+# The 7 externally-sourced measurements (can go stale independently).
+EXTERNAL_MEASUREMENTS: tuple[Measurement, ...] = tuple(
+    m for m in STATUS_MEASUREMENTS if m.device_sensor_attr is not None
+)

--- a/custom_components/plant/condition.py
+++ b/custom_components/plant/condition.py
@@ -1,0 +1,29 @@
+"""Condition platform for the plant integration (Home Assistant 2026.7+).
+
+Mirror of trigger.py: import-safe everywhere, returns {} on HA without the
+2026.7 purpose-condition API.
+"""
+
+from __future__ import annotations
+
+import homeassistant.helpers.condition as ha_condition
+from homeassistant.core import HomeAssistant
+
+_CONDITIONS_CACHE: dict[str, type] | None = None
+
+
+def _has_purpose_condition_api() -> bool:
+    """True when the HA 2026.7 purpose-condition helper API is available."""
+    return hasattr(ha_condition, "make_entity_state_condition")
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type]:
+    """Return the plant.* conditions, or {} on HA without the 2026.7 API."""
+    global _CONDITIONS_CACHE
+    if not _has_purpose_condition_api():
+        return {}
+    if _CONDITIONS_CACHE is None:
+        from .condition_impl import build_conditions
+
+        _CONDITIONS_CACHE = build_conditions()
+    return _CONDITIONS_CACHE

--- a/custom_components/plant/condition.py
+++ b/custom_components/plant/condition.py
@@ -6,15 +6,32 @@ Mirror of trigger.py: import-safe everywhere, returns {} on HA without the
 
 from __future__ import annotations
 
-import homeassistant.helpers.condition as ha_condition
+import logging
+
 from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
 
 _CONDITIONS_CACHE: dict[str, type] | None = None
 
 
 def _has_purpose_condition_api() -> bool:
-    """True when the HA 2026.7 purpose-condition helper API is available."""
-    return hasattr(ha_condition, "make_entity_state_condition")
+    """True when the full HA 2026.7 purpose-condition helper API is importable.
+
+    Checks the settled-2026.7 symbols, not just make_entity_state_condition
+    (which also existed in the 2026.2-2026.6 Labs form without DomainSpec). Returns
+    False on the 2025.8 floor, on the Labs-era API, and on any future HA where a
+    required symbol has moved, so the platform stays inert instead of crashing
+    discovery with an ImportError.
+    """
+    try:
+        from homeassistant.helpers.automation import DomainSpec  # noqa: F401
+        from homeassistant.helpers.condition import (  # noqa: F401
+            make_entity_state_condition,
+        )
+    except ImportError:
+        return False
+    return True
 
 
 async def async_get_conditions(hass: HomeAssistant) -> dict[str, type]:
@@ -23,7 +40,11 @@ async def async_get_conditions(hass: HomeAssistant) -> dict[str, type]:
     if not _has_purpose_condition_api():
         return {}
     if _CONDITIONS_CACHE is None:
-        from .condition_impl import build_conditions
+        try:
+            from .condition_impl import build_conditions
 
-        _CONDITIONS_CACHE = build_conditions()
+            _CONDITIONS_CACHE = build_conditions()
+        except ImportError as err:
+            _LOGGER.debug("plant.* conditions unavailable on this HA version: %s", err)
+            _CONDITIONS_CACHE = {}
     return _CONDITIONS_CACHE

--- a/custom_components/plant/condition_impl.py
+++ b/custom_components/plant/condition_impl.py
@@ -2,7 +2,29 @@
 
 from __future__ import annotations
 
+from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.condition import make_entity_state_condition
+
+from .automation_meta import STATUS_MEASUREMENTS
+from .const import DOMAIN, STATE_HIGH, STATE_LOW
+
+_STATUS_CONDITIONS = {
+    "is_low": STATE_LOW,
+    "is_high": STATE_HIGH,
+    "is_ok": STATE_OK,
+}
+
 
 def build_conditions() -> dict[str, type]:
-    """Assemble the full plant.* condition surface. Filled in Tasks 3 & 5."""
-    return {}
+    """Assemble the plant.* condition surface (aggregate + per-measurement status)."""
+    conditions: dict[str, type] = {
+        "has_problem": make_entity_state_condition(DOMAIN, STATE_PROBLEM),
+    }
+    for m in STATUS_MEASUREMENTS:
+        for suffix, state in _STATUS_CONDITIONS.items():
+            conditions[f"{m.key}_{suffix}"] = make_entity_state_condition(
+                {DOMAIN: DomainSpec(value_source=m.status_attr)},
+                state,
+            )
+    return conditions

--- a/custom_components/plant/condition_impl.py
+++ b/custom_components/plant/condition_impl.py
@@ -1,0 +1,8 @@
+"""2026.7-only condition construction. Imported lazily by condition.py."""
+
+from __future__ import annotations
+
+
+def build_conditions() -> dict[str, type]:
+    """Assemble the full plant.* condition surface. Filled in Tasks 3 & 5."""
+    return {}

--- a/custom_components/plant/condition_impl.py
+++ b/custom_components/plant/condition_impl.py
@@ -6,8 +6,9 @@ from homeassistant.const import STATE_OK, STATE_PROBLEM
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.condition import make_entity_state_condition
 
-from .automation_meta import STATUS_MEASUREMENTS
+from .automation_meta import EXTERNAL_MEASUREMENTS, STATUS_MEASUREMENTS
 from .const import DOMAIN, STATE_HIGH, STATE_LOW
+from .stale import make_stale_condition
 
 _STATUS_CONDITIONS = {
     "is_low": STATE_LOW,
@@ -27,4 +28,6 @@ def build_conditions() -> dict[str, type]:
                 {DOMAIN: DomainSpec(value_source=m.status_attr)},
                 state,
             )
+    for m in EXTERNAL_MEASUREMENTS:
+        conditions[f"{m.key}_sensor_is_stale"] = make_stale_condition(m)
     return conditions

--- a/custom_components/plant/conditions.yaml
+++ b/custom_components/plant/conditions.yaml
@@ -145,34 +145,76 @@ moisture_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 
 conductivity_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 
 temperature_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 
 soil_temperature_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 
 humidity_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 
 illuminance_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 
 co2_sensor_is_stale:
   target:
     entity:
       domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
 

--- a/custom_components/plant/conditions.yaml
+++ b/custom_components/plant/conditions.yaml
@@ -1,0 +1,178 @@
+# Condition descriptions for the plant integration (HA 2026.7+).
+# Generated from automation_meta.py — keep in sync.
+
+has_problem:
+  target:
+    entity:
+      domain: plant
+
+moisture_is_low:
+  target:
+    entity:
+      domain: plant
+
+moisture_is_high:
+  target:
+    entity:
+      domain: plant
+
+moisture_is_ok:
+  target:
+    entity:
+      domain: plant
+
+conductivity_is_low:
+  target:
+    entity:
+      domain: plant
+
+conductivity_is_high:
+  target:
+    entity:
+      domain: plant
+
+conductivity_is_ok:
+  target:
+    entity:
+      domain: plant
+
+temperature_is_low:
+  target:
+    entity:
+      domain: plant
+
+temperature_is_high:
+  target:
+    entity:
+      domain: plant
+
+temperature_is_ok:
+  target:
+    entity:
+      domain: plant
+
+soil_temperature_is_low:
+  target:
+    entity:
+      domain: plant
+
+soil_temperature_is_high:
+  target:
+    entity:
+      domain: plant
+
+soil_temperature_is_ok:
+  target:
+    entity:
+      domain: plant
+
+humidity_is_low:
+  target:
+    entity:
+      domain: plant
+
+humidity_is_high:
+  target:
+    entity:
+      domain: plant
+
+humidity_is_ok:
+  target:
+    entity:
+      domain: plant
+
+illuminance_is_low:
+  target:
+    entity:
+      domain: plant
+
+illuminance_is_high:
+  target:
+    entity:
+      domain: plant
+
+illuminance_is_ok:
+  target:
+    entity:
+      domain: plant
+
+co2_is_low:
+  target:
+    entity:
+      domain: plant
+
+co2_is_high:
+  target:
+    entity:
+      domain: plant
+
+co2_is_ok:
+  target:
+    entity:
+      domain: plant
+
+dli_is_low:
+  target:
+    entity:
+      domain: plant
+
+dli_is_high:
+  target:
+    entity:
+      domain: plant
+
+dli_is_ok:
+  target:
+    entity:
+      domain: plant
+
+vpd_is_low:
+  target:
+    entity:
+      domain: plant
+
+vpd_is_high:
+  target:
+    entity:
+      domain: plant
+
+vpd_is_ok:
+  target:
+    entity:
+      domain: plant
+
+moisture_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+
+conductivity_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+
+temperature_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+
+soil_temperature_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+
+humidity_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+
+illuminance_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+
+co2_sensor_is_stale:
+  target:
+    entity:
+      domain: plant
+

--- a/custom_components/plant/stale.py
+++ b/custom_components/plant/stale.py
@@ -1,0 +1,185 @@
+"""Per-measurement stale/fresh source-sensor tracking for plant.* triggers.
+
+A stale trigger targets the *plant* entity; it resolves that measurement's
+external source sensor from the PlantDevice and watches that sensor. "Stale" =
+unavailable/unknown, or no update within `for` (default 24h). Imported lazily
+by trigger_impl.py — only on HA with the 2026.7 API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_FOR,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.target import (
+    TargetStateChangedData,
+    async_track_target_selector_state_change_event,
+)
+from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
+from homeassistant.helpers.typing import ConfigType
+
+from .automation_meta import Measurement
+from .const import ATTR_PLANT, DOMAIN
+
+DEFAULT_STALE_FOR = timedelta(hours=24)
+_EXCLUDED = {STATE_UNAVAILABLE, STATE_UNKNOWN}
+
+
+def resolve_external_sensor(
+    hass: HomeAssistant, plant_entity_id: str, device_sensor_attr: str
+) -> str | None:
+    """Return the external source sensor entity_id for a plant measurement."""
+    for data in hass.data.get(DOMAIN, {}).values():
+        if not isinstance(data, dict) or ATTR_PLANT not in data:
+            continue
+        plant = data[ATTR_PLANT]
+        if plant.entity_id != plant_entity_id:
+            continue
+        sensor = getattr(plant, device_sensor_attr, None)
+        return getattr(sensor, "external_sensor", None) if sensor else None
+    return None
+
+
+def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger]:
+    """Build a stale (fresh=False) or fresh (fresh=True) trigger for a measurement."""
+
+    class _PlantStaleTrigger(Trigger):
+        _schema = vol.Schema(
+            {
+                vol.Required("target"): cv.TARGET_FIELDS,
+                vol.Optional("options", default=dict): vol.Schema(
+                    {vol.Optional(CONF_FOR): cv.positive_time_period},
+                    extra=vol.ALLOW_EXTRA,
+                ),
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
+
+        @classmethod
+        async def async_validate_config(
+            cls, hass: HomeAssistant, config: ConfigType
+        ) -> ConfigType:
+            return cls._schema(config)
+
+        def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+            super().__init__(hass, config)
+            self._target = config.target
+            self._duration: timedelta = (config.options or {}).get(
+                CONF_FOR
+            ) or DEFAULT_STALE_FOR
+
+        @callback
+        def _sources(self, entities: set[str]) -> set[str]:
+            """Map targeted plant entities to their external source sensor."""
+            resolved: set[str] = set()
+            for entity_id in entities:
+                if not entity_id.startswith(f"{DOMAIN}."):
+                    continue
+                source = resolve_external_sensor(
+                    self._hass, entity_id, measurement.device_sensor_attr
+                )
+                if source:
+                    resolved.add(source)
+            return resolved
+
+        async def async_attach_runner(
+            self, run_action: TriggerActionRunner, did_not_trigger: Any | None = None
+        ) -> CALLBACK_TYPE:
+            timers: dict[str, CALLBACK_TYPE] = {}
+            stale: set[str] = set()
+
+            @callback
+            def _fire(entity_id: str, reason: str | None) -> None:
+                data = {ATTR_ENTITY_ID: entity_id, "measurement": measurement.key}
+                if not fresh:
+                    data["reason"] = reason  # "unavailable" | "no_update"
+                run_action(data, f"{measurement.key} sensor {entity_id}", None)
+
+            @callback
+            def _mark_stale(entity_id: str, reason: str) -> None:
+                timer = timers.pop(entity_id, None)
+                if timer is not None:
+                    timer()
+                if entity_id not in stale:
+                    stale.add(entity_id)
+                    if not fresh:
+                        _fire(entity_id, reason)
+
+            @callback
+            def _arm(entity_id: str) -> None:
+                was_stale = entity_id in stale
+                stale.discard(entity_id)
+                timer = timers.pop(entity_id, None)
+                if timer is not None:
+                    timer()
+                if fresh and was_stale:
+                    _fire(entity_id, None)
+
+                @callback
+                def _expired(_now: datetime) -> None:
+                    timers.pop(entity_id, None)
+                    if entity_id not in stale:
+                        stale.add(entity_id)
+                        if not fresh:
+                            _fire(entity_id, "no_update")
+
+                timers[entity_id] = async_call_later(
+                    self._hass, self._duration, _expired
+                )
+
+            @callback
+            def _consider(entity_id: str, state: State | None) -> None:
+                if state is None or state.state in _EXCLUDED:
+                    _mark_stale(entity_id, "unavailable")
+                else:
+                    _arm(entity_id)
+
+            @callback
+            def _on_state_change(d: TargetStateChangedData) -> None:
+                ev = d.state_change_event
+                _consider(ev.data["entity_id"], ev.data["new_state"])
+
+            @callback
+            def _on_entities_update(
+                added: set[str],
+                removed: set[str],
+                entity_states: Mapping[str, State | None],
+            ) -> None:
+                for entity_id in removed:
+                    timer = timers.pop(entity_id, None)
+                    if timer is not None:
+                        timer()
+                    stale.discard(entity_id)
+                for entity_id in added:
+                    _consider(entity_id, entity_states.get(entity_id))
+
+            unsub = await async_track_target_selector_state_change_event(
+                self._hass,
+                self._target,
+                _on_state_change,
+                self._sources,
+                _on_entities_update,
+            )
+
+            @callback
+            def _remove() -> None:
+                unsub()
+                for timer in timers.values():
+                    timer()
+                timers.clear()
+                stale.clear()
+
+            return _remove
+
+    return _PlantStaleTrigger

--- a/custom_components/plant/stale.py
+++ b/custom_components/plant/stale.py
@@ -21,6 +21,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.condition import Condition, ConditionConfig
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.target import (
     TargetStateChangedData,
@@ -28,6 +29,7 @@ from homeassistant.helpers.target import (
 )
 from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.util import dt as dt_util
 
 from .automation_meta import Measurement
 from .const import ATTR_PLANT, DOMAIN
@@ -183,3 +185,61 @@ def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger
             return _remove
 
     return _PlantStaleTrigger
+
+
+def make_stale_condition(measurement: Measurement) -> type[Condition]:
+    """True when the measurement's external source sensor is currently stale."""
+
+    class _PlantStaleCondition(Condition):
+        _schema = vol.Schema(
+            {
+                vol.Required("target"): cv.TARGET_FIELDS,
+                vol.Optional("options", default=dict): vol.Schema(
+                    {vol.Optional(CONF_FOR): cv.positive_time_period},
+                    extra=vol.ALLOW_EXTRA,
+                ),
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
+
+        @classmethod
+        async def async_validate_config(
+            cls, hass: HomeAssistant, config: ConfigType
+        ) -> ConfigType:
+            return cls._schema(config)
+
+        def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+            super().__init__(hass, config)
+            self._target = config.target
+            self._duration: timedelta = (config.options or {}).get(
+                CONF_FOR
+            ) or DEFAULT_STALE_FOR
+
+        def _async_check(self, **kwargs: Any) -> bool:
+            from homeassistant.helpers.target import (
+                TargetSelection,
+                async_extract_referenced_entity_ids,
+            )
+
+            selection = TargetSelection(self._target)
+            selected = async_extract_referenced_entity_ids(
+                self._hass, selection, expand_group=False
+            )
+            plant_ids = selected.referenced | selected.indirectly_referenced
+            now = dt_util.utcnow()
+            for plant_id in plant_ids:
+                if not plant_id.startswith(f"{DOMAIN}."):
+                    continue
+                source = resolve_external_sensor(
+                    self._hass, plant_id, measurement.device_sensor_attr
+                )
+                if not source:
+                    continue
+                state = self._hass.states.get(source)
+                if state is None or state.state in _EXCLUDED:
+                    return True
+                if now - state.last_updated > self._duration:
+                    return True
+            return False
+
+    return _PlantStaleCondition

--- a/custom_components/plant/stale.py
+++ b/custom_components/plant/stale.py
@@ -37,6 +37,27 @@ from .const import ATTR_PLANT, DOMAIN
 DEFAULT_STALE_FOR = timedelta(hours=24)
 _EXCLUDED = {STATE_UNAVAILABLE, STATE_UNKNOWN}
 
+# Per-source status in the stale-detection state machine.
+_HEALTHY = "healthy"  # reporting real values; a freshness timer guards for silence
+_PENDING = "pending"  # stale since attach; a grace timer may promote it to stale
+_STALE = "stale"  # confirmed stale (fired became_stale unless this is a fresh trigger)
+
+_STALE_SCHEMA = vol.Schema(
+    {
+        vol.Required("target"): cv.TARGET_FIELDS,
+        vol.Optional("options", default=dict): vol.Schema(
+            {vol.Optional(CONF_FOR): cv.positive_time_period},
+            extra=vol.ALLOW_EXTRA,
+        ),
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+
+def _stale_duration(config: Any) -> timedelta:
+    """Return the configured `for` window, defaulting to DEFAULT_STALE_FOR."""
+    return (config.options or {}).get(CONF_FOR) or DEFAULT_STALE_FOR
+
 
 def resolve_external_sensor(
     hass: HomeAssistant, plant_entity_id: str, device_sensor_attr: str
@@ -57,29 +78,16 @@ def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger
     """Build a stale (fresh=False) or fresh (fresh=True) trigger for a measurement."""
 
     class _PlantStaleTrigger(Trigger):
-        _schema = vol.Schema(
-            {
-                vol.Required("target"): cv.TARGET_FIELDS,
-                vol.Optional("options", default=dict): vol.Schema(
-                    {vol.Optional(CONF_FOR): cv.positive_time_period},
-                    extra=vol.ALLOW_EXTRA,
-                ),
-            },
-            extra=vol.ALLOW_EXTRA,
-        )
-
         @classmethod
         async def async_validate_config(
             cls, hass: HomeAssistant, config: ConfigType
         ) -> ConfigType:
-            return cls._schema(config)
+            return _STALE_SCHEMA(config)
 
         def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
             super().__init__(hass, config)
             self._target = config.target
-            self._duration: timedelta = (config.options or {}).get(
-                CONF_FOR
-            ) or DEFAULT_STALE_FOR
+            self._duration: timedelta = _stale_duration(config)
 
         @callback
         def _sources(self, entities: set[str]) -> set[str]:
@@ -98,8 +106,16 @@ def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger
         async def async_attach_runner(
             self, run_action: TriggerActionRunner, did_not_trigger: Any | None = None
         ) -> CALLBACK_TYPE:
+            # Grace-period state machine, keyed per source entity:
+            #   healthy -> stale        real transition, fires became_stale now
+            #   healthy -> (silence)    freshness timer expires, fires no_update
+            #   pending -> healthy      recovered within grace, no fire
+            #   pending -> (silence)    grace timer expires still dead, fires stale
+            #   stale   -> healthy      real recovery, fires became_fresh
+            # `pending` exists only so a source that is already stale at attach (a
+            # sensor not yet populated after restart) does NOT fire immediately.
             timers: dict[str, CALLBACK_TYPE] = {}
-            stale: set[str] = set()
+            status: dict[str, str] = {}
 
             @callback
             def _fire(entity_id: str, reason: str | None) -> None:
@@ -109,48 +125,73 @@ def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger
                 run_action(data, f"{measurement.key} sensor {entity_id}", None)
 
             @callback
-            def _mark_stale(entity_id: str, reason: str) -> None:
+            def _cancel(entity_id: str) -> None:
+                # Enforce the invariant of at most one live timer per entity.
                 timer = timers.pop(entity_id, None)
                 if timer is not None:
                     timer()
-                if entity_id not in stale:
-                    stale.add(entity_id)
-                    if not fresh:
-                        _fire(entity_id, reason)
 
             @callback
-            def _arm(entity_id: str) -> None:
-                was_stale = entity_id in stale
-                stale.discard(entity_id)
-                timer = timers.pop(entity_id, None)
-                if timer is not None:
-                    timer()
+            def _on_healthy(entity_id: str) -> None:
+                was_stale = status.get(entity_id) == _STALE
+                _cancel(entity_id)
                 if fresh and was_stale:
                     _fire(entity_id, None)
+                status[entity_id] = _HEALTHY
 
                 @callback
-                def _expired(_now: datetime) -> None:
+                def _no_update(_now: datetime) -> None:
                     timers.pop(entity_id, None)
-                    if entity_id not in stale:
-                        stale.add(entity_id)
+                    if status.get(entity_id) != _STALE:
+                        status[entity_id] = _STALE
                         if not fresh:
                             _fire(entity_id, "no_update")
 
                 timers[entity_id] = async_call_later(
-                    self._hass, self._duration, _expired
+                    self._hass, self._duration, _no_update
                 )
 
             @callback
-            def _consider(entity_id: str, state: State | None) -> None:
+            def _on_stale(entity_id: str, *, initial: bool) -> None:
+                current = status.get(entity_id)
+                if not initial and current == _HEALTHY:
+                    # Real healthy -> stale transition: fire immediately.
+                    _cancel(entity_id)
+                    status[entity_id] = _STALE
+                    if not fresh:
+                        _fire(entity_id, "unavailable")
+                    return
+                if current in (_PENDING, _STALE):
+                    # pending: grace timer still running; stale: already fired.
+                    return
+                # Stale at attach / dynamic add (or an untracked transition): hold
+                # as pending under a grace timer instead of firing now.
+                status[entity_id] = _PENDING
+                _cancel(entity_id)
+
+                @callback
+                def _grace(_now: datetime) -> None:
+                    timers.pop(entity_id, None)
+                    if status.get(entity_id) == _PENDING:
+                        status[entity_id] = _STALE
+                        if not fresh:
+                            _fire(entity_id, "unavailable")
+
+                timers[entity_id] = async_call_later(self._hass, self._duration, _grace)
+
+            @callback
+            def _consider(
+                entity_id: str, state: State | None, *, initial: bool
+            ) -> None:
                 if state is None or state.state in _EXCLUDED:
-                    _mark_stale(entity_id, "unavailable")
+                    _on_stale(entity_id, initial=initial)
                 else:
-                    _arm(entity_id)
+                    _on_healthy(entity_id)
 
             @callback
             def _on_state_change(d: TargetStateChangedData) -> None:
                 ev = d.state_change_event
-                _consider(ev.data["entity_id"], ev.data["new_state"])
+                _consider(ev.data["entity_id"], ev.data["new_state"], initial=False)
 
             @callback
             def _on_entities_update(
@@ -159,12 +200,10 @@ def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger
                 entity_states: Mapping[str, State | None],
             ) -> None:
                 for entity_id in removed:
-                    timer = timers.pop(entity_id, None)
-                    if timer is not None:
-                        timer()
-                    stale.discard(entity_id)
+                    _cancel(entity_id)
+                    status.pop(entity_id, None)
                 for entity_id in added:
-                    _consider(entity_id, entity_states.get(entity_id))
+                    _consider(entity_id, entity_states.get(entity_id), initial=True)
 
             unsub = await async_track_target_selector_state_change_event(
                 self._hass,
@@ -180,7 +219,7 @@ def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger
                 for timer in timers.values():
                     timer()
                 timers.clear()
-                stale.clear()
+                status.clear()
 
             return _remove
 
@@ -191,29 +230,16 @@ def make_stale_condition(measurement: Measurement) -> type[Condition]:
     """True when the measurement's external source sensor is currently stale."""
 
     class _PlantStaleCondition(Condition):
-        _schema = vol.Schema(
-            {
-                vol.Required("target"): cv.TARGET_FIELDS,
-                vol.Optional("options", default=dict): vol.Schema(
-                    {vol.Optional(CONF_FOR): cv.positive_time_period},
-                    extra=vol.ALLOW_EXTRA,
-                ),
-            },
-            extra=vol.ALLOW_EXTRA,
-        )
-
         @classmethod
         async def async_validate_config(
             cls, hass: HomeAssistant, config: ConfigType
         ) -> ConfigType:
-            return cls._schema(config)
+            return _STALE_SCHEMA(config)
 
         def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
             super().__init__(hass, config)
             self._target = config.target
-            self._duration: timedelta = (config.options or {}).get(
-                CONF_FOR
-            ) or DEFAULT_STALE_FOR
+            self._duration: timedelta = _stale_duration(config)
 
         def _async_check(self, **kwargs: Any) -> bool:
             from homeassistant.helpers.target import (

--- a/custom_components/plant/trigger.py
+++ b/custom_components/plant/trigger.py
@@ -1,0 +1,31 @@
+"""Trigger platform for the plant integration (Home Assistant 2026.7+).
+
+Exposes purpose-specific ``plant.*`` triggers built on the integration's
+species-threshold-aware status. Import-safe on every supported HA version: the
+2026.7-only helper API is imported lazily and only when present, so on HA
+2025.8-2026.6 async_get_triggers returns {} and nothing is registered.
+"""
+
+from __future__ import annotations
+
+import homeassistant.helpers.trigger as ha_trigger
+from homeassistant.core import HomeAssistant
+
+_TRIGGERS_CACHE: dict[str, type] | None = None
+
+
+def _has_purpose_trigger_api() -> bool:
+    """True when the HA 2026.7 purpose-trigger helper API is available."""
+    return hasattr(ha_trigger, "make_entity_target_state_trigger")
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type]:
+    """Return the plant.* triggers, or {} on HA without the 2026.7 API."""
+    global _TRIGGERS_CACHE
+    if not _has_purpose_trigger_api():
+        return {}
+    if _TRIGGERS_CACHE is None:
+        from .trigger_impl import build_triggers
+
+        _TRIGGERS_CACHE = build_triggers()
+    return _TRIGGERS_CACHE

--- a/custom_components/plant/trigger.py
+++ b/custom_components/plant/trigger.py
@@ -8,15 +8,32 @@ species-threshold-aware status. Import-safe on every supported HA version: the
 
 from __future__ import annotations
 
-import homeassistant.helpers.trigger as ha_trigger
+import logging
+
 from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
 
 _TRIGGERS_CACHE: dict[str, type] | None = None
 
 
 def _has_purpose_trigger_api() -> bool:
-    """True when the HA 2026.7 purpose-trigger helper API is available."""
-    return hasattr(ha_trigger, "make_entity_target_state_trigger")
+    """True when the full HA 2026.7 purpose-trigger helper API is importable.
+
+    Checks the settled-2026.7 symbols, not just make_entity_target_state_trigger
+    (which also existed in the 2026.2-2026.6 Labs form without DomainSpec). Returns
+    False on the 2025.8 floor, on the Labs-era API, and on any future HA where a
+    required symbol has moved, so the platform stays inert instead of crashing
+    discovery with an ImportError.
+    """
+    try:
+        from homeassistant.helpers.automation import DomainSpec  # noqa: F401
+        from homeassistant.helpers.trigger import (  # noqa: F401
+            make_entity_target_state_trigger,
+        )
+    except ImportError:
+        return False
+    return True
 
 
 async def async_get_triggers(hass: HomeAssistant) -> dict[str, type]:
@@ -25,7 +42,11 @@ async def async_get_triggers(hass: HomeAssistant) -> dict[str, type]:
     if not _has_purpose_trigger_api():
         return {}
     if _TRIGGERS_CACHE is None:
-        from .trigger_impl import build_triggers
+        try:
+            from .trigger_impl import build_triggers
 
-        _TRIGGERS_CACHE = build_triggers()
+            _TRIGGERS_CACHE = build_triggers()
+        except ImportError as err:
+            _LOGGER.debug("plant.* triggers unavailable on this HA version: %s", err)
+            _TRIGGERS_CACHE = {}
     return _TRIGGERS_CACHE

--- a/custom_components/plant/trigger_impl.py
+++ b/custom_components/plant/trigger_impl.py
@@ -1,0 +1,8 @@
+"""2026.7-only trigger construction. Imported lazily by trigger.py."""
+
+from __future__ import annotations
+
+
+def build_triggers() -> dict[str, type]:
+    """Assemble the full plant.* trigger surface. Filled in Tasks 2 & 4."""
+    return {}

--- a/custom_components/plant/trigger_impl.py
+++ b/custom_components/plant/trigger_impl.py
@@ -2,7 +2,33 @@
 
 from __future__ import annotations
 
+from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.trigger import make_entity_target_state_trigger
+
+from .automation_meta import STATUS_MEASUREMENTS
+from .const import DOMAIN, STATE_HIGH, STATE_LOW
+
+# transition-name suffix -> plant <m>_status value it maps to
+_STATUS_TRANSITIONS = {
+    "became_low": STATE_LOW,
+    "became_high": STATE_HIGH,
+    "became_ok": STATE_OK,
+}
+
 
 def build_triggers() -> dict[str, type]:
-    """Assemble the full plant.* trigger surface. Filled in Tasks 2 & 4."""
-    return {}
+    """Assemble the plant.* trigger surface (aggregate + per-measurement status)."""
+    triggers: dict[str, type] = {
+        # Aggregate plant health (entity state).
+        "problem_detected": make_entity_target_state_trigger(DOMAIN, STATE_PROBLEM),
+        "problem_cleared": make_entity_target_state_trigger(DOMAIN, STATE_OK),
+    }
+    # Per-measurement status, auto-thresholded off the plant's own <m>_status.
+    for m in STATUS_MEASUREMENTS:
+        for suffix, to_state in _STATUS_TRANSITIONS.items():
+            triggers[f"{m.key}_{suffix}"] = make_entity_target_state_trigger(
+                {DOMAIN: DomainSpec(value_source=m.status_attr)},
+                to_state,
+            )
+    return triggers

--- a/custom_components/plant/trigger_impl.py
+++ b/custom_components/plant/trigger_impl.py
@@ -6,8 +6,9 @@ from homeassistant.const import STATE_OK, STATE_PROBLEM
 from homeassistant.helpers.automation import DomainSpec
 from homeassistant.helpers.trigger import make_entity_target_state_trigger
 
-from .automation_meta import STATUS_MEASUREMENTS
+from .automation_meta import EXTERNAL_MEASUREMENTS, STATUS_MEASUREMENTS
 from .const import DOMAIN, STATE_HIGH, STATE_LOW
+from .stale import make_stale_trigger
 
 # transition-name suffix -> plant <m>_status value it maps to
 _STATUS_TRANSITIONS = {
@@ -31,4 +32,8 @@ def build_triggers() -> dict[str, type]:
                 {DOMAIN: DomainSpec(value_source=m.status_attr)},
                 to_state,
             )
+    # Per-measurement source-sensor staleness (external measurements only).
+    for m in EXTERNAL_MEASUREMENTS:
+        triggers[f"{m.key}_sensor_became_stale"] = make_stale_trigger(m, fresh=False)
+        triggers[f"{m.key}_sensor_became_fresh"] = make_stale_trigger(m, fresh=True)
     return triggers

--- a/custom_components/plant/triggers.yaml
+++ b/custom_components/plant/triggers.yaml
@@ -1,0 +1,505 @@
+# Trigger descriptions for the plant integration (HA 2026.7+).
+# Generated from automation_meta.py — keep in sync.
+
+problem_detected:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+problem_cleared:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+moisture_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+moisture_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+moisture_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+conductivity_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+conductivity_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+conductivity_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+temperature_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+temperature_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+temperature_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+soil_temperature_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+soil_temperature_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+soil_temperature_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+humidity_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+humidity_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+humidity_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+illuminance_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+illuminance_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+illuminance_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+co2_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+co2_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+co2_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+dli_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+dli_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+dli_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+vpd_became_low:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+vpd_became_high:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+vpd_became_ok:
+  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+
+moisture_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+moisture_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+conductivity_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+conductivity_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+temperature_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+temperature_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+soil_temperature_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+soil_temperature_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+humidity_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+humidity_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+illuminance_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+illuminance_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+co2_sensor_became_stale:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+
+co2_sensor_became_fresh:
+  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+

--- a/docs/superpowers/plans/2026-07-27-plant-triggers-conditions.md
+++ b/docs/superpowers/plans/2026-07-27-plant-triggers-conditions.md
@@ -1,0 +1,1225 @@
+# Plant `plant.*` Triggers & Conditions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the full `plant.*` purpose-trigger and -condition surface for Home Assistant 2026.7+, auto-thresholded off the plant's own per-measurement status, while staying inert and import-clean on HA 2025.8–2026.6.
+
+**Architecture:** A pure-data measurement table (`automation_meta.py`) is the single source of truth. `trigger.py` and `condition.py` expose `async_get_triggers`/`async_get_conditions`; both feature-detect the 2026.7 purpose-trigger API and return `{}` when it's absent, doing all 2026.7-only imports lazily inside a cached `_build_*()` helper. Status families are generated with core's `make_entity_target_state_trigger` / `make_entity_state_condition` reading the plant's `<m>_status` attribute via `DomainSpec(value_source=...)`. Stale families are a custom `Trigger`/`Condition` that resolves each measurement's external source sensor from the `PlantDevice` and watches *that* sensor.
+
+**Tech Stack:** Python 3.13+, Home Assistant core helpers (`homeassistant.helpers.trigger`, `.condition`, `.automation`, `.target`, `.event`), pytest + `pytest-homeassistant-custom-component`, black, ruff.
+
+## Global Constraints
+
+- **HA version floor: 2025.8.** The integration must load cleanly on 2025.8+. `trigger.py`/`condition.py` MUST NOT import any of `make_entity_target_state_trigger`, `make_entity_state_condition`, `TriggerConfig`, `TriggerActionRunner`, `ConditionConfig`, `DomainSpec`, `TargetStateChangedData`, `async_track_target_selector_state_change_event` at module top level. All such imports happen lazily inside a `_build_*()` function guarded by feature detection.
+- **Feature detection, not version strings:** gate on `hasattr(homeassistant.helpers.trigger, "make_entity_target_state_trigger")`.
+- **`async_get_triggers`/`async_get_conditions` return `{}`** when the API is absent — no registration, no exception, no log noise.
+- **Naming is verbatim from the spec** (copy exactly):
+  - Aggregate triggers: `problem_detected`, `problem_cleared`; condition: `has_problem`.
+  - Per-measurement status triggers: `<m>_became_low`, `<m>_became_high`, `<m>_became_ok`; conditions: `<m>_is_low`, `<m>_is_high`, `<m>_is_ok`.
+  - Per-measurement stale triggers: `<m>_sensor_became_stale`, `<m>_sensor_became_fresh`; condition: `<m>_sensor_is_stale`.
+- **Status measurements (9):** `moisture, conductivity, temperature, soil_temperature, humidity, illuminance, co2, dli, vpd`.
+- **External measurements (7):** the above minus `dli, vpd` (and `ppfd`, which has no status). Stale families apply to external only.
+- **Status values:** `STATE_LOW = "Low"`, `STATE_HIGH = "High"` (from `.const`); `STATE_OK = "ok"`, `STATE_PROBLEM = "problem"` (from `homeassistant.const`).
+- **Stale default window:** 24h (`timedelta(hours=24)`), overridable via the trigger/condition `for:` option.
+- **No `crossed_threshold` family** (explicit non-goal).
+- Run `black custom_components/plant/ tests/` before every commit; keep `ruff` clean.
+- Tests that exercise the 2026.7 API are gated to skip below 2026.7 (module-level skip, as the existing `tests/test_triggers.py` does).
+
+---
+
+### Task 1: Measurement metadata table + version-safe platform scaffolding
+
+**Files:**
+- Create: `custom_components/plant/automation_meta.py`
+- Rewrite: `custom_components/plant/trigger.py` (replace strawman)
+- Rewrite: `custom_components/plant/condition.py` (replace strawman)
+- Rewrite: `tests/test_triggers.py` (replace strawman key-set tests; keep module skip guard)
+- Create: `tests/test_automation_version_safety.py`
+
+**Interfaces:**
+- Produces: `automation_meta.Measurement` (NamedTuple `key: str`, `status_attr: str`, `device_sensor_attr: str | None`); `automation_meta.STATUS_MEASUREMENTS: tuple[Measurement, ...]`; `automation_meta.EXTERNAL_MEASUREMENTS: tuple[Measurement, ...]`.
+- Produces: `trigger.async_get_triggers(hass) -> dict[str, type]`; `condition.async_get_conditions(hass) -> dict[str, type]`; both return `{}` when the 2026.7 API is absent.
+- Produces: `trigger._has_purpose_trigger_api() -> bool`; `condition._has_purpose_condition_api() -> bool`.
+
+- [ ] **Step 1: Write the measurement table (pure data, always import-safe)**
+
+Create `custom_components/plant/automation_meta.py`:
+
+```python
+"""Shared metadata for the plant.* trigger/condition surface.
+
+Pure data — safe to import on any Home Assistant version. The 2026.7-only
+trigger/condition helper APIs are imported lazily inside trigger.py /
+condition.py, never here.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+
+class Measurement(NamedTuple):
+    """One plant measurement and how the automation surface reaches it."""
+
+    key: str
+    """Name fragment and status-attribute prefix, e.g. "moisture"."""
+    status_attr: str
+    """Plant entity attribute holding Low/High/ok, e.g. "moisture_status"."""
+    device_sensor_attr: str | None
+    """PlantDevice attribute holding the external source sensor entity, or
+    None for derived measurements (dli, vpd) that have no source of their own."""
+
+
+# The 9 measurements that expose a <key>_status attribute (Low / High / ok).
+STATUS_MEASUREMENTS: tuple[Measurement, ...] = (
+    Measurement("moisture", "moisture_status", "sensor_moisture"),
+    Measurement("conductivity", "conductivity_status", "sensor_conductivity"),
+    Measurement("temperature", "temperature_status", "sensor_temperature"),
+    Measurement(
+        "soil_temperature", "soil_temperature_status", "sensor_soil_temperature"
+    ),
+    Measurement("humidity", "humidity_status", "sensor_humidity"),
+    Measurement("illuminance", "illuminance_status", "sensor_illuminance"),
+    Measurement("co2", "co2_status", "sensor_co2"),
+    Measurement("dli", "dli_status", None),
+    Measurement("vpd", "vpd_status", None),
+)
+
+# The 7 externally-sourced measurements (can go stale independently).
+EXTERNAL_MEASUREMENTS: tuple[Measurement, ...] = tuple(
+    m for m in STATUS_MEASUREMENTS if m.device_sensor_attr is not None
+)
+```
+
+- [ ] **Step 2: Write the failing version-safety + key-set tests**
+
+Create `tests/test_automation_version_safety.py`:
+
+```python
+"""The trigger/condition platforms must be import-clean and return {} when the
+2026.7 purpose-trigger API is unavailable (HA 2025.8-2026.6)."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.plant import condition, trigger
+
+
+async def test_triggers_empty_when_api_absent(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(trigger, "_has_purpose_trigger_api", lambda: False)
+    assert await trigger.async_get_triggers(hass) == {}
+
+
+async def test_conditions_empty_when_api_absent(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(condition, "_has_purpose_condition_api", lambda: False)
+    assert await condition.async_get_conditions(hass) == {}
+```
+
+Replace the two key-set tests at the top of `tests/test_triggers.py` (keep the
+module-level HA-version skip guard, lines 1-30, unchanged) with:
+
+```python
+from custom_components.plant.automation_meta import (
+    EXTERNAL_MEASUREMENTS,
+    STATUS_MEASUREMENTS,
+)
+from custom_components.plant.condition import async_get_conditions
+from custom_components.plant.trigger import async_get_triggers
+
+
+def _expected_trigger_keys() -> set[str]:
+    keys = {"problem_detected", "problem_cleared"}
+    for m in STATUS_MEASUREMENTS:
+        keys |= {f"{m.key}_became_low", f"{m.key}_became_high", f"{m.key}_became_ok"}
+    for m in EXTERNAL_MEASUREMENTS:
+        keys |= {f"{m.key}_sensor_became_stale", f"{m.key}_sensor_became_fresh"}
+    return keys
+
+
+def _expected_condition_keys() -> set[str]:
+    keys = {"has_problem"}
+    for m in STATUS_MEASUREMENTS:
+        keys |= {f"{m.key}_is_low", f"{m.key}_is_high", f"{m.key}_is_ok"}
+    for m in EXTERNAL_MEASUREMENTS:
+        keys |= {f"{m.key}_sensor_is_stale"}
+    return keys
+
+
+async def test_async_get_triggers_full_surface(hass: HomeAssistant) -> None:
+    assert set(await async_get_triggers(hass)) == _expected_trigger_keys()
+    assert len(_expected_trigger_keys()) == 43
+
+
+async def test_async_get_conditions_full_surface(hass: HomeAssistant) -> None:
+    assert set(await async_get_conditions(hass)) == _expected_condition_keys()
+    assert len(_expected_condition_keys()) == 35
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `source .venv/bin/activate && python -m pytest tests/test_automation_version_safety.py tests/test_triggers.py -q`
+Expected: FAIL — `trigger._has_purpose_trigger_api` / `_build_*` not defined, key sets don't match.
+
+- [ ] **Step 4: Write the version-safe `trigger.py` scaffolding**
+
+Replace `custom_components/plant/trigger.py` entirely:
+
+```python
+"""Trigger platform for the plant integration (Home Assistant 2026.7+).
+
+Exposes purpose-specific ``plant.*`` triggers built on the integration's
+species-threshold-aware status. Import-safe on every supported HA version: the
+2026.7-only helper API is imported lazily and only when present, so on HA
+2025.8-2026.6 async_get_triggers returns {} and nothing is registered.
+"""
+
+from __future__ import annotations
+
+import homeassistant.helpers.trigger as ha_trigger
+from homeassistant.core import HomeAssistant
+
+_TRIGGERS_CACHE: dict[str, type] | None = None
+
+
+def _has_purpose_trigger_api() -> bool:
+    """True when the HA 2026.7 purpose-trigger helper API is available."""
+    return hasattr(ha_trigger, "make_entity_target_state_trigger")
+
+
+async def async_get_triggers(hass: HomeAssistant) -> dict[str, type]:
+    """Return the plant.* triggers, or {} on HA without the 2026.7 API."""
+    global _TRIGGERS_CACHE
+    if not _has_purpose_trigger_api():
+        return {}
+    if _TRIGGERS_CACHE is None:
+        from .trigger_impl import build_triggers
+
+        _TRIGGERS_CACHE = build_triggers()
+    return _TRIGGERS_CACHE
+```
+
+Create an empty stub `custom_components/plant/trigger_impl.py` so the import
+resolves (filled in Tasks 2 & 4):
+
+```python
+"""2026.7-only trigger construction. Imported lazily by trigger.py."""
+
+from __future__ import annotations
+
+
+def build_triggers() -> dict[str, type]:
+    """Assemble the full plant.* trigger surface. Filled in Tasks 2 & 4."""
+    return {}
+```
+
+- [ ] **Step 5: Write the version-safe `condition.py` scaffolding**
+
+Replace `custom_components/plant/condition.py` entirely (mirror of trigger.py):
+
+```python
+"""Condition platform for the plant integration (Home Assistant 2026.7+).
+
+Mirror of trigger.py: import-safe everywhere, returns {} on HA without the
+2026.7 purpose-condition API.
+"""
+
+from __future__ import annotations
+
+import homeassistant.helpers.condition as ha_condition
+from homeassistant.core import HomeAssistant
+
+_CONDITIONS_CACHE: dict[str, type] | None = None
+
+
+def _has_purpose_condition_api() -> bool:
+    """True when the HA 2026.7 purpose-condition helper API is available."""
+    return hasattr(ha_condition, "make_entity_state_condition")
+
+
+async def async_get_conditions(hass: HomeAssistant) -> dict[str, type]:
+    """Return the plant.* conditions, or {} on HA without the 2026.7 API."""
+    global _CONDITIONS_CACHE
+    if not _has_purpose_condition_api():
+        return {}
+    if _CONDITIONS_CACHE is None:
+        from .condition_impl import build_conditions
+
+        _CONDITIONS_CACHE = build_conditions()
+    return _CONDITIONS_CACHE
+```
+
+Create stub `custom_components/plant/condition_impl.py`:
+
+```python
+"""2026.7-only condition construction. Imported lazily by condition.py."""
+
+from __future__ import annotations
+
+
+def build_conditions() -> dict[str, type]:
+    """Assemble the full plant.* condition surface. Filled in Tasks 3 & 5."""
+    return {}
+```
+
+- [ ] **Step 6: Run version-safety tests (pass) and full-surface tests (still fail)**
+
+Run: `python -m pytest tests/test_automation_version_safety.py -q`
+Expected: PASS (both return `{}`).
+Run: `python -m pytest tests/test_triggers.py::test_async_get_triggers_full_surface -q`
+Expected: FAIL — build returns `{}`, key set mismatch. (Filled in Tasks 2-5.)
+
+- [ ] **Step 7: Format and commit**
+
+```bash
+black custom_components/plant/ tests/
+git add custom_components/plant/automation_meta.py \
+        custom_components/plant/trigger.py custom_components/plant/trigger_impl.py \
+        custom_components/plant/condition.py custom_components/plant/condition_impl.py \
+        tests/test_automation_version_safety.py tests/test_triggers.py
+git commit -m "feat: version-safe plant trigger/condition scaffolding + measurement table"
+```
+
+---
+
+### Task 2: Aggregate + per-measurement status triggers
+
+**Files:**
+- Modify: `custom_components/plant/trigger_impl.py`
+- Test: `tests/test_triggers.py`
+
+**Interfaces:**
+- Consumes: `automation_meta.STATUS_MEASUREMENTS`; `homeassistant.helpers.trigger.make_entity_target_state_trigger`; `homeassistant.helpers.automation.DomainSpec`.
+- Produces: `trigger_impl.build_triggers()` now returns the 2 aggregate + 27 status triggers (stale added in Task 4).
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+Add to `tests/test_triggers.py` (the `async_capture_events` / `async_setup_component` helpers are already imported at the top of the strawman file):
+
+```python
+async def test_problem_detected_fires(hass: HomeAssistant) -> None:
+    hass.states.async_set("plant.test", "ok")
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "plant_problem")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"trigger": "plant.problem_detected",
+                        "target": {"entity_id": "plant.test"}},
+            "action": {"event": "plant_problem"}}},
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("plant.test", "problem")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_became_low_uses_status_attribute(hass: HomeAssistant) -> None:
+    hass.states.async_set("plant.test", "ok", {"moisture_status": "ok"})
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "moisture_low")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"trigger": "plant.moisture_became_low",
+                        "target": {"entity_id": "plant.test"}},
+            "action": {"event": "moisture_low"}}},
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("plant.test", "problem", {"moisture_status": "Low"})
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_became_ok_fires_on_recovery(hass: HomeAssistant) -> None:
+    hass.states.async_set("plant.test", "problem", {"moisture_status": "Low"})
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "moisture_ok")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"trigger": "plant.moisture_became_ok",
+                        "target": {"entity_id": "plant.test"}},
+            "action": {"event": "moisture_ok"}}},
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("plant.test", "ok", {"moisture_status": "ok"})
+    await hass.async_block_till_done()
+    assert len(events) == 1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_triggers.py::test_problem_detected_fires tests/test_triggers.py::test_moisture_became_ok_fires_on_recovery -q`
+Expected: FAIL — trigger key `plant.problem_detected` unknown.
+
+- [ ] **Step 3: Implement the aggregate + status triggers in `trigger_impl.py`**
+
+Replace `build_triggers` in `custom_components/plant/trigger_impl.py`:
+
+```python
+"""2026.7-only trigger construction. Imported lazily by trigger.py."""
+
+from __future__ import annotations
+
+from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.trigger import make_entity_target_state_trigger
+
+from .automation_meta import STATUS_MEASUREMENTS
+from .const import DOMAIN, STATE_HIGH, STATE_LOW
+
+# transition-name suffix -> plant <m>_status value it maps to
+_STATUS_TRANSITIONS = {
+    "became_low": STATE_LOW,
+    "became_high": STATE_HIGH,
+    "became_ok": STATE_OK,
+}
+
+
+def build_triggers() -> dict[str, type]:
+    """Assemble the plant.* trigger surface (aggregate + per-measurement status)."""
+    triggers: dict[str, type] = {
+        # Aggregate plant health (entity state).
+        "problem_detected": make_entity_target_state_trigger(DOMAIN, STATE_PROBLEM),
+        "problem_cleared": make_entity_target_state_trigger(DOMAIN, STATE_OK),
+    }
+    # Per-measurement status, auto-thresholded off the plant's own <m>_status.
+    for m in STATUS_MEASUREMENTS:
+        for suffix, to_state in _STATUS_TRANSITIONS.items():
+            triggers[f"{m.key}_{suffix}"] = make_entity_target_state_trigger(
+                {DOMAIN: DomainSpec(value_source=m.status_attr)},
+                to_state,
+            )
+    return triggers
+```
+
+- [ ] **Step 4: Run the behavioral + surface tests**
+
+Run: `python -m pytest tests/test_triggers.py -q -k "problem_detected or moisture_became or became_ok"`
+Expected: PASS.
+Run: `python -m pytest tests/test_triggers.py::test_async_get_triggers_full_surface -q`
+Expected: still FAIL (stale keys missing — added in Task 4). Confirm the failure names only the 14 `_sensor_became_*` keys.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+black custom_components/plant/ tests/
+git add custom_components/plant/trigger_impl.py tests/test_triggers.py
+git commit -m "feat: aggregate + per-measurement status plant triggers"
+```
+
+---
+
+### Task 3: Per-measurement status conditions + aggregate `has_problem`
+
+**Files:**
+- Modify: `custom_components/plant/condition_impl.py`
+- Test: `tests/test_conditions.py` (create)
+
+**Interfaces:**
+- Consumes: `automation_meta.STATUS_MEASUREMENTS`; `homeassistant.helpers.condition.make_entity_state_condition`; `homeassistant.helpers.automation.DomainSpec`.
+- Produces: `condition_impl.build_conditions()` returns the 1 aggregate + 27 status conditions (stale added in Task 5).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_conditions.py`:
+
+```python
+"""Tests for the plant.* condition surface (HA 2026.7+)."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.const import __version__ as HA_VERSION
+
+_p = HA_VERSION.split(".")
+if (int(_p[0]), int(_p[1])) < (2026, 7):
+    pytest.skip(
+        "plant conditions require the HA 2026.7+ platform",
+        allow_module_level=True,
+    )
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_capture_events
+
+
+async def _condition_passes(hass: HomeAssistant, cond: dict) -> bool:
+    events = async_capture_events(hass, "cond_passed")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"platform": "event", "event_type": "probe"},
+            "condition": cond,
+            "action": {"event": "cond_passed"}}},
+    )
+    await hass.async_block_till_done()
+    await hass.services.async_call(
+        "automation", "trigger",
+        {"entity_id": "automation.automation_0", "skip_condition": False},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    return len(events) == 1
+
+
+@pytest.mark.parametrize(("state", "expected"), [("problem", True), ("ok", False)])
+async def test_has_problem(hass: HomeAssistant, state: str, expected: bool) -> None:
+    hass.states.async_set("plant.test", state)
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass, {"condition": "plant.has_problem", "target": {"entity_id": "plant.test"}}
+    )
+    assert got is expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"), [("Low", True), ("High", False), ("ok", False)]
+)
+async def test_moisture_is_low(hass: HomeAssistant, status: str, expected: bool) -> None:
+    hass.states.async_set("plant.test", "problem", {"moisture_status": status})
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {"condition": "plant.moisture_is_low", "target": {"entity_id": "plant.test"}},
+    )
+    assert got is expected
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_conditions.py -q`
+Expected: FAIL — condition `plant.has_problem` unknown.
+
+- [ ] **Step 3: Implement conditions in `condition_impl.py`**
+
+Replace `build_conditions` in `custom_components/plant/condition_impl.py`:
+
+```python
+"""2026.7-only condition construction. Imported lazily by condition.py."""
+
+from __future__ import annotations
+
+from homeassistant.const import STATE_OK, STATE_PROBLEM
+from homeassistant.helpers.automation import DomainSpec
+from homeassistant.helpers.condition import make_entity_state_condition
+
+from .automation_meta import STATUS_MEASUREMENTS
+from .const import DOMAIN, STATE_HIGH, STATE_LOW
+
+_STATUS_CONDITIONS = {
+    "is_low": STATE_LOW,
+    "is_high": STATE_HIGH,
+    "is_ok": STATE_OK,
+}
+
+
+def build_conditions() -> dict[str, type]:
+    """Assemble the plant.* condition surface (aggregate + per-measurement status)."""
+    conditions: dict[str, type] = {
+        "has_problem": make_entity_state_condition(DOMAIN, STATE_PROBLEM),
+    }
+    for m in STATUS_MEASUREMENTS:
+        for suffix, state in _STATUS_CONDITIONS.items():
+            conditions[f"{m.key}_{suffix}"] = make_entity_state_condition(
+                {DOMAIN: DomainSpec(value_source=m.status_attr)},
+                state,
+            )
+    return conditions
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_conditions.py -q`
+Expected: PASS.
+Run: `python -m pytest tests/test_triggers.py::test_async_get_conditions_full_surface -q`
+Expected: still FAIL (stale conditions missing — Task 5).
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+black custom_components/plant/ tests/
+git add custom_components/plant/condition_impl.py tests/test_conditions.py
+git commit -m "feat: aggregate + per-measurement status plant conditions"
+```
+
+---
+
+### Task 4: Per-measurement stale/fresh triggers
+
+**Files:**
+- Create: `custom_components/plant/stale.py`
+- Modify: `custom_components/plant/trigger_impl.py`
+- Test: `tests/test_triggers.py`
+
+**Interfaces:**
+- Consumes: `automation_meta.EXTERNAL_MEASUREMENTS`; `PlantDevice` attributes `sensor_<measurement>` (each a sensor entity exposing `.external_sensor: str | None` and `.entity_id`); `hass.data[DOMAIN][entry_id][ATTR_PLANT]`.
+- Produces: `stale.resolve_external_sensor(hass, plant_entity_id, device_sensor_attr) -> str | None`; `stale.make_stale_trigger(measurement, fresh: bool) -> type[Trigger]`.
+- Produces: `trigger_impl.build_triggers()` now also returns the 14 stale/fresh triggers.
+
+- [ ] **Step 1: Write the failing tests (targeting the plant entity; sensor resolved internally)**
+
+Add to `tests/test_triggers.py`. These use the real integration setup fixture
+`init_integration` from `tests/conftest.py` (a configured plant with external
+`sensor.test_*` sources):
+
+```python
+from datetime import timedelta
+
+import homeassistant.util.dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.plant.const import ATTR_PLANT, DOMAIN as PLANT_DOMAIN
+
+
+def _plant_entity_id(hass, init_integration) -> str:
+    return hass.data[PLANT_DOMAIN][init_integration.entry_id][ATTR_PLANT].entity_id
+
+
+async def test_moisture_sensor_became_stale_on_unavailable(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    events = async_capture_events(hass, "stale")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"trigger": "plant.moisture_sensor_became_stale",
+                        "target": {"entity_id": plant_id}},
+            "action": {"event": "stale",
+                       "event_data": {"reason": "{{ trigger.reason }}"}}}},
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["reason"] == "unavailable"
+
+
+async def test_moisture_sensor_became_stale_on_no_update(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    events = async_capture_events(hass, "stale")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"trigger": "plant.moisture_sensor_became_stale",
+                        "target": {"entity_id": plant_id},
+                        "options": {"for": {"seconds": 30}}},
+            "action": {"event": "stale"}}},
+    )
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_sensor_became_fresh_on_recovery(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "fresh")
+    assert await async_setup_component(
+        hass, "automation",
+        {"automation": {
+            "trigger": {"trigger": "plant.moisture_sensor_became_fresh",
+                        "target": {"entity_id": plant_id}},
+            "action": {"event": "fresh"}}},
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_moisture", "42")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_triggers.py -q -k "sensor_became_stale or sensor_became_fresh"`
+Expected: FAIL — trigger key unknown.
+
+- [ ] **Step 3: Implement `stale.py` (external-sensor resolution + custom Trigger)**
+
+Create `custom_components/plant/stale.py`:
+
+```python
+"""Per-measurement stale/fresh source-sensor tracking for plant.* triggers.
+
+A stale trigger targets the *plant* entity; it resolves that measurement's
+external source sensor from the PlantDevice and watches that sensor. "Stale" =
+unavailable/unknown, or no update within `for` (default 24h). Imported lazily
+by trigger_impl.py — only on HA with the 2026.7 API.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timedelta
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_FOR,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+)
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, State, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.target import (
+    TargetStateChangedData,
+    async_track_target_selector_state_change_event,
+)
+from homeassistant.helpers.trigger import Trigger, TriggerActionRunner, TriggerConfig
+from homeassistant.helpers.typing import ConfigType
+
+from .automation_meta import Measurement
+from .const import ATTR_PLANT, DOMAIN
+
+DEFAULT_STALE_FOR = timedelta(hours=24)
+_EXCLUDED = {STATE_UNAVAILABLE, STATE_UNKNOWN}
+
+
+def resolve_external_sensor(
+    hass: HomeAssistant, plant_entity_id: str, device_sensor_attr: str
+) -> str | None:
+    """Return the external source sensor entity_id for a plant measurement."""
+    for data in hass.data.get(DOMAIN, {}).values():
+        if not isinstance(data, dict) or ATTR_PLANT not in data:
+            continue
+        plant = data[ATTR_PLANT]
+        if plant.entity_id != plant_entity_id:
+            continue
+        sensor = getattr(plant, device_sensor_attr, None)
+        return getattr(sensor, "external_sensor", None) if sensor else None
+    return None
+
+
+def make_stale_trigger(measurement: Measurement, *, fresh: bool) -> type[Trigger]:
+    """Build a stale (fresh=False) or fresh (fresh=True) trigger for a measurement."""
+
+    class _PlantStaleTrigger(Trigger):
+        _schema = vol.Schema(
+            {
+                vol.Required("target"): cv.TARGET_FIELDS,
+                vol.Optional("options", default=dict): vol.Schema(
+                    {vol.Optional(CONF_FOR): cv.positive_time_period},
+                    extra=vol.ALLOW_EXTRA,
+                ),
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
+
+        @classmethod
+        async def async_validate_config(
+            cls, hass: HomeAssistant, config: ConfigType
+        ) -> ConfigType:
+            return cls._schema(config)
+
+        def __init__(self, hass: HomeAssistant, config: TriggerConfig) -> None:
+            super().__init__(hass, config)
+            self._target = config.target
+            self._duration: timedelta = (config.options or {}).get(
+                CONF_FOR
+            ) or DEFAULT_STALE_FOR
+
+        @callback
+        def _sources(self, entities: set[str]) -> set[str]:
+            """Map targeted plant entities to their external source sensor."""
+            resolved: set[str] = set()
+            for entity_id in entities:
+                if not entity_id.startswith(f"{DOMAIN}."):
+                    continue
+                source = resolve_external_sensor(
+                    self._hass, entity_id, measurement.device_sensor_attr
+                )
+                if source:
+                    resolved.add(source)
+            return resolved
+
+        async def async_attach_runner(
+            self, run_action: TriggerActionRunner, did_not_trigger: Any | None = None
+        ) -> CALLBACK_TYPE:
+            timers: dict[str, CALLBACK_TYPE] = {}
+            stale: set[str] = set()
+
+            @callback
+            def _fire(entity_id: str, reason: str | None) -> None:
+                data = {ATTR_ENTITY_ID: entity_id, "measurement": measurement.key}
+                if not fresh:
+                    data["reason"] = reason  # "unavailable" | "no_update"
+                run_action(data, f"{measurement.key} sensor {entity_id}", None)
+
+            @callback
+            def _mark_stale(entity_id: str, reason: str) -> None:
+                timer = timers.pop(entity_id, None)
+                if timer is not None:
+                    timer()
+                if entity_id not in stale:
+                    stale.add(entity_id)
+                    if not fresh:
+                        _fire(entity_id, reason)
+
+            @callback
+            def _arm(entity_id: str) -> None:
+                was_stale = entity_id in stale
+                stale.discard(entity_id)
+                timer = timers.pop(entity_id, None)
+                if timer is not None:
+                    timer()
+                if fresh and was_stale:
+                    _fire(entity_id, None)
+
+                @callback
+                def _expired(_now: datetime) -> None:
+                    timers.pop(entity_id, None)
+                    if entity_id not in stale:
+                        stale.add(entity_id)
+                        if not fresh:
+                            _fire(entity_id, "no_update")
+
+                timers[entity_id] = async_call_later(
+                    self._hass, self._duration, _expired
+                )
+
+            @callback
+            def _consider(entity_id: str, state: State | None) -> None:
+                if state is None or state.state in _EXCLUDED:
+                    _mark_stale(entity_id, "unavailable")
+                else:
+                    _arm(entity_id)
+
+            @callback
+            def _on_state_change(d: TargetStateChangedData) -> None:
+                ev = d.state_change_event
+                _consider(ev.data["entity_id"], ev.data["new_state"])
+
+            @callback
+            def _on_entities_update(
+                added: set[str],
+                removed: set[str],
+                entity_states: Mapping[str, State | None],
+            ) -> None:
+                for entity_id in removed:
+                    timer = timers.pop(entity_id, None)
+                    if timer is not None:
+                        timer()
+                    stale.discard(entity_id)
+                for entity_id in added:
+                    _consider(entity_id, entity_states.get(entity_id))
+
+            unsub = await async_track_target_selector_state_change_event(
+                self._hass, self._target, _on_state_change, self._sources,
+                _on_entities_update,
+            )
+
+            @callback
+            def _remove() -> None:
+                unsub()
+                for timer in timers.values():
+                    timer()
+                timers.clear()
+                stale.clear()
+
+            return _remove
+
+    return _PlantStaleTrigger
+```
+
+- [ ] **Step 4: Wire stale triggers into `build_triggers`**
+
+In `custom_components/plant/trigger_impl.py`, add the import and the loop. Change
+the imports block to add:
+
+```python
+from .automation_meta import EXTERNAL_MEASUREMENTS, STATUS_MEASUREMENTS
+from .stale import make_stale_trigger
+```
+
+and before `return triggers` in `build_triggers`, add:
+
+```python
+    # Per-measurement source-sensor staleness (external measurements only).
+    for m in EXTERNAL_MEASUREMENTS:
+        triggers[f"{m.key}_sensor_became_stale"] = make_stale_trigger(m, fresh=False)
+        triggers[f"{m.key}_sensor_became_fresh"] = make_stale_trigger(m, fresh=True)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_triggers.py -q -k "sensor_became_stale or sensor_became_fresh"`
+Expected: PASS.
+Run: `python -m pytest tests/test_triggers.py::test_async_get_triggers_full_surface -q`
+Expected: PASS (all 43 keys present).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+black custom_components/plant/ tests/
+git add custom_components/plant/stale.py custom_components/plant/trigger_impl.py tests/test_triggers.py
+git commit -m "feat: per-measurement stale/fresh plant sensor triggers"
+```
+
+---
+
+### Task 5: Per-measurement `sensor_is_stale` conditions
+
+**Files:**
+- Modify: `custom_components/plant/stale.py`
+- Modify: `custom_components/plant/condition_impl.py`
+- Test: `tests/test_conditions.py`
+
+**Interfaces:**
+- Consumes: `stale.resolve_external_sensor`; `automation_meta.EXTERNAL_MEASUREMENTS`; `homeassistant.helpers.condition.Condition`, `ConditionConfig`.
+- Produces: `stale.make_stale_condition(measurement) -> type[Condition]`.
+- Produces: `condition_impl.build_conditions()` now also returns the 7 `<m>_sensor_is_stale` conditions.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/test_conditions.py`:
+
+```python
+from datetime import timedelta
+
+import homeassistant.util.dt as dt_util
+
+from custom_components.plant.const import ATTR_PLANT, DOMAIN as PLANT_DOMAIN
+
+
+def _plant_entity_id(hass, init_integration) -> str:
+    return hass.data[PLANT_DOMAIN][init_integration.entry_id][ATTR_PLANT].entity_id
+
+
+async def test_moisture_sensor_is_stale_when_unavailable(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {"condition": "plant.moisture_sensor_is_stale",
+         "target": {"entity_id": plant_id}},
+    )
+    assert got is True
+
+
+async def test_moisture_sensor_is_stale_false_when_fresh(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "42")
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {"condition": "plant.moisture_sensor_is_stale",
+         "target": {"entity_id": plant_id}},
+    )
+    assert got is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_conditions.py -q -k "sensor_is_stale"`
+Expected: FAIL — condition key unknown.
+
+- [ ] **Step 3: Add `make_stale_condition` to `stale.py`**
+
+Append to `custom_components/plant/stale.py` (add the imports
+`from homeassistant.helpers.condition import Condition, ConditionConfig` and
+`from homeassistant.util import dt as dt_util` at the top with the others):
+
+```python
+def make_stale_condition(measurement: Measurement) -> type[Condition]:
+    """True when the measurement's external source sensor is currently stale."""
+
+    class _PlantStaleCondition(Condition):
+        _schema = vol.Schema(
+            {
+                vol.Required("target"): cv.TARGET_FIELDS,
+                vol.Optional("options", default=dict): vol.Schema(
+                    {vol.Optional(CONF_FOR): cv.positive_time_period},
+                    extra=vol.ALLOW_EXTRA,
+                ),
+            },
+            extra=vol.ALLOW_EXTRA,
+        )
+
+        @classmethod
+        async def async_validate_config(
+            cls, hass: HomeAssistant, config: ConfigType
+        ) -> ConfigType:
+            return cls._schema(config)
+
+        def __init__(self, hass: HomeAssistant, config: ConditionConfig) -> None:
+            super().__init__(hass, config)
+            self._target = config.target
+            self._duration: timedelta = (config.options or {}).get(
+                CONF_FOR
+            ) or DEFAULT_STALE_FOR
+
+        def _async_check(self, **kwargs: Any) -> bool:
+            from homeassistant.helpers.target import (
+                TargetSelection,
+                async_extract_referenced_entity_ids,
+            )
+
+            selection = TargetSelection(self._target)
+            selected = async_extract_referenced_entity_ids(
+                self._hass, selection, expand_group=False
+            )
+            plant_ids = selected.referenced | selected.indirectly_referenced
+            now = dt_util.utcnow()
+            for plant_id in plant_ids:
+                if not plant_id.startswith(f"{DOMAIN}."):
+                    continue
+                source = resolve_external_sensor(
+                    self._hass, plant_id, measurement.device_sensor_attr
+                )
+                if not source:
+                    continue
+                state = self._hass.states.get(source)
+                if state is None or state.state in _EXCLUDED:
+                    return True
+                if now - state.last_updated > self._duration:
+                    return True
+            return False
+
+    return _PlantStaleCondition
+```
+
+- [ ] **Step 4: Wire stale conditions into `build_conditions`**
+
+In `custom_components/plant/condition_impl.py`, change the `automation_meta`
+import to `from .automation_meta import EXTERNAL_MEASUREMENTS, STATUS_MEASUREMENTS`,
+add `from .stale import make_stale_condition`, and before `return conditions` add:
+
+```python
+    for m in EXTERNAL_MEASUREMENTS:
+        conditions[f"{m.key}_sensor_is_stale"] = make_stale_condition(m)
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `python -m pytest tests/test_conditions.py -q -k "sensor_is_stale"`
+Expected: PASS.
+Run: `python -m pytest tests/test_triggers.py::test_async_get_conditions_full_surface -q`
+Expected: PASS (all 35 keys present).
+
+- [ ] **Step 6: Format and commit**
+
+```bash
+black custom_components/plant/ tests/
+git add custom_components/plant/stale.py custom_components/plant/condition_impl.py tests/test_conditions.py
+git commit -m "feat: per-measurement plant sensor_is_stale conditions"
+```
+
+---
+
+### Task 6: UI descriptions (`triggers.yaml` / `conditions.yaml`)
+
+**Files:**
+- Rewrite: `custom_components/plant/triggers.yaml`
+- Rewrite: `custom_components/plant/conditions.yaml`
+- Test: `tests/test_automation_descriptions.py` (create)
+
+**Interfaces:**
+- Consumes: the trigger/condition keys from Tasks 2-5. Every advertised key MUST have a matching description block; HA logs a warning otherwise.
+
+- [ ] **Step 1: Write the failing coverage test**
+
+Create `tests/test_automation_descriptions.py`:
+
+```python
+"""Every advertised trigger/condition key must have a UI description block."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from homeassistant.const import __version__ as HA_VERSION
+
+_p = HA_VERSION.split(".")
+if (int(_p[0]), int(_p[1])) < (2026, 7):
+    pytest.skip("requires HA 2026.7+", allow_module_level=True)
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.plant.condition import async_get_conditions
+from custom_components.plant.trigger import async_get_triggers
+
+_ROOT = Path("custom_components/plant")
+
+
+def _described_keys(filename: str) -> set[str]:
+    doc = yaml.safe_load((_ROOT / filename).read_text())
+    return {k for k in doc if not k.startswith(".")}
+
+
+async def test_every_trigger_has_a_description(hass: HomeAssistant) -> None:
+    assert set(await async_get_triggers(hass)) <= _described_keys("triggers.yaml")
+
+
+async def test_every_condition_has_a_description(hass: HomeAssistant) -> None:
+    assert set(await async_get_conditions(hass)) <= _described_keys("conditions.yaml")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python -m pytest tests/test_automation_descriptions.py -q`
+Expected: FAIL — strawman yaml only describes the old key names.
+
+- [ ] **Step 3: Generate the description YAML**
+
+Generate the two files from the measurement table so keys always match. Run this
+one-off generator from the repo root and commit its output (not the script):
+
+```python
+# scratch generator — run once, do not commit
+from custom_components.plant.automation_meta import (
+    EXTERNAL_MEASUREMENTS, STATUS_MEASUREMENTS,
+)
+
+STATE_TGT = """  target:
+    entity:
+      domain: plant
+  fields:
+    behavior:
+      required: true
+      default: each
+      selector:
+        automation_behavior:
+          mode: trigger
+"""
+STALE_TGT = """  target:
+    entity:
+      domain: plant
+  fields:
+    for:
+      required: false
+      default: "24:00:00"
+      selector:
+        duration:
+"""
+
+lines = ["# Trigger descriptions for the plant integration (HA 2026.7+).",
+         "# Generated from automation_meta.py — keep in sync.", ""]
+for key in ("problem_detected", "problem_cleared"):
+    lines += [f"{key}:", STATE_TGT.rstrip(), ""]
+for m in STATUS_MEASUREMENTS:
+    for suf in ("became_low", "became_high", "became_ok"):
+        lines += [f"{m.key}_{suf}:", STATE_TGT.rstrip(), ""]
+for m in EXTERNAL_MEASUREMENTS:
+    for suf in ("sensor_became_stale", "sensor_became_fresh"):
+        lines += [f"{m.key}_{suf}:", STALE_TGT.rstrip(), ""]
+open("custom_components/plant/triggers.yaml", "w").write("\n".join(lines) + "\n")
+
+clines = ["# Condition descriptions for the plant integration (HA 2026.7+).",
+          "# Generated from automation_meta.py — keep in sync.", ""]
+COND_TGT = """  target:
+    entity:
+      domain: plant
+"""
+for key in ["has_problem"]:
+    clines += [f"{key}:", COND_TGT.rstrip(), ""]
+for m in STATUS_MEASUREMENTS:
+    for suf in ("is_low", "is_high", "is_ok"):
+        clines += [f"{m.key}_{suf}:", COND_TGT.rstrip(), ""]
+for m in EXTERNAL_MEASUREMENTS:
+    clines += [f"{m.key}_sensor_is_stale:", COND_TGT.rstrip(), ""]
+open("custom_components/plant/conditions.yaml", "w").write("\n".join(clines) + "\n")
+```
+
+Run: `python -c "$(cat scratch_gen.py)"` (or paste into a REPL), then delete the script.
+
+- [ ] **Step 4: Run tests**
+
+Run: `python -m pytest tests/test_automation_descriptions.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit**
+
+```bash
+black tests/
+git add custom_components/plant/triggers.yaml custom_components/plant/conditions.yaml tests/test_automation_descriptions.py
+git commit -m "feat: UI descriptions for the full plant.* trigger/condition surface"
+```
+
+---
+
+### Task 7: Full-suite verification against released 2026.7.4 + strawman cleanup
+
+**Files:**
+- Verify only: whole test suite
+- Modify (if present): remove any leftover strawman-only symbols
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Confirm no strawman leftovers**
+
+Run: `grep -rn "became_problem\b\|became_ok\b\|moisture_became_low\|sensor_became_stale\b\|is_problem\b\|PROTOTYPE\|strawman" custom_components/plant/trigger.py custom_components/plant/condition.py custom_components/plant/trigger_impl.py custom_components/plant/condition_impl.py custom_components/plant/triggers.yaml custom_components/plant/conditions.yaml`
+Expected: no matches (all replaced by the new names; `problem_detected`/`problem_cleared` are the aggregate keys now).
+
+- [ ] **Step 2: Run the full test suite on the installed HA**
+
+Run: `python -m pytest tests/ -q`
+Expected: PASS. Note the count (existing 347 + new trigger/condition/version tests).
+
+- [ ] **Step 3: Verify against the actually-released 2026.7.4 in a throwaway venv**
+
+```bash
+python -m venv /tmp/ha274venv && /tmp/ha274venv/bin/pip install -q \
+  homeassistant==2026.7.4 pytest pytest-homeassistant-custom-component pytest-asyncio
+/tmp/ha274venv/bin/python -m pytest tests/test_triggers.py tests/test_conditions.py \
+  tests/test_automation_descriptions.py tests/test_automation_version_safety.py -q
+```
+Expected: PASS on the released 2026.7.4 (not just the b1 in the project venv).
+
+- [ ] **Step 4: Verify version-safety on the 2025.8 floor**
+
+```bash
+python -m venv /tmp/ha258venv && /tmp/ha258venv/bin/pip install -q \
+  homeassistant==2025.8.3 pytest pytest-homeassistant-custom-component pytest-asyncio
+/tmp/ha258venv/bin/python -m pytest tests/test_automation_version_safety.py -q
+/tmp/ha258venv/bin/python -c "import custom_components.plant.trigger, custom_components.plant.condition; print('import clean on 2025.8')"
+```
+Expected: version-safety tests PASS; the import line prints "import clean on 2025.8" with no ImportError.
+
+- [ ] **Step 5: black + ruff clean, then commit any cleanup**
+
+```bash
+black --check custom_components/plant/ tests/
+git add -A && git commit -m "test: verify plant.* automation surface on released 2026.7.4 and 2025.8" || echo "nothing to commit"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Aggregate `problem_detected`/`problem_cleared` + `has_problem` → Tasks 2, 3. ✓
+- Per-measurement status `became_low/high/ok` + `is_low/high/ok` (9) → Tasks 2, 3. ✓
+- Per-measurement stale `sensor_became_stale/fresh` + `sensor_is_stale` (7 external) → Tasks 4, 5. ✓
+- Uniform plant-entity targeting + auto-threshold via `DomainSpec(value_source=...)` → Tasks 2, 3. ✓
+- Stale semantics (unavailable-or-silent, 24h, recovery, external resolution) → Task 4 (`stale.py`). ✓
+- Version safety (feature-detect, lazy import, `{}` on <2026.7) → Task 1, verified Task 7 step 4. ✓
+- Discovery contract (`async_get_triggers`/`async_get_conditions`) → Task 1. ✓
+- UI descriptions → Task 6. ✓
+- Testing incl. 2025.8 safety + released 2026.7.4 → Tasks 1, 7. ✓
+- No `crossed_threshold` (non-goal) → nothing adds it. ✓
+- Measurement table single source of truth → Task 1 (`automation_meta.py`). ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. The one-off YAML generator in Task 6 is explicitly a scratch script that is run and deleted, with the committed artifact being its output.
+
+**Type consistency:** `Measurement(key, status_attr, device_sensor_attr)` used consistently. `resolve_external_sensor(hass, plant_entity_id, device_sensor_attr)`, `make_stale_trigger(measurement, *, fresh)`, `make_stale_condition(measurement)` referenced identically in `stale.py` and both `_impl` modules. `build_triggers()`/`build_conditions()` names match their lazy-import call sites in `trigger.py`/`condition.py`. Status suffix→state maps (`became_low`→`STATE_LOW`, etc.) consistent across trigger and condition impls.

--- a/docs/superpowers/specs/2026-07-27-plant-triggers-conditions-design.md
+++ b/docs/superpowers/specs/2026-07-27-plant-triggers-conditions-design.md
@@ -1,0 +1,185 @@
+# Design: `plant.*` triggers & conditions for HA 2026.7
+
+- **Date:** 2026-07-27
+- **Status:** Approved (design), pending implementation plan
+- **Feedback issue:** #480
+- **Prototype (strawman) PR:** #481 (`prototype/2026.7-triggers`)
+- **Supersedes:** the strawman — this is the real, complete implementation
+
+## Background
+
+Home Assistant 2026.7 introduces **purpose-specific triggers and conditions**: an
+integration can teach the automation engine its own triggers/conditions
+(e.g. `battery.became_low`), and *custom* integrations are explicitly supported.
+The platform is discovered by HA calling `platform.async_get_triggers(hass)` /
+`platform.async_get_conditions(hass)` on the integration's `trigger.py` /
+`condition.py`.
+
+The plant integration's value-add over core's generic purpose triggers is
+**auto-thresholding**: core's `temperature.crossed_threshold` makes the user
+supply a number (or point at a threshold entity); the plant already computes a
+per-measurement `<m>_status` (Low / High / ok) from the species-configured
+min/max **with hysteresis**, so `plant.*` triggers fire on the plant's own
+threshold with zero user input.
+
+### API verification (done before this design)
+
+Verified against the **released** `homeassistant==2026.7.4` source (not the
+`2026.7.0b1` the strawman was written against):
+
+- Every helper the strawman uses exists in 2026.7.4 with **identical signatures**
+  to b1: `make_entity_target_state_trigger`, `make_entity_state_condition`,
+  `DomainSpec` (incl. `value_source`), `async_track_target_selector_state_change_event`,
+  `Trigger` / `TriggerConfig` / `TriggerActionRunner`, `Condition` / `ConditionConfig`.
+- Discovery hooks confirmed: `helpers/trigger.py` calls
+  `platform.async_get_triggers(hass)`; `helpers/condition.py` calls
+  `platform.async_get_conditions(hass)`.
+- Strawman's own tests pass 8/8 on the installed HA.
+
+**Correctness gap the strawman missed (must fix here):** HA **2025.8** (our support
+floor) *already* has trigger/condition platform discovery (`async_get_triggers`
+exists) and **will import** `trigger.py`/`condition.py`, but it lacks the newer
+helper symbols (`make_entity_target_state_trigger`, `TriggerConfig`,
+`TriggerActionRunner`). The strawman imports those at module level with no guard,
+so its "inert on < 2026.7" claim is false. This design makes version-safety a
+first-class requirement (see §6).
+
+## Goals
+
+- Ship the full, consistent `plant.*` trigger/condition surface for HA 2026.7+.
+- Zero-config auto-thresholding: users never type a threshold or pick a sensor.
+- Stay clean and inert on HA 2025.8–2026.6 (we still support 2025.8+).
+- Table-generated surface (loop over a measurement table), not hand-written per key.
+
+## Non-goals
+
+- **No `crossed_threshold` family.** For standard-device-class measurements core
+  already provides it (and it can read the plant's `number.<plant>_min_*`/`_max_*`
+  threshold entities); for custom classes the `became_low/high` auto-threshold is
+  strictly nicer UX. A manual-threshold `plant.*` would duplicate core / reintroduce
+  the friction we remove. YAGNI — can add later.
+- No change to how the plant computes `<m>_status` or hysteresis.
+- No new device classes on the moisture/conductivity sensors (deferred; #480 Q4).
+
+## Measurement taxonomy
+
+Two sets, derived from the sensor classes in `sensor.py`:
+
+- **Status measurements (9)** — have a `<m>_status` attribute (Low/High/ok):
+  `moisture, conductivity, temperature, soil_temperature, humidity, illuminance,
+  co2, dli, vpd`. These get the per-measurement **status** family.
+- **Externally-sourced measurements (7)** — subclasses of `PlantCurrentStatus`
+  with a configured `FLOW_SENSOR_*` external source:
+  `moisture, conductivity, temperature, soil_temperature, humidity, illuminance,
+  co2`. These get the per-measurement **stale** family.
+- **Derived (`dli, vpd, ppfd`)** have no source of their own; their staleness
+  inherits from their inputs, so they get **no** stale family. (`ppfd` also has no
+  `<m>_status`, so it appears in neither family.)
+
+## Families, naming, and surface
+
+Naming grounded in core 2026.7.4 conventions (`battery.became_low`/`is_low`,
+`update.became_available`, `motion.detected`/`cleared`, universal `is_*` conditions).
+
+| Family | Applies to | Triggers | Conditions |
+|---|---|---|---|
+| **Aggregate** | the plant (1) | `problem_detected`, `problem_cleared` | `has_problem` |
+| **Per-measurement status** | 9 | `<m>_became_low`, `<m>_became_high`, `<m>_became_ok` | `<m>_is_low`, `<m>_is_high`, `<m>_is_ok` |
+| **Per-measurement stale** | 7 external | `<m>_sensor_became_stale`, `<m>_sensor_became_fresh` | `<m>_sensor_is_stale` |
+
+**Totals: ~43 triggers, ~35 conditions.** Large but deliberate — matches core's
+per-measurement philosophy (`air_quality` is ~18 keys), table-generated, and
+approved. `<m>` uses the lowercase measurement key in the trigger name even though
+`STATE_LOW`/`STATE_HIGH` are `"Low"`/`"High"` and `STATE_OK` is `"ok"`.
+
+### Naming rationale (decided)
+
+- Aggregate uses **detected/cleared** (motion/occupancy style); `problem_cleared`
+  is unambiguous even with multiple simultaneous problems (preferred over
+  `no_longer_problem` / `became_ok` for the aggregate).
+- Aggregate condition is **`has_problem`** (not `is_problem`): "problem" is a noun,
+  so `has_` is the grammatically correct verb; the one intentional exception to the
+  `is_*` pattern.
+- Per-measurement recovery is **`became_ok` / `is_ok`** (not `became_normal`):
+  matches the plant's own `<m>_status == "ok"` value exactly.
+- Stale recovery is **`became_fresh`** (stale↔fresh); condition stays a single
+  `sensor_is_stale` (gate "fresh" with `not`), mirroring aggregate's two-trigger /
+  one-condition shape.
+
+## Targeting model (uniform, zero-config)
+
+Every trigger and condition targets the **plant entity** — the user only picks
+*which plant*.
+
+- **Status** families read the plant's own `<m>_status` attribute via
+  `DomainSpec(value_source="<m>_status")` + `make_entity_target_state_trigger` /
+  `make_entity_state_condition`. The threshold is the plant's configured min/max
+  with hysteresis — no user input.
+- **Stale** families: given the plant entity, the integration resolves that
+  measurement's **external source sensor** (the plant's `sensor.<plant>_<m>` carries
+  an `external_sensor` reference / the config `FLOW_SENSOR_<M>`), and watches *that
+  external sensor*. The plant's internal mirror sensor is never watched — it cannot
+  be independently stale, and the external sensor is the root cause we care about.
+
+This removes the strawman's device-vs-entity targeting question entirely.
+
+## Stale detection semantics
+
+- **Stale** = the external source sensor is `unavailable`/`unknown` **OR** has not
+  produced an update within `for` (**default 24h**, overridable per automation).
+  Two failure modes (drops to unavailable, or silently stops updating with a stale
+  last value) are both caught.
+- **Recovery** (`<m>_sensor_became_fresh`) fires on the reverse transition (a fresh
+  update arrives, or it returns from unavailable). The strawman already tracks a
+  `stale` set and re-arms on fresh updates; recovery fires on the stale→fresh edge.
+- Implemented as a custom `Trigger`/`Condition` (per-measurement) that resolves the
+  external sensor and manages a freshness timer via `async_call_later`.
+
+## Version safety (§6)
+
+`trigger.py` and `condition.py` must not import 2026.7-only symbols at module top
+level. Approach:
+
+- Top-level imports limited to always-available symbols.
+- **Feature-detect** the 2026.7 API (e.g. `hasattr(homeassistant.helpers.trigger,
+  "make_entity_target_state_trigger")`), lazily importing the new API inside
+  `async_get_triggers` / `async_get_conditions`.
+- On HA < 2026.7, `async_get_triggers` / `async_get_conditions` return `{}` — no
+  triggers/conditions registered, no import error, no log noise.
+- Feature-detection is preferred over a version-string check (robust to backports).
+
+## File structure
+
+- `custom_components/plant/trigger.py` — `async_get_triggers`, the status-trigger
+  factory (`make_entity_target_state_trigger` + `DomainSpec(value_source=...)`),
+  the aggregate triggers, and the per-measurement `PlantSensorStale`/`Fresh`
+  triggers. Built from a measurement table.
+- `custom_components/plant/condition.py` — mirror: `async_get_conditions`, status
+  conditions, `has_problem`, per-measurement `sensor_is_stale`.
+- `custom_components/plant/triggers.yaml` / `conditions.yaml` — descriptions/selectors
+  for the UI, generated to match the table.
+- `tests/test_triggers.py` / `tests/test_conditions.py` — behavioral tests, gated
+  to run only on HA >= 2026.7, plus a **version-safety test** asserting the module
+  imports cleanly and registers nothing on an older-API stub.
+- Shared measurement table (single source of truth for the generated surface),
+  likely in `const.py` or a small `automation_meta.py`.
+
+## Testing strategy
+
+- Behavioral trigger/condition tests gated on HA >= 2026.7 (feature-detected), run
+  in CI's "HA latest" job (currently 2026.7.4).
+- Version-safety: a test that importing `trigger.py`/`condition.py` on an
+  environment lacking the new API yields empty `async_get_triggers`/`_conditions`
+  and raises nothing — so the "HA 2025.8" CI job stays green and the integration
+  loads cleanly.
+- During implementation, exercise at least one status trigger, the aggregate
+  detected/cleared pair, and one stale/fresh pair end-to-end against real 2026.7.4.
+
+## Risks / open items
+
+- The 2026.7 purpose-trigger platform API, though released, is young; monitor for
+  changes in later 2026.7.x/2026.8. Feature-detection limits blast radius.
+- Stale resolution depends on the `external_sensor` reference staying accurate
+  across the "replace sensor" service and reloads — cover in tests.
+- Surface size (~43/~35) is intentional; revisit only if user feedback finds it
+  unwieldy in the UI.

--- a/info.md
+++ b/info.md
@@ -14,6 +14,7 @@ A comprehensive plant monitoring integration that treats each plant as a **devic
 - 🚨 **Configurable problem triggers** — enable/disable per sensor type
 - 🔌 **Auto-disable** — sensors without a source entity are automatically disabled
 - 🖼️ **Flexible images** — HTTP URLs, local `/www/` files, or media source URLs
+- 🔔 **Automation triggers & conditions** *(Home Assistant 2026.7+)* — auto-thresholded `plant.*` triggers for problem/status changes, plus source-sensor staleness detection. See [Automations: Triggers & Conditions](https://github.com/Olen/homeassistant-plant/#-automations-triggers--conditions) in the README
 
 ## 📦 Dependencies
 

--- a/tests/test_automation_descriptions.py
+++ b/tests/test_automation_descriptions.py
@@ -6,11 +6,14 @@ from pathlib import Path
 
 import pytest
 import yaml
-from homeassistant.const import __version__ as HA_VERSION
 
-_p = HA_VERSION.split(".")
-if (int(_p[0]), int(_p[1])) < (2026, 7):
-    pytest.skip("requires HA 2026.7+", allow_module_level=True)
+from custom_components.plant.trigger import _has_purpose_trigger_api
+
+if not _has_purpose_trigger_api():
+    pytest.skip(
+        "plant purpose-trigger API not available on this HA",
+        allow_module_level=True,
+    )
 
 from homeassistant.core import HomeAssistant
 

--- a/tests/test_automation_descriptions.py
+++ b/tests/test_automation_descriptions.py
@@ -1,0 +1,33 @@
+"""Every advertised trigger/condition key must have a UI description block."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+from homeassistant.const import __version__ as HA_VERSION
+
+_p = HA_VERSION.split(".")
+if (int(_p[0]), int(_p[1])) < (2026, 7):
+    pytest.skip("requires HA 2026.7+", allow_module_level=True)
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.plant.condition import async_get_conditions
+from custom_components.plant.trigger import async_get_triggers
+
+_ROOT = Path("custom_components/plant")
+
+
+def _described_keys(filename: str) -> set[str]:
+    doc = yaml.safe_load((_ROOT / filename).read_text())
+    return {k for k in doc if not k.startswith(".")}
+
+
+async def test_every_trigger_has_a_description(hass: HomeAssistant) -> None:
+    assert set(await async_get_triggers(hass)) <= _described_keys("triggers.yaml")
+
+
+async def test_every_condition_has_a_description(hass: HomeAssistant) -> None:
+    assert set(await async_get_conditions(hass)) <= _described_keys("conditions.yaml")

--- a/tests/test_automation_version_safety.py
+++ b/tests/test_automation_version_safety.py
@@ -8,6 +8,20 @@ from homeassistant.core import HomeAssistant
 
 from custom_components.plant import condition, trigger
 
+# trigger_impl/condition_impl are only importable when the full settled API is
+# present (they import homeassistant.helpers.automation.DomainSpec at module
+# level). Import them lazily/conditionally so this file stays import-clean and
+# ungated on every HA version, per the platform's own contract.
+if trigger._has_purpose_trigger_api():
+    from custom_components.plant import trigger_impl
+else:
+    trigger_impl = None
+
+if condition._has_purpose_condition_api():
+    from custom_components.plant import condition_impl
+else:
+    condition_impl = None
+
 
 async def test_triggers_empty_when_api_absent(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
@@ -20,4 +34,41 @@ async def test_conditions_empty_when_api_absent(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(condition, "_has_purpose_condition_api", lambda: False)
+    assert await condition.async_get_conditions(hass) == {}
+
+
+@pytest.mark.skipif(
+    trigger_impl is None,
+    reason="trigger_impl is only importable when the full purpose-trigger API is present",
+)
+async def test_triggers_degrade_to_empty_on_build_import_error(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A build-time ImportError (e.g. a residual missing symbol) must degrade to
+    {} instead of propagating and crashing platform discovery."""
+
+    def _raise() -> dict[str, type]:
+        raise ImportError("simulated residual missing symbol")
+
+    monkeypatch.setattr(trigger, "_has_purpose_trigger_api", lambda: True)
+    monkeypatch.setattr(trigger_impl, "build_triggers", _raise)
+    monkeypatch.setattr(trigger, "_TRIGGERS_CACHE", None)
+    assert await trigger.async_get_triggers(hass) == {}
+
+
+@pytest.mark.skipif(
+    condition_impl is None,
+    reason="condition_impl is only importable when the full purpose-condition API is present",
+)
+async def test_conditions_degrade_to_empty_on_build_import_error(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirror of the trigger degradation test for the condition platform."""
+
+    def _raise() -> dict[str, type]:
+        raise ImportError("simulated residual missing symbol")
+
+    monkeypatch.setattr(condition, "_has_purpose_condition_api", lambda: True)
+    monkeypatch.setattr(condition_impl, "build_conditions", _raise)
+    monkeypatch.setattr(condition, "_CONDITIONS_CACHE", None)
     assert await condition.async_get_conditions(hass) == {}

--- a/tests/test_automation_version_safety.py
+++ b/tests/test_automation_version_safety.py
@@ -1,0 +1,23 @@
+"""The trigger/condition platforms must be import-clean and return {} when the
+2026.7 purpose-trigger API is unavailable (HA 2025.8-2026.6)."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from custom_components.plant import condition, trigger
+
+
+async def test_triggers_empty_when_api_absent(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(trigger, "_has_purpose_trigger_api", lambda: False)
+    assert await trigger.async_get_triggers(hass) == {}
+
+
+async def test_conditions_empty_when_api_absent(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(condition, "_has_purpose_condition_api", lambda: False)
+    assert await condition.async_get_conditions(hass) == {}

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -17,6 +17,7 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import async_capture_events
 
 from custom_components.plant.const import ATTR_PLANT, DOMAIN as PLANT_DOMAIN
+from custom_components.plant.stale import resolve_external_sensor
 
 
 async def _condition_passes(hass: HomeAssistant, cond: dict) -> bool:
@@ -93,6 +94,61 @@ async def test_moisture_sensor_is_stale_false_when_fresh(
 ) -> None:
     plant_id = _plant_entity_id(hass, init_integration)
     hass.states.async_set("sensor.test_moisture", "42")
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {
+            "condition": "plant.moisture_sensor_is_stale",
+            "target": {"entity_id": plant_id},
+        },
+    )
+    assert got is False
+
+
+async def test_stale_resolution_follows_replace_sensor(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """resolve_external_sensor and the stale condition must track a sensor swap.
+
+    replace_external_sensor updates PlantDevice.sensor_moisture.external_sensor
+    in place; resolve_external_sensor reads that attribute live, and the stale
+    CONDITION (unlike the trigger, which only re-binds on reload) re-resolves
+    the source on every evaluation. So both must follow a replace_sensor swap
+    without any reload.
+    """
+    plant_id = _plant_entity_id(hass, init_integration)
+    plant = hass.data[PLANT_DOMAIN][init_integration.entry_id][ATTR_PLANT]
+
+    assert (
+        resolve_external_sensor(hass, plant_id, "sensor_moisture")
+        == "sensor.test_moisture"
+    )
+
+    hass.states.async_set("sensor.new_moisture", "42")
+    await hass.async_block_till_done()
+    plant.sensor_moisture.replace_external_sensor("sensor.new_moisture")
+    await hass.async_block_till_done()
+
+    assert (
+        resolve_external_sensor(hass, plant_id, "sensor_moisture")
+        == "sensor.new_moisture"
+    )
+
+    # Old source going stale must no longer matter; new source drives the result.
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    hass.states.async_set("sensor.new_moisture", "unavailable")
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {
+            "condition": "plant.moisture_sensor_is_stale",
+            "target": {"entity_id": plant_id},
+        },
+    )
+    assert got is True
+
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    hass.states.async_set("sensor.new_moisture", "42")
     await hass.async_block_till_done()
     got = await _condition_passes(
         hass,

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import pytest
-from homeassistant.const import __version__ as HA_VERSION
 
-_p = HA_VERSION.split(".")
-if (int(_p[0]), int(_p[1])) < (2026, 7):
+from custom_components.plant.condition import _has_purpose_condition_api
+
+if not _has_purpose_condition_api():
     pytest.skip(
-        "plant conditions require the HA 2026.7+ platform",
+        "plant purpose-condition API not available on this HA",
         allow_module_level=True,
     )
 

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -16,6 +16,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import async_capture_events
 
+from custom_components.plant.const import ATTR_PLANT, DOMAIN as PLANT_DOMAIN
+
 
 async def _condition_passes(hass: HomeAssistant, cond: dict) -> bool:
     events = async_capture_events(hass, "cond_passed")
@@ -64,3 +66,39 @@ async def test_moisture_is_low(
         {"condition": "plant.moisture_is_low", "target": {"entity_id": "plant.test"}},
     )
     assert got is expected
+
+
+def _plant_entity_id(hass, init_integration) -> str:
+    return hass.data[PLANT_DOMAIN][init_integration.entry_id][ATTR_PLANT].entity_id
+
+
+async def test_moisture_sensor_is_stale_when_unavailable(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {
+            "condition": "plant.moisture_sensor_is_stale",
+            "target": {"entity_id": plant_id},
+        },
+    )
+    assert got is True
+
+
+async def test_moisture_sensor_is_stale_false_when_fresh(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "42")
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {
+            "condition": "plant.moisture_sensor_is_stale",
+            "target": {"entity_id": plant_id},
+        },
+    )
+    assert got is False

--- a/tests/test_conditions.py
+++ b/tests/test_conditions.py
@@ -1,0 +1,66 @@
+"""Tests for the plant.* condition surface (HA 2026.7+)."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.const import __version__ as HA_VERSION
+
+_p = HA_VERSION.split(".")
+if (int(_p[0]), int(_p[1])) < (2026, 7):
+    pytest.skip(
+        "plant conditions require the HA 2026.7+ platform",
+        allow_module_level=True,
+    )
+
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_capture_events
+
+
+async def _condition_passes(hass: HomeAssistant, cond: dict) -> bool:
+    events = async_capture_events(hass, "cond_passed")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {"platform": "event", "event_type": "probe"},
+                "condition": cond,
+                "action": {"event": "cond_passed"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.services.async_call(
+        "automation",
+        "trigger",
+        {"entity_id": "automation.automation_0", "skip_condition": False},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    return len(events) == 1
+
+
+@pytest.mark.parametrize(("state", "expected"), [("problem", True), ("ok", False)])
+async def test_has_problem(hass: HomeAssistant, state: str, expected: bool) -> None:
+    hass.states.async_set("plant.test", state)
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass, {"condition": "plant.has_problem", "target": {"entity_id": "plant.test"}}
+    )
+    assert got is expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"), [("Low", True), ("High", False), ("ok", False)]
+)
+async def test_moisture_is_low(
+    hass: HomeAssistant, status: str, expected: bool
+) -> None:
+    hass.states.async_set("plant.test", "problem", {"moisture_status": status})
+    await hass.async_block_till_done()
+    got = await _condition_passes(
+        hass,
+        {"condition": "plant.moisture_is_low", "target": {"entity_id": "plant.test"}},
+    )
+    assert got is expected

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 from homeassistant.const import __version__ as HA_VERSION
 
@@ -16,15 +18,21 @@ if (int(_ha_parts[0]), int(_ha_parts[1])) < (2026, 7):
         allow_module_level=True,
     )
 
+import homeassistant.util.dt as dt_util
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
-from pytest_homeassistant_custom_component.common import async_capture_events
+from pytest_homeassistant_custom_component.common import (
+    async_capture_events,
+    async_fire_time_changed,
+)
 
 from custom_components.plant.automation_meta import (
     EXTERNAL_MEASUREMENTS,
     STATUS_MEASUREMENTS,
 )
 from custom_components.plant.condition import async_get_conditions
+from custom_components.plant.const import ATTR_PLANT
+from custom_components.plant.const import DOMAIN as PLANT_DOMAIN
 from custom_components.plant.trigger import async_get_triggers
 
 
@@ -123,3 +131,101 @@ async def test_moisture_became_ok_fires_on_recovery(hass: HomeAssistant) -> None
     hass.states.async_set("plant.test", "ok", {"moisture_status": "ok"})
     await hass.async_block_till_done()
     assert len(events) == 1
+
+
+def _plant_entity_id(hass, init_integration) -> str:
+    return hass.data[PLANT_DOMAIN][init_integration.entry_id][ATTR_PLANT].entity_id
+
+
+async def test_moisture_sensor_became_stale_on_unavailable(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    events = async_capture_events(hass, "stale")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_sensor_became_stale",
+                    "target": {"entity_id": plant_id},
+                },
+                "action": {
+                    "event": "stale",
+                    "event_data": {"reason": "{{ trigger.reason }}"},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["reason"] == "unavailable"
+
+
+async def test_moisture_sensor_became_stale_on_no_update(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    events = async_capture_events(hass, "stale")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_sensor_became_stale",
+                    "target": {"entity_id": plant_id},
+                    "options": {"for": {"seconds": 30}},
+                },
+                "action": {"event": "stale"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_sensor_became_fresh_on_recovery(
+    hass: HomeAssistant, init_integration
+) -> None:
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "fresh")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_sensor_became_fresh",
+                    "target": {"entity_id": plant_id},
+                },
+                "action": {"event": "fresh"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("sensor.test_moisture", "42")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+    # A "became_fresh" trigger re-arms its no-update watch timer after every
+    # recovery (so it can detect a *future* stale->fresh transition too).
+    # Turn the automation off so its trigger detaches and cancels that timer
+    # before hass tears down -- otherwise pytest-homeassistant-custom-component
+    # fails the test for a lingering scheduled callback, same as init_integration
+    # explicitly unloads the config entry above for the same reason.
+    automation_entity_id = hass.states.async_entity_ids("automation")[0]
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": automation_entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -5,16 +5,17 @@ from __future__ import annotations
 from datetime import timedelta
 
 import pytest
-from homeassistant.const import __version__ as HA_VERSION
+
+from custom_components.plant.trigger import _has_purpose_trigger_api
 
 # The trigger/condition platform settled into its current shape in HA 2026.7; an
 # earlier Labs form existed in 2026.2-2026.6 with a different API. The integration
 # still supports 2025.8+, and the platform files are never imported on older cores,
-# so skip the whole module below 2026.7 rather than fail at collection/runtime.
-_ha_parts = HA_VERSION.split(".")
-if (int(_ha_parts[0]), int(_ha_parts[1])) < (2026, 7):
+# so skip the whole module unless the full purpose-trigger API is importable
+# (capability-based, not a version-string check).
+if not _has_purpose_trigger_api():
     pytest.skip(
-        "plant triggers require the HA 2026.7+ trigger platform",
+        "plant purpose-trigger API not available on this HA",
         allow_module_level=True,
     )
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -1,0 +1,54 @@
+"""Tests for the plant trigger/condition platforms (HA 2026.7+ prototype)."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.const import __version__ as HA_VERSION
+
+# The trigger/condition platform settled into its current shape in HA 2026.7; an
+# earlier Labs form existed in 2026.2-2026.6 with a different API. The integration
+# still supports 2025.8+, and the platform files are never imported on older cores,
+# so skip the whole module below 2026.7 rather than fail at collection/runtime.
+_ha_parts = HA_VERSION.split(".")
+if (int(_ha_parts[0]), int(_ha_parts[1])) < (2026, 7):
+    pytest.skip(
+        "plant triggers require the HA 2026.7+ trigger platform",
+        allow_module_level=True,
+    )
+
+from homeassistant.core import HomeAssistant
+
+from custom_components.plant.automation_meta import (
+    EXTERNAL_MEASUREMENTS,
+    STATUS_MEASUREMENTS,
+)
+from custom_components.plant.condition import async_get_conditions
+from custom_components.plant.trigger import async_get_triggers
+
+
+def _expected_trigger_keys() -> set[str]:
+    keys = {"problem_detected", "problem_cleared"}
+    for m in STATUS_MEASUREMENTS:
+        keys |= {f"{m.key}_became_low", f"{m.key}_became_high", f"{m.key}_became_ok"}
+    for m in EXTERNAL_MEASUREMENTS:
+        keys |= {f"{m.key}_sensor_became_stale", f"{m.key}_sensor_became_fresh"}
+    return keys
+
+
+def _expected_condition_keys() -> set[str]:
+    keys = {"has_problem"}
+    for m in STATUS_MEASUREMENTS:
+        keys |= {f"{m.key}_is_low", f"{m.key}_is_high", f"{m.key}_is_ok"}
+    for m in EXTERNAL_MEASUREMENTS:
+        keys |= {f"{m.key}_sensor_is_stale"}
+    return keys
+
+
+async def test_async_get_triggers_full_surface(hass: HomeAssistant) -> None:
+    assert set(await async_get_triggers(hass)) == _expected_trigger_keys()
+    assert len(_expected_trigger_keys()) == 43
+
+
+async def test_async_get_conditions_full_surface(hass: HomeAssistant) -> None:
+    assert set(await async_get_conditions(hass)) == _expected_condition_keys()
+    assert len(_expected_condition_keys()) == 35

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -137,6 +137,90 @@ def _plant_entity_id(hass, init_integration) -> str:
     return hass.data[PLANT_DOMAIN][init_integration.entry_id][ATTR_PLANT].entity_id
 
 
+async def test_moisture_sensor_no_spurious_stale_when_recovers_in_window(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A source already stale at attach that recovers within `for` must NOT fire.
+
+    This is the restart case: the integration hasn't populated the sensor yet, so
+    it reads unknown/unavailable at attach. The grace-period state machine holds it
+    as `pending` (not stale) and cancels the grace timer on recovery.
+    """
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "stale")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_sensor_became_stale",
+                    "target": {"entity_id": plant_id},
+                    "options": {"for": {"seconds": 30}},
+                },
+                "action": {"event": "stale"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    # Part-way through the grace window, still dead -- must not fire yet.
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15))
+    await hass.async_block_till_done()
+    # Source populates before the grace window elapses -> not a stale event.
+    hass.states.async_set("sensor.test_moisture", "42")
+    await hass.async_block_till_done()
+    assert len(events) == 0
+
+    # Recovery (re)armed a freshness watch timer; detach it before teardown so
+    # pytest-homeassistant-custom-component doesn't flag a lingering callback.
+    automation_entity_id = hass.states.async_entity_ids("automation")[0]
+    await hass.services.async_call(
+        "automation",
+        "turn_off",
+        {"entity_id": automation_entity_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_moisture_sensor_became_stale_after_grace_when_dead(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """A source stale at attach that stays dead past `for` fires once (unavailable).
+
+    This catches a source that genuinely died during the restart: the grace timer
+    expires while still `pending`, so it fires became_stale.
+    """
+    plant_id = _plant_entity_id(hass, init_integration)
+    hass.states.async_set("sensor.test_moisture", "unavailable")
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "stale")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_sensor_became_stale",
+                    "target": {"entity_id": plant_id},
+                    "options": {"for": {"seconds": 30}},
+                },
+                "action": {
+                    "event": "stale",
+                    "event_data": {"reason": "{{ trigger.reason }}"},
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    assert len(events) == 1
+    assert events[0].data["reason"] == "unavailable"
+
+
 async def test_moisture_sensor_became_stale_on_unavailable(
     hass: HomeAssistant, init_integration
 ) -> None:
@@ -205,12 +289,20 @@ async def test_moisture_sensor_became_fresh_on_recovery(
                 "trigger": {
                     "trigger": "plant.moisture_sensor_became_fresh",
                     "target": {"entity_id": plant_id},
+                    "options": {"for": {"seconds": 30}},
                 },
                 "action": {"event": "fresh"},
             }
         },
     )
     await hass.async_block_till_done()
+    # Stale at attach -> `pending`. Let the grace window elapse while still dead so
+    # the source becomes genuinely `stale` (no became_fresh yet -- fresh triggers
+    # stay silent on stale transitions).
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=31))
+    await hass.async_block_till_done()
+    assert len(events) == 0
+    # Now it recovers: a real stale->fresh transition fires became_fresh once.
     hass.states.async_set("sensor.test_moisture", "42")
     await hass.async_block_till_done()
     assert len(events) == 1

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -31,8 +31,7 @@ from custom_components.plant.automation_meta import (
     STATUS_MEASUREMENTS,
 )
 from custom_components.plant.condition import async_get_conditions
-from custom_components.plant.const import ATTR_PLANT
-from custom_components.plant.const import DOMAIN as PLANT_DOMAIN
+from custom_components.plant.const import ATTR_PLANT, DOMAIN as PLANT_DOMAIN
 from custom_components.plant.trigger import async_get_triggers
 
 

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -17,6 +17,8 @@ if (int(_ha_parts[0]), int(_ha_parts[1])) < (2026, 7):
     )
 
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import async_capture_events
 
 from custom_components.plant.automation_meta import (
     EXTERNAL_MEASUREMENTS,
@@ -52,3 +54,72 @@ async def test_async_get_triggers_full_surface(hass: HomeAssistant) -> None:
 async def test_async_get_conditions_full_surface(hass: HomeAssistant) -> None:
     assert set(await async_get_conditions(hass)) == _expected_condition_keys()
     assert len(_expected_condition_keys()) == 35
+
+
+async def test_problem_detected_fires(hass: HomeAssistant) -> None:
+    hass.states.async_set("plant.test", "ok")
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "plant_problem")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.problem_detected",
+                    "target": {"entity_id": "plant.test"},
+                },
+                "action": {"event": "plant_problem"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("plant.test", "problem")
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_became_low_uses_status_attribute(hass: HomeAssistant) -> None:
+    hass.states.async_set("plant.test", "ok", {"moisture_status": "ok"})
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "moisture_low")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_became_low",
+                    "target": {"entity_id": "plant.test"},
+                },
+                "action": {"event": "moisture_low"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("plant.test", "problem", {"moisture_status": "Low"})
+    await hass.async_block_till_done()
+    assert len(events) == 1
+
+
+async def test_moisture_became_ok_fires_on_recovery(hass: HomeAssistant) -> None:
+    hass.states.async_set("plant.test", "problem", {"moisture_status": "Low"})
+    await hass.async_block_till_done()
+    events = async_capture_events(hass, "moisture_ok")
+    assert await async_setup_component(
+        hass,
+        "automation",
+        {
+            "automation": {
+                "trigger": {
+                    "trigger": "plant.moisture_became_ok",
+                    "target": {"entity_id": "plant.test"},
+                },
+                "action": {"event": "moisture_ok"},
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    hass.states.async_set("plant.test", "ok", {"moisture_status": "ok"})
+    await hass.async_block_till_done()
+    assert len(events) == 1


### PR DESCRIPTION
## Summary

Adds the full `plant.*` **purpose triggers & conditions** surface for Home Assistant 2026.7+, turning the strawman in #481 into a complete, tested implementation. Resolves the feedback in #480.

The value over core's generic purpose triggers is **auto-thresholding**: the per-measurement triggers fire off the plant's own `<measurement>_status` (computed from the species-configured min/max **with hysteresis**), so you never type a threshold or point at an entity.

## What it adds (43 triggers, 35 conditions)

- **Whole-plant:** `plant.problem_detected` / `plant.problem_cleared`; condition `plant.has_problem`.
- **Per-measurement status** (9: moisture, conductivity, temperature, soil_temperature, humidity, illuminance, co2, dli, vpd): `plant.<m>_became_low` / `_became_high` / `_became_ok`; conditions `plant.<m>_is_low` / `_is_high` / `_is_ok`.
- **Per-measurement source-sensor staleness** (7 externally-sourced): `plant.<m>_sensor_became_stale` / `_became_fresh`; condition `plant.<m>_sensor_is_stale`. "Stale" = the source sensor is unavailable/unknown or hasn't updated within `for` (default 24h). A **grace-period** state machine means it does **not** false-alarm at restart (when sensors are briefly `unknown` before their integration populates them) — it only fires if the source is genuinely still dead after the window.

Every trigger/condition targets the **plant entity**; for staleness the integration resolves each measurement's configured external source sensor itself.

## Version safety

`trigger.py` / `condition.py` **feature-detect** the 2026.7 purpose-trigger API and return `{}` on older cores, doing all 2026.7-only imports lazily. The integration still supports 2025.8+; on those versions nothing is registered and nothing is imported that doesn't exist.

Verified against **real released HA**, not just the RC the strawman used:
- **HA 2025.8.3:** `trigger.py`/`condition.py` import cleanly and return `{}` (inert).
- **HA 2026.7.4:** the full 43/35 surface is produced.

## Naming

Grounded in core 2026.7 conventions (`battery.became_low`, `update.became_available`, `motion.detected`/`cleared`, universal `is_*` conditions). Design rationale and the alternatives considered are in the design doc under `docs/superpowers/specs/`.

## Testing

- New behavioral tests drive the real automation engine (status transitions, aggregate detected/cleared, stale/fresh grace-period paths in both directions, condition gating, description coverage, version-safety, stale-resolution across `replace_sensor`).
- **369 tests passing**, black + ruff clean.

## Docs

New README section (**🔔 Automations: Triggers & Conditions**) with examples and the 2026.7+ availability note, plus an `info.md` pointer.

## Known follow-up (deliberately out of scope here)

Staleness keys off `last_updated`, which doesn't advance when a live sensor reports an *identical* value. A sensor pinned at a steady value for longer than the window could read stale; `last_reported` would be more correct for poll-based sources. Left as a follow-up to avoid changing the stale semantics in this PR.

Supersedes #481. Resolves #480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
