### PR TITLE
ci: native GitHub release notes + PR-label categories; add CONTRIBUTING.md

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,26 @@
+# Configures GitHub's native release-notes generator (used by the Auto Release
+# workflow via `generate_release_notes: true`). PRs are bucketed by their labels;
+# label every PR so it lands in the right category. Unlabeled PRs fall into
+# "Other Changes". See CONTRIBUTING.md.
+changelog:
+  categories:
+    - title: 🚀 Features & Enhancements
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧹 Maintenance & CI
+      labels:
+        - dependencies
+        - github_actions
+        - ci
+        - chore
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,15 +55,6 @@ jobs:
         run: echo "Skipping release - manifest unchanged or tag already exists"
         if: steps.check_manifest.outputs.changed != 'true' || steps.check_tag.outputs.exists == 'true'
 
-      - name: "Get previous release version"
-        id: last_release
-        run: |
-          LAST_TAG=$(gh release list --exclude-drafts --exclude-pre-releases --limit 1 --json tagName --jq '.[0].tagName // empty')
-          echo "tag_name=${LAST_TAG}" >> $GITHUB_OUTPUT
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: steps.check_manifest.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
-
       - name: "Create new tag"
         uses: rickstaa/action-create-tag@v1
         id: "tag_create"
@@ -73,22 +64,14 @@ jobs:
           message: "Version ${{ env.COMPONENT_VERSION }}"
         if: steps.check_manifest.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
 
-      - name: "Generate release changelog"
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          sinceTag: ${{ steps.last_release.outputs.tag_name }}
-          headerLabel: "# Notable changes since ${{ steps.last_release.outputs.tag_name }}"
-          stripGeneratorNotice: true
-          output: RELEASE_CHANGELOG.md
-        if: steps.check_manifest.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true'
-
+      # GitHub's native release notes: auto-detects the previous tag (so a beta's
+      # notes don't span back to the last stable) and buckets PRs by label per
+      # .github/release.yml. Replaces the raw changelog-generator dump.
       - name: "Create Stable release"
         uses: softprops/action-gh-release@v3
         with:
           prerelease: false
-          body_path: RELEASE_CHANGELOG.md
+          generate_release_notes: true
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
         if: steps.check_manifest.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true' && contains(env.COMPONENT_VERSION, 'beta') == false
@@ -97,7 +80,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           prerelease: true
-          body_path: RELEASE_CHANGELOG.md
+          generate_release_notes: true
           name: "Version ${{ env.COMPONENT_VERSION }}"
           tag_name: "v${{ env.COMPONENT_VERSION }}"
         if: steps.check_manifest.outputs.changed == 'true' && steps.check_tag.outputs.exists != 'true' && contains(env.COMPONENT_VERSION, 'beta') == true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,51 @@
+# Contributing
+
+Thanks for helping improve **Plant Monitor**! This guide covers the pull-request
+workflow and — importantly — the **PR labels** that drive our release notes.
+
+## Development setup
+
+Environment setup, running the tests, and linting are covered in
+[DEVELOPMENT.md](DEVELOPMENT.md).
+
+## Pull requests
+
+- Branch from `main`, open your PR against `main`.
+- CI must pass: formatting (Black), linting (Ruff), and the full test suite on the
+  supported Home Assistant versions.
+- Keep the change focused; add tests for new behavior and bug fixes.
+
+## PR labels (please add one)
+
+Release notes are generated automatically from **merged-PR labels** (GitHub's
+native generator, configured in [`.github/release.yml`](.github/release.yml)).
+Add a label so your change lands in the right section of the changelog:
+
+| Label | Release-notes section |
+|-------|-----------------------|
+| `enhancement` or `feature` | 🚀 Features & Enhancements |
+| `bug` or `fix` | 🐛 Bug Fixes |
+| `documentation` | 📚 Documentation |
+| `dependencies`, `github_actions`, `ci`, `chore` | 🧹 Maintenance & CI |
+| _(no label)_ | Other Changes |
+
+Pick the single label that best describes the PR's primary intent. Unlabeled PRs
+still appear under **Other Changes**, but a label makes the changelog readable.
+
+### For automated agents (Claude Code, etc.)
+
+When you open a PR, apply the matching label in the same step, e.g.:
+
+```bash
+gh pr edit <number> --add-label enhancement   # or bug / documentation / dependencies ...
+```
+
+Choose the label from the table above based on the PR's primary intent.
+
+## Releases (maintainers)
+
+Releases are automated. Bump the version in
+`custom_components/plant/manifest.json` on `main`; on the next green CI run the
+**Auto Release** workflow tags `v<version>` and publishes a GitHub release
+(prerelease when the version contains `beta`), with notes categorized from the
+merged-PR labels. Version format: `YYYY.M.P` (stable) or `YYYY.M.P-betaN` (beta).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -123,7 +123,16 @@ rm -f uv.lock
 The project uses GitHub Actions for CI. The workflow runs:
 
 1. Code formatting check with Black
-2. Full test suite with pytest
+2. Linting with Ruff
+3. Full test suite with pytest against a minimum and the latest Home Assistant
+
+---
+
+## 🏷️ Pull Requests & Releases
+
+The contribution workflow, the **PR label convention** (which drives categorized
+release notes), and the automated release process live in
+[CONTRIBUTING.md](CONTRIBUTING.md).
 
 ---
 


### PR DESCRIPTION
## Summary

Improves the **Auto Release** notes and documents the PR-label convention that drives them.

### Release CI
- Replace `heinrichreimer/github-changelog-generator` (a raw "Closed issues" + "Merged pull requests" dump) with GitHub's **native release notes** (`generate_release_notes: true` on the existing `softprops/action-gh-release` steps).
  - Auto-detects the correct **previous tag**, so a beta's notes no longer span back to the last *stable* and re-list the prior beta's changelog.
  - Buckets merged PRs by **label** per the new `.github/release.yml` (🚀 Features / 🐛 Fixes / 📚 Docs / 🧹 Maintenance & CI / Other).
- Drops the now-unused `last_release` + changelog-generator steps.

### Docs
- New **CONTRIBUTING.md** (GitHub surfaces it in the PR/Contribute UI): PR workflow + the label→section table, incl. a note for automated agents to `gh pr edit --add-label` when opening a PR.
- **DEVELOPMENT.md** points to it (setup/build mechanics stay there; the PR/label/release process lives in CONTRIBUTING.md — no duplication).

### Note
GitHub's categorization keys off **PR labels**; this repo's PRs aren't consistently labeled yet, so early releases will show a clean flat list under *Other Changes* until labels are applied. The label buckets fill in as PRs carry `enhancement`/`bug`/`documentation`/`dependencies` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)