### PR TITLE
fix: translated names for plant.* triggers & conditions (Unknown Trigger/condition)

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.7.0"
+  "version": "2026.7.1"
 }

--- a/custom_components/plant/strings.json
+++ b/custom_components/plant/strings.json
@@ -198,5 +198,621 @@
         }
       }
     }
+  },
+  "triggers": {
+    "problem_detected": {
+      "name": "Problem detected",
+      "description": "Triggers when the plant develops a problem (any reading crosses its threshold).",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "problem_cleared": {
+      "name": "Problem cleared",
+      "description": "Triggers when the plant's last problem clears and all readings are back to normal.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_became_low": {
+      "name": "Moisture became low",
+      "description": "Triggers when the plant's moisture drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_became_high": {
+      "name": "Moisture became high",
+      "description": "Triggers when the plant's moisture rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_became_ok": {
+      "name": "Moisture became normal",
+      "description": "Triggers when the plant's moisture returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "conductivity_became_low": {
+      "name": "Conductivity became low",
+      "description": "Triggers when the plant's conductivity drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "conductivity_became_high": {
+      "name": "Conductivity became high",
+      "description": "Triggers when the plant's conductivity rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "conductivity_became_ok": {
+      "name": "Conductivity became normal",
+      "description": "Triggers when the plant's conductivity returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "temperature_became_low": {
+      "name": "Temperature became low",
+      "description": "Triggers when the plant's temperature drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "temperature_became_high": {
+      "name": "Temperature became high",
+      "description": "Triggers when the plant's temperature rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "temperature_became_ok": {
+      "name": "Temperature became normal",
+      "description": "Triggers when the plant's temperature returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "soil_temperature_became_low": {
+      "name": "Soil temperature became low",
+      "description": "Triggers when the plant's soil temperature drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "soil_temperature_became_high": {
+      "name": "Soil temperature became high",
+      "description": "Triggers when the plant's soil temperature rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "soil_temperature_became_ok": {
+      "name": "Soil temperature became normal",
+      "description": "Triggers when the plant's soil temperature returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "humidity_became_low": {
+      "name": "Humidity became low",
+      "description": "Triggers when the plant's humidity drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "humidity_became_high": {
+      "name": "Humidity became high",
+      "description": "Triggers when the plant's humidity rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "humidity_became_ok": {
+      "name": "Humidity became normal",
+      "description": "Triggers when the plant's humidity returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "illuminance_became_low": {
+      "name": "Illuminance became low",
+      "description": "Triggers when the plant's illuminance drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "illuminance_became_high": {
+      "name": "Illuminance became high",
+      "description": "Triggers when the plant's illuminance rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "illuminance_became_ok": {
+      "name": "Illuminance became normal",
+      "description": "Triggers when the plant's illuminance returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "co2_became_low": {
+      "name": "CO2 became low",
+      "description": "Triggers when the plant's CO2 drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "co2_became_high": {
+      "name": "CO2 became high",
+      "description": "Triggers when the plant's CO2 rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "co2_became_ok": {
+      "name": "CO2 became normal",
+      "description": "Triggers when the plant's CO2 returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "dli_became_low": {
+      "name": "DLI became low",
+      "description": "Triggers when the plant's DLI drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "dli_became_high": {
+      "name": "DLI became high",
+      "description": "Triggers when the plant's DLI rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "dli_became_ok": {
+      "name": "DLI became normal",
+      "description": "Triggers when the plant's DLI returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "vpd_became_low": {
+      "name": "VPD became low",
+      "description": "Triggers when the plant's VPD drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "vpd_became_high": {
+      "name": "VPD became high",
+      "description": "Triggers when the plant's VPD rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "vpd_became_ok": {
+      "name": "VPD became normal",
+      "description": "Triggers when the plant's VPD returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_sensor_became_stale": {
+      "name": "Moisture sensor became stale",
+      "description": "Triggers when the plant's moisture sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "moisture_sensor_became_fresh": {
+      "name": "Moisture sensor became live",
+      "description": "Triggers when the plant's moisture sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "conductivity_sensor_became_stale": {
+      "name": "Conductivity sensor became stale",
+      "description": "Triggers when the plant's conductivity sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "conductivity_sensor_became_fresh": {
+      "name": "Conductivity sensor became live",
+      "description": "Triggers when the plant's conductivity sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "temperature_sensor_became_stale": {
+      "name": "Temperature sensor became stale",
+      "description": "Triggers when the plant's temperature sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "temperature_sensor_became_fresh": {
+      "name": "Temperature sensor became live",
+      "description": "Triggers when the plant's temperature sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "soil_temperature_sensor_became_stale": {
+      "name": "Soil temperature sensor became stale",
+      "description": "Triggers when the plant's soil temperature sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "soil_temperature_sensor_became_fresh": {
+      "name": "Soil temperature sensor became live",
+      "description": "Triggers when the plant's soil temperature sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "humidity_sensor_became_stale": {
+      "name": "Humidity sensor became stale",
+      "description": "Triggers when the plant's humidity sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "humidity_sensor_became_fresh": {
+      "name": "Humidity sensor became live",
+      "description": "Triggers when the plant's humidity sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "illuminance_sensor_became_stale": {
+      "name": "Illuminance sensor became stale",
+      "description": "Triggers when the plant's illuminance sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "illuminance_sensor_became_fresh": {
+      "name": "Illuminance sensor became live",
+      "description": "Triggers when the plant's illuminance sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "co2_sensor_became_stale": {
+      "name": "CO2 sensor became stale",
+      "description": "Triggers when the plant's CO2 sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "co2_sensor_became_fresh": {
+      "name": "CO2 sensor became live",
+      "description": "Triggers when the plant's CO2 sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    }
+  },
+  "conditions": {
+    "has_problem": {
+      "name": "Has a problem",
+      "description": "Passes while the plant has any active problem."
+    },
+    "moisture_is_low": {
+      "name": "Moisture is low",
+      "description": "Passes while the plant's moisture is below its configured minimum."
+    },
+    "moisture_is_high": {
+      "name": "Moisture is high",
+      "description": "Passes while the plant's moisture is above its configured maximum."
+    },
+    "moisture_is_ok": {
+      "name": "Moisture is normal",
+      "description": "Passes while the plant's moisture is within its normal range."
+    },
+    "conductivity_is_low": {
+      "name": "Conductivity is low",
+      "description": "Passes while the plant's conductivity is below its configured minimum."
+    },
+    "conductivity_is_high": {
+      "name": "Conductivity is high",
+      "description": "Passes while the plant's conductivity is above its configured maximum."
+    },
+    "conductivity_is_ok": {
+      "name": "Conductivity is normal",
+      "description": "Passes while the plant's conductivity is within its normal range."
+    },
+    "temperature_is_low": {
+      "name": "Temperature is low",
+      "description": "Passes while the plant's temperature is below its configured minimum."
+    },
+    "temperature_is_high": {
+      "name": "Temperature is high",
+      "description": "Passes while the plant's temperature is above its configured maximum."
+    },
+    "temperature_is_ok": {
+      "name": "Temperature is normal",
+      "description": "Passes while the plant's temperature is within its normal range."
+    },
+    "soil_temperature_is_low": {
+      "name": "Soil temperature is low",
+      "description": "Passes while the plant's soil temperature is below its configured minimum."
+    },
+    "soil_temperature_is_high": {
+      "name": "Soil temperature is high",
+      "description": "Passes while the plant's soil temperature is above its configured maximum."
+    },
+    "soil_temperature_is_ok": {
+      "name": "Soil temperature is normal",
+      "description": "Passes while the plant's soil temperature is within its normal range."
+    },
+    "humidity_is_low": {
+      "name": "Humidity is low",
+      "description": "Passes while the plant's humidity is below its configured minimum."
+    },
+    "humidity_is_high": {
+      "name": "Humidity is high",
+      "description": "Passes while the plant's humidity is above its configured maximum."
+    },
+    "humidity_is_ok": {
+      "name": "Humidity is normal",
+      "description": "Passes while the plant's humidity is within its normal range."
+    },
+    "illuminance_is_low": {
+      "name": "Illuminance is low",
+      "description": "Passes while the plant's illuminance is below its configured minimum."
+    },
+    "illuminance_is_high": {
+      "name": "Illuminance is high",
+      "description": "Passes while the plant's illuminance is above its configured maximum."
+    },
+    "illuminance_is_ok": {
+      "name": "Illuminance is normal",
+      "description": "Passes while the plant's illuminance is within its normal range."
+    },
+    "co2_is_low": {
+      "name": "CO2 is low",
+      "description": "Passes while the plant's CO2 is below its configured minimum."
+    },
+    "co2_is_high": {
+      "name": "CO2 is high",
+      "description": "Passes while the plant's CO2 is above its configured maximum."
+    },
+    "co2_is_ok": {
+      "name": "CO2 is normal",
+      "description": "Passes while the plant's CO2 is within its normal range."
+    },
+    "dli_is_low": {
+      "name": "DLI is low",
+      "description": "Passes while the plant's DLI is below its configured minimum."
+    },
+    "dli_is_high": {
+      "name": "DLI is high",
+      "description": "Passes while the plant's DLI is above its configured maximum."
+    },
+    "dli_is_ok": {
+      "name": "DLI is normal",
+      "description": "Passes while the plant's DLI is within its normal range."
+    },
+    "vpd_is_low": {
+      "name": "VPD is low",
+      "description": "Passes while the plant's VPD is below its configured minimum."
+    },
+    "vpd_is_high": {
+      "name": "VPD is high",
+      "description": "Passes while the plant's VPD is above its configured maximum."
+    },
+    "vpd_is_ok": {
+      "name": "VPD is normal",
+      "description": "Passes while the plant's VPD is within its normal range."
+    },
+    "moisture_sensor_is_stale": {
+      "name": "Moisture sensor is stale",
+      "description": "Passes while the plant's moisture sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "conductivity_sensor_is_stale": {
+      "name": "Conductivity sensor is stale",
+      "description": "Passes while the plant's conductivity sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "temperature_sensor_is_stale": {
+      "name": "Temperature sensor is stale",
+      "description": "Passes while the plant's temperature sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "soil_temperature_sensor_is_stale": {
+      "name": "Soil temperature sensor is stale",
+      "description": "Passes while the plant's soil temperature sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "humidity_sensor_is_stale": {
+      "name": "Humidity sensor is stale",
+      "description": "Passes while the plant's humidity sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "illuminance_sensor_is_stale": {
+      "name": "Illuminance sensor is stale",
+      "description": "Passes while the plant's illuminance sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "co2_sensor_is_stale": {
+      "name": "CO2 sensor is stale",
+      "description": "Passes while the plant's CO2 sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    }
   }
 }

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -222,5 +222,621 @@
         }
       }
     }
+  },
+  "triggers": {
+    "problem_detected": {
+      "name": "Problem detected",
+      "description": "Triggers when the plant develops a problem (any reading crosses its threshold).",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "problem_cleared": {
+      "name": "Problem cleared",
+      "description": "Triggers when the plant's last problem clears and all readings are back to normal.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_became_low": {
+      "name": "Moisture became low",
+      "description": "Triggers when the plant's moisture drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_became_high": {
+      "name": "Moisture became high",
+      "description": "Triggers when the plant's moisture rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_became_ok": {
+      "name": "Moisture became normal",
+      "description": "Triggers when the plant's moisture returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "conductivity_became_low": {
+      "name": "Conductivity became low",
+      "description": "Triggers when the plant's conductivity drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "conductivity_became_high": {
+      "name": "Conductivity became high",
+      "description": "Triggers when the plant's conductivity rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "conductivity_became_ok": {
+      "name": "Conductivity became normal",
+      "description": "Triggers when the plant's conductivity returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "temperature_became_low": {
+      "name": "Temperature became low",
+      "description": "Triggers when the plant's temperature drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "temperature_became_high": {
+      "name": "Temperature became high",
+      "description": "Triggers when the plant's temperature rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "temperature_became_ok": {
+      "name": "Temperature became normal",
+      "description": "Triggers when the plant's temperature returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "soil_temperature_became_low": {
+      "name": "Soil temperature became low",
+      "description": "Triggers when the plant's soil temperature drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "soil_temperature_became_high": {
+      "name": "Soil temperature became high",
+      "description": "Triggers when the plant's soil temperature rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "soil_temperature_became_ok": {
+      "name": "Soil temperature became normal",
+      "description": "Triggers when the plant's soil temperature returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "humidity_became_low": {
+      "name": "Humidity became low",
+      "description": "Triggers when the plant's humidity drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "humidity_became_high": {
+      "name": "Humidity became high",
+      "description": "Triggers when the plant's humidity rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "humidity_became_ok": {
+      "name": "Humidity became normal",
+      "description": "Triggers when the plant's humidity returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "illuminance_became_low": {
+      "name": "Illuminance became low",
+      "description": "Triggers when the plant's illuminance drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "illuminance_became_high": {
+      "name": "Illuminance became high",
+      "description": "Triggers when the plant's illuminance rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "illuminance_became_ok": {
+      "name": "Illuminance became normal",
+      "description": "Triggers when the plant's illuminance returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "co2_became_low": {
+      "name": "CO2 became low",
+      "description": "Triggers when the plant's CO2 drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "co2_became_high": {
+      "name": "CO2 became high",
+      "description": "Triggers when the plant's CO2 rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "co2_became_ok": {
+      "name": "CO2 became normal",
+      "description": "Triggers when the plant's CO2 returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "dli_became_low": {
+      "name": "DLI became low",
+      "description": "Triggers when the plant's DLI drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "dli_became_high": {
+      "name": "DLI became high",
+      "description": "Triggers when the plant's DLI rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "dli_became_ok": {
+      "name": "DLI became normal",
+      "description": "Triggers when the plant's DLI returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "vpd_became_low": {
+      "name": "VPD became low",
+      "description": "Triggers when the plant's VPD drops below its configured minimum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "vpd_became_high": {
+      "name": "VPD became high",
+      "description": "Triggers when the plant's VPD rises above its configured maximum.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "vpd_became_ok": {
+      "name": "VPD became normal",
+      "description": "Triggers when the plant's VPD returns to its normal range.",
+      "fields": {
+        "behavior": {
+          "name": "Behavior",
+          "description": "Whether the trigger fires for each targeted plant or only once for the group."
+        }
+      }
+    },
+    "moisture_sensor_became_stale": {
+      "name": "Moisture sensor became stale",
+      "description": "Triggers when the plant's moisture sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "moisture_sensor_became_fresh": {
+      "name": "Moisture sensor became live",
+      "description": "Triggers when the plant's moisture sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "conductivity_sensor_became_stale": {
+      "name": "Conductivity sensor became stale",
+      "description": "Triggers when the plant's conductivity sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "conductivity_sensor_became_fresh": {
+      "name": "Conductivity sensor became live",
+      "description": "Triggers when the plant's conductivity sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "temperature_sensor_became_stale": {
+      "name": "Temperature sensor became stale",
+      "description": "Triggers when the plant's temperature sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "temperature_sensor_became_fresh": {
+      "name": "Temperature sensor became live",
+      "description": "Triggers when the plant's temperature sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "soil_temperature_sensor_became_stale": {
+      "name": "Soil temperature sensor became stale",
+      "description": "Triggers when the plant's soil temperature sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "soil_temperature_sensor_became_fresh": {
+      "name": "Soil temperature sensor became live",
+      "description": "Triggers when the plant's soil temperature sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "humidity_sensor_became_stale": {
+      "name": "Humidity sensor became stale",
+      "description": "Triggers when the plant's humidity sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "humidity_sensor_became_fresh": {
+      "name": "Humidity sensor became live",
+      "description": "Triggers when the plant's humidity sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "illuminance_sensor_became_stale": {
+      "name": "Illuminance sensor became stale",
+      "description": "Triggers when the plant's illuminance sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "illuminance_sensor_became_fresh": {
+      "name": "Illuminance sensor became live",
+      "description": "Triggers when the plant's illuminance sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "co2_sensor_became_stale": {
+      "name": "CO2 sensor became stale",
+      "description": "Triggers when the plant's CO2 sensor stops sending updates.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    },
+    "co2_sensor_became_fresh": {
+      "name": "CO2 sensor became live",
+      "description": "Triggers when the plant's CO2 sensor starts sending updates again.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must stay in this state for at least this long before the trigger fires."
+        }
+      }
+    }
+  },
+  "conditions": {
+    "has_problem": {
+      "name": "Has a problem",
+      "description": "Passes while the plant has any active problem."
+    },
+    "moisture_is_low": {
+      "name": "Moisture is low",
+      "description": "Passes while the plant's moisture is below its configured minimum."
+    },
+    "moisture_is_high": {
+      "name": "Moisture is high",
+      "description": "Passes while the plant's moisture is above its configured maximum."
+    },
+    "moisture_is_ok": {
+      "name": "Moisture is normal",
+      "description": "Passes while the plant's moisture is within its normal range."
+    },
+    "conductivity_is_low": {
+      "name": "Conductivity is low",
+      "description": "Passes while the plant's conductivity is below its configured minimum."
+    },
+    "conductivity_is_high": {
+      "name": "Conductivity is high",
+      "description": "Passes while the plant's conductivity is above its configured maximum."
+    },
+    "conductivity_is_ok": {
+      "name": "Conductivity is normal",
+      "description": "Passes while the plant's conductivity is within its normal range."
+    },
+    "temperature_is_low": {
+      "name": "Temperature is low",
+      "description": "Passes while the plant's temperature is below its configured minimum."
+    },
+    "temperature_is_high": {
+      "name": "Temperature is high",
+      "description": "Passes while the plant's temperature is above its configured maximum."
+    },
+    "temperature_is_ok": {
+      "name": "Temperature is normal",
+      "description": "Passes while the plant's temperature is within its normal range."
+    },
+    "soil_temperature_is_low": {
+      "name": "Soil temperature is low",
+      "description": "Passes while the plant's soil temperature is below its configured minimum."
+    },
+    "soil_temperature_is_high": {
+      "name": "Soil temperature is high",
+      "description": "Passes while the plant's soil temperature is above its configured maximum."
+    },
+    "soil_temperature_is_ok": {
+      "name": "Soil temperature is normal",
+      "description": "Passes while the plant's soil temperature is within its normal range."
+    },
+    "humidity_is_low": {
+      "name": "Humidity is low",
+      "description": "Passes while the plant's humidity is below its configured minimum."
+    },
+    "humidity_is_high": {
+      "name": "Humidity is high",
+      "description": "Passes while the plant's humidity is above its configured maximum."
+    },
+    "humidity_is_ok": {
+      "name": "Humidity is normal",
+      "description": "Passes while the plant's humidity is within its normal range."
+    },
+    "illuminance_is_low": {
+      "name": "Illuminance is low",
+      "description": "Passes while the plant's illuminance is below its configured minimum."
+    },
+    "illuminance_is_high": {
+      "name": "Illuminance is high",
+      "description": "Passes while the plant's illuminance is above its configured maximum."
+    },
+    "illuminance_is_ok": {
+      "name": "Illuminance is normal",
+      "description": "Passes while the plant's illuminance is within its normal range."
+    },
+    "co2_is_low": {
+      "name": "CO2 is low",
+      "description": "Passes while the plant's CO2 is below its configured minimum."
+    },
+    "co2_is_high": {
+      "name": "CO2 is high",
+      "description": "Passes while the plant's CO2 is above its configured maximum."
+    },
+    "co2_is_ok": {
+      "name": "CO2 is normal",
+      "description": "Passes while the plant's CO2 is within its normal range."
+    },
+    "dli_is_low": {
+      "name": "DLI is low",
+      "description": "Passes while the plant's DLI is below its configured minimum."
+    },
+    "dli_is_high": {
+      "name": "DLI is high",
+      "description": "Passes while the plant's DLI is above its configured maximum."
+    },
+    "dli_is_ok": {
+      "name": "DLI is normal",
+      "description": "Passes while the plant's DLI is within its normal range."
+    },
+    "vpd_is_low": {
+      "name": "VPD is low",
+      "description": "Passes while the plant's VPD is below its configured minimum."
+    },
+    "vpd_is_high": {
+      "name": "VPD is high",
+      "description": "Passes while the plant's VPD is above its configured maximum."
+    },
+    "vpd_is_ok": {
+      "name": "VPD is normal",
+      "description": "Passes while the plant's VPD is within its normal range."
+    },
+    "moisture_sensor_is_stale": {
+      "name": "Moisture sensor is stale",
+      "description": "Passes while the plant's moisture sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "conductivity_sensor_is_stale": {
+      "name": "Conductivity sensor is stale",
+      "description": "Passes while the plant's conductivity sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "temperature_sensor_is_stale": {
+      "name": "Temperature sensor is stale",
+      "description": "Passes while the plant's temperature sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "soil_temperature_sensor_is_stale": {
+      "name": "Soil temperature sensor is stale",
+      "description": "Passes while the plant's soil temperature sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "humidity_sensor_is_stale": {
+      "name": "Humidity sensor is stale",
+      "description": "Passes while the plant's humidity sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "illuminance_sensor_is_stale": {
+      "name": "Illuminance sensor is stale",
+      "description": "Passes while the plant's illuminance sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    },
+    "co2_sensor_is_stale": {
+      "name": "CO2 sensor is stale",
+      "description": "Passes while the plant's CO2 sensor has not sent updates for the configured time.",
+      "fields": {
+        "for": {
+          "name": "For",
+          "description": "The sensor must have been stale for at least this long for the condition to pass."
+        }
+      }
+    }
   }
 }

--- a/tests/test_automation_descriptions.py
+++ b/tests/test_automation_descriptions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
@@ -34,3 +35,38 @@ async def test_every_trigger_has_a_description(hass: HomeAssistant) -> None:
 
 async def test_every_condition_has_a_description(hass: HomeAssistant) -> None:
     assert set(await async_get_conditions(hass)) <= _described_keys("conditions.yaml")
+
+
+_TRANSLATION_FILES = ("strings.json", "translations/en.json")
+
+
+def _named_keys(translation_file: str, section: str) -> set[str]:
+    """Keys under a strings.json section that carry a non-empty display name."""
+    data = json.loads((_ROOT / translation_file).read_text())
+    return {
+        key
+        for key, block in data.get(section, {}).items()
+        if isinstance(block, dict) and block.get("name")
+    }
+
+
+@pytest.mark.parametrize("translation_file", _TRANSLATION_FILES)
+async def test_every_trigger_has_a_translated_name(
+    hass: HomeAssistant, translation_file: str
+) -> None:
+    """Every advertised trigger needs a translated name, or the automation UI
+    shows "Unknown Trigger". Guards both strings.json and its en.json mirror."""
+    assert set(await async_get_triggers(hass)) <= _named_keys(
+        translation_file, "triggers"
+    )
+
+
+@pytest.mark.parametrize("translation_file", _TRANSLATION_FILES)
+async def test_every_condition_has_a_translated_name(
+    hass: HomeAssistant, translation_file: str
+) -> None:
+    """Every advertised condition needs a translated name, or the automation UI
+    shows "Unknown condition". Guards both strings.json and its en.json mirror."""
+    assert set(await async_get_conditions(hass)) <= _named_keys(
+        translation_file, "conditions"
+    )


### PR DESCRIPTION
## Problem
The new `plant.*` triggers & conditions (2026.7.0) work, but the automation UI shows every one as **"Unknown Trigger"** / **"Unknown condition"**. The display name comes from the integration's translations (`strings.json` → `triggers`/`conditions`), not from `triggers.yaml`/`conditions.yaml` (which only describe config fields). Those sections were missing, so HA had no name to show.

## Fix
Add `triggers` and `conditions` sections to `strings.json` and its `translations/en.json` mirror, with `name` + `description` for all **43 triggers** and **35 conditions** (plus `behavior`/`for` field labels), matching HA Core's triggers/conditions translation schema.

## Regression guard
`test_automation_descriptions.py` previously only checked the YAML files. Extended it to assert every advertised trigger/condition also has a translated **name** in both `strings.json` and `en.json` — which is exactly what was missing.

## Tests
Full suite **376 passed** (+4); black + ruff clean; both JSON files valid.

Bumps `2026.7.0` → `2026.7.1`.