### PR TITLE
release: 2026.7.0 (stable)

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.7.0-beta2"
+  "version": "2026.7.0"
 }


### PR DESCRIPTION
Promote `2026.7.0-beta2` → stable **2026.7.0**.

Highlights since the last stable (2026.6.x):
- 🚀 `plant.*` **triggers & conditions** for HA 2026.7 (#491)
- 🐛 fixes: `_check_threshold` crash on 2026.7 (#486), shared EntityComponent platform (#487/#488), reload duplicate unique_id (#490), reload 'no platform' warning (#493), DLI hysteresis (#483)
- 📚/🧹 docs + CI (native release notes, Python 3.14 matrix)

Version bump only; CI cuts the stable GitHub release.