### PR TITLE
fix: use UnitOfRatio.PARTS_PER_MILLION instead of deprecated CONCENTRATION_PARTS_PER_MILLION

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -167,7 +167,7 @@ UNIT_DLI = "mol/d⋅m²"
 UNIT_VPD = "kPa"
 UNIT_MICRO_DLI = "µmol/d⋅m²"
 # Note: For conductivity, use UnitOfConductivity.MICROSIEMENS_PER_CM from homeassistant.const
-# Note: For CO2, use CONCENTRATION_PARTS_PER_MILLION from homeassistant.const
+# Note: For CO2, use UnitOfRatio.PARTS_PER_MILLION from homeassistant.const
 
 FLOW_WRONG_PLANT = "wrong_plant"
 FLOW_RIGHT_PLANT = "right_plant"

--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.7.1"
+  "version": "2026.7.2"
 }

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -29,10 +29,20 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfConductivity,
-    UnitOfRatio,
     UnitOfTemperature,
     UnitOfTime,
 )
+
+try:
+    # HA 2026.7+ deprecated CONCENTRATION_PARTS_PER_MILLION in favour of the
+    # UnitOfRatio enumerator (removed in HA Core 2027.8). Fall back to the old
+    # constant on HA < 2026.7, where UnitOfRatio does not exist yet.
+    from homeassistant.const import UnitOfRatio
+
+    _UNIT_PPM: str = UnitOfRatio.PARTS_PER_MILLION
+except ImportError:  # HA < 2026.7
+    from homeassistant.const import CONCENTRATION_PARTS_PER_MILLION as _UNIT_PPM
+
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -721,7 +731,7 @@ class PlantCurrentCo2(PlantCurrentStatus):
 
     _attr_device_class = SensorDeviceClass.CO2
     _attr_icon = ICON_CO2
-    _attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
+    _attr_native_unit_of_measurement = _UNIT_PPM
     _attr_suggested_display_precision = 0
     _attr_translation_key = TRANSLATION_KEY_CO2
     _config_key = FLOW_SENSOR_CO2

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -24,12 +24,12 @@ from homeassistant.const import (
     ATTR_ICON,
     ATTR_NAME,
     ATTR_UNIT_OF_MEASUREMENT,
-    CONCENTRATION_PARTS_PER_MILLION,
     LIGHT_LUX,
     PERCENTAGE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
     UnitOfConductivity,
+    UnitOfRatio,
     UnitOfTemperature,
     UnitOfTime,
 )
@@ -721,7 +721,7 @@ class PlantCurrentCo2(PlantCurrentStatus):
 
     _attr_device_class = SensorDeviceClass.CO2
     _attr_icon = ICON_CO2
-    _attr_native_unit_of_measurement = CONCENTRATION_PARTS_PER_MILLION
+    _attr_native_unit_of_measurement = UnitOfRatio.PARTS_PER_MILLION
     _attr_suggested_display_precision = 0
     _attr_translation_key = TRANSLATION_KEY_CO2
     _config_key = FLOW_SENSOR_CO2


### PR DESCRIPTION
## What

Replaces the deprecated `CONCENTRATION_PARTS_PER_MILLION` constant (used for the CO2 sensor's unit) with `UnitOfRatio.PARTS_PER_MILLION`, per the [new unit enumerators](https://developers.home-assistant.io/blog/2026/06/30/new-unit-enumerators) change.

Fixes this warning on HA 2026.8.0b0:
```
The deprecated constant CONCENTRATION_PARTS_PER_MILLION was used from plant. It will be removed in HA Core 2027.8. Use UnitOfRatio.PARTS_PER_MILLION instead
```

## Changes
- `sensor.py`: swap the import and `PlantCurrentCo2._attr_native_unit_of_measurement`
- `const.py`: update the stale reference comment
- `manifest.json`: 2026.7.1 → 2026.7.2

## Notes
`UnitOfRatio.PARTS_PER_MILLION == 'ppm'`, so the reported unit is **unchanged** — this is a pure deprecation cleanup. All 376 tests pass.

Addresses the units half of #496. The second warning in that issue (device attached to an entity without a config entry) is architectural and tracked separately.