### PR TITLE
fix: no 'does not have a platform' warning on reload_config_entry

### DIFF
--- a/custom_components/plant/config_flow.py
+++ b/custom_components/plant/config_flow.py
@@ -873,7 +873,15 @@ async def update_plant_options(
     # Push attribute changes (display_species, entity_picture) into the
     # state machine immediately. Without this the UI would only see the
     # update on the next 30 s poll.
-    plant.async_write_ha_state()
+    #
+    # Skip the write if the plant entity has not been added to a platform yet.
+    # On a reload, a child sensor's state restoration re-persists its
+    # external_sensor to the config entry, which fires this listener before the
+    # plant has been re-added to the shared EntityComponent. Writing state
+    # without a platform warns in HA 2026.7 and raises in 2026.8; the plant
+    # writes its initial state when it is added (async_setup_entry).
+    if plant.platform is not None:
+        plant.async_write_ha_state()
     _LOGGER.debug("update_plant_options done for %s", entry.entry_id)
 
 

--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.7.0-beta1"
+  "version": "2026.7.0-beta2"
 }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
@@ -153,6 +154,29 @@ class TestIntegrationSetup:
         # The plant entity is live again (not a stale/unknown orphan)
         assert hass.states.get(plant_entity_id) is not None
         assert ATTR_PLANT in hass.data[DOMAIN][init_integration.entry_id]
+
+    async def test_reload_no_platform_warning(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+        caplog,
+    ) -> None:
+        """Reloading must not write plant state before the plant has a platform.
+
+        Regression for the reload-only residual of #487 (reported on #485): on
+        reload, each child sensor's state restoration re-persisted its
+        external_sensor to the config entry, which fired the update-options
+        listener (update_plant_options) and pushed plant state before the plant
+        entity had been re-added to the shared EntityComponent -- i.e. before it
+        had a platform. HA Core warns ("... does not have a platform ...") for
+        this in 2026.7 and turns it into a hard error in 2026.8.
+        """
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            await hass.config_entries.async_reload(init_integration.entry_id)
+            await hass.async_block_till_done()
+
+        assert "does not have a platform" not in caplog.text
 
     async def test_remove_entry(
         self,


### PR DESCRIPTION
## Problem
On a manual `homeassistant.reload_config_entry`, HA Core logs `Entity plant.<name> ... does not have a platform, this may be caused by adding it manually instead of with an EntityComponent helper` — once per child sensor. Reported by @CybDis on #485; it's the reload-only residual of #487/#488 (a normal HACS upgrade + HA restart never hits it, which is why most users — and my own install — don't see it).

## Root cause
On reload, each child sensor's `async_added_to_hass` restores its `external_sensor` via `replace_external_sensor`, which re-persists it to the config entry (`_update_config_entry` → `async_update_entry`). That fires the `update_plant_options` listener, which calls `plant.async_write_ha_state()` — but this happens during `async_forward_entry_setups`, **before** the plant entity has been re-added to the shared `EntityComponent`, so it has no platform yet.

## Fix
Guard the write in `update_plant_options` on `plant.platform is not None`. The plant writes its initial state when it is added in `async_setup_entry`, so nothing is lost; the legitimate options-flow path (species / entity_picture change) is unaffected because the plant is already added there.

## Impact
Harmless today (one-time, state stays correct), but HA Core turns this 'no platform' guard into a **hard error in 2026.8** — so worth fixing before stable `2026.7.0`.

## Tests
- New regression test `test_reload_no_platform_warning` (asserts no platform warning on reload).
- Full suite **372 passed**; black + ruff clean.

Bumps `2026.7.0-beta1` → `2026.7.0-beta2`. Refs #485, #487.