### PR TITLE
fix: attach plant device via a config-entry-bound platform (no version bump)

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import asyncio
+import contextlib
 import logging
 from datetime import datetime, timedelta
 
@@ -248,28 +248,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    plant_entities = [
-        plant,
-    ]
-
-    # Add the entities to Hass via the single shared domain-level component
-    # (see _get_plant_component), so each entity has a valid platform.
+    # Add the plant.<name> entity through the shared domain component's
+    # config-entry platform (plant/plant.py). Binding the config entry to the
+    # platform lets Home Assistant attach the device and register the entity
+    # natively (entity_platform links both to the config entry) - which replaces
+    # the old manual device-registry patch and avoids the HA 2026.8 warning
+    # about attaching a device to an entity without a config entry. The per-entry
+    # EntityPlatform lives inside the single shared component, so the entity
+    # still always has a valid platform (issue #487), and async_unload_entry
+    # resets it cleanly on unload/reload.
     component = _get_plant_component(hass)
-    # On a reload the previous plant.<name> entity leaves a stale, non-restored
-    # state behind that keeps the entity_id "in use"; core would then abort the
-    # re-add with a duplicate unique_id. Clear any such orphan (no live entity
-    # backing it) right before adding so the id can be reclaimed.
-    erreg = er.async_get(hass)
-    existing_entity_id = erreg.async_get_entity_id(DOMAIN, DOMAIN, entry.entry_id)
-    if existing_entity_id and not hass.states.async_available(existing_entity_id):
-        existing_state = hass.states.get(existing_entity_id)
-        if existing_state is not None and not existing_state.attributes.get("restored"):
-            hass.states.async_remove(existing_entity_id)
-    await component.async_add_entities(plant_entities)
-
-    # Add the entities to device registry and tie to config entry
-    device_id = plant.device_id
-    await _plant_add_to_device_registry(hass, plant_entities, device_id, entry)
+    if not await component.async_setup_entry(entry):
+        _LOGGER.error(
+            "Failed to set up the plant entity platform for entry %s",
+            entry.entry_id,
+        )
+        return False
 
     # Set up utility sensor
     hass.data.setdefault(DATA_UTILITY, {})
@@ -369,51 +363,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-_REGISTRY_RETRY_DELAY = 1  # seconds between retries
-_REGISTRY_MAX_RETRIES = 5
-
-
-async def _plant_add_to_device_registry(
-    hass: HomeAssistant,
-    plant_entities: list[Entity],
-    device_id: str,
-    entry: ConfigEntry,
-) -> None:
-    """Add all related entities to the correct device and config entry."""
-
-    # There must be a better way to do this, but I just can't find a way to set the
-    # device_id when adding the entities.
-    erreg = er.async_get(hass)
-    for entity in plant_entities:
-        registry_entry = entity.registry_entry or erreg.async_get(entity.entity_id)
-        retries = 0
-        while registry_entry is None and retries < _REGISTRY_MAX_RETRIES:
-            retries += 1
-            _LOGGER.debug(
-                "Entity %s not yet in registry, retrying (%s/%s)",
-                entity.entity_id,
-                retries,
-                _REGISTRY_MAX_RETRIES,
-            )
-            await asyncio.sleep(_REGISTRY_RETRY_DELAY)
-            registry_entry = entity.registry_entry or erreg.async_get(entity.entity_id)
-
-        if registry_entry is None:
-            _LOGGER.warning(
-                "Entity %s not found in registry after %s retries, "
-                "skipping device assignment",
-                entity.entity_id,
-                retries,
-            )
-            continue
-
-        erreg.async_update_entity(
-            registry_entry.entity_id,
-            device_id=device_id,
-            config_entry_id=entry.entry_id,
-        )
-
-
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     # Prevent auto-disable from firing during unload teardown
@@ -421,12 +370,17 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if ATTR_PLANT in plant_data:
         plant_data[ATTR_PLANT].plant_complete = False
 
-    # Remove the plant entity from the shared EntityComponent so reloads don't
-    # hit a duplicate unique_id error
-    plant = plant_data.get(ATTR_PLANT)
+    # Reset this entry's platform on the shared component so the plant.<name>
+    # entity is removed cleanly (mirror of component.async_setup_entry in
+    # async_setup_entry). This frees the entity_id so a reload can re-add it
+    # without a duplicate unique_id. Entries without plant info were never set
+    # up on the component, so async_unload_entry raises ValueError - ignore it.
     component = hass.data.get(DOMAIN, {}).get(DATA_COMPONENT)
-    if component and plant and plant.entity_id:
-        await component.async_remove_entity(plant.entity_id)
+    if component is not None:
+        # Entries without plant info were never set up on the component, so
+        # async_unload_entry raises ValueError - ignore it.
+        with contextlib.suppress(ValueError):
+            await component.async_unload_entry(entry)
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 

--- a/custom_components/plant/plant.py
+++ b/custom_components/plant/plant.py
@@ -1,0 +1,37 @@
+"""Config-entry platform for the plant.<name> device entity.
+
+The ``plant.<name>`` entity lives on the ``plant`` domain, which this
+integration owns (it shadows Home Assistant's built-in plant component). Adding
+it through a real config-entry platform - rather than the shared component's
+default, config-entry-less platform - gives the entity's ``EntityPlatform`` a
+``config_entry``. Home Assistant then attaches the entity's device and registers
+the entity registry entry to that config entry natively
+(``entity_platform.async_add_entities``), so the integration no longer needs to
+patch the device/entity registries by hand, and HA Core 2026.8 no longer warns
+that a device is attached to an entity without a config entry.
+
+The ``PlantDevice`` instance is created in ``__init__.async_setup_entry`` (it is
+needed there for the utility sensor wiring) and stashed under the entry's data;
+this platform just hands that same instance to the config-entry-bound
+``async_add_entities``. ``__init__.async_setup_entry`` drives this module via
+``component.async_setup_entry(entry)`` on the single shared EntityComponent, so
+the entity still always has a valid, stable platform (issue #487).
+"""
+
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import ATTR_PLANT, DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Add the PlantDevice for this config entry to its bound platform."""
+    plant = hass.data[DOMAIN][entry.entry_id][ATTR_PLANT]
+    async_add_entities([plant])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -55,6 +55,9 @@ class TestIntegrationSetup:
         )
         assert device is not None
         assert device.name == TEST_PLANT_NAME
+        # The device is owned by the config entry - attached natively by the
+        # config-entry-bound platform, not patched in after the fact.
+        assert init_integration.entry_id in device.config_entries
 
     async def test_setup_entry_creates_entities(
         self,
@@ -100,15 +103,24 @@ class TestIntegrationSetup:
         and removes the compatibility guard in 2026.8. A single shared
         domain-level component must own the entity so ``entity.platform`` is set.
         """
-        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        entry_id = init_integration.entry_id
+        plant = hass.data[DOMAIN][entry_id][ATTR_PLANT]
 
         # The entity carries a valid platform reference...
         assert plant.platform is not None
-        # ...and it is the single shared domain component (stored under
-        # DATA_COMPONENT), not a per-entry one under the entry's own data.
+        # ...owned by the single shared domain component (stored under
+        # DATA_COMPONENT), not a per-entry EntityComponent under the entry data.
         assert DATA_COMPONENT in hass.data[DOMAIN]
-        assert plant.platform is hass.data[DOMAIN][DATA_COMPONENT]._platforms[DOMAIN]
-        assert "component" not in hass.data[DOMAIN][init_integration.entry_id]
+        component = hass.data[DOMAIN][DATA_COMPONENT]
+        # The entity is on this entry's config-entry-bound platform (added via
+        # component.async_setup_entry -> plant/plant.py), so its platform carries
+        # the config entry. That is what lets HA attach the device natively and
+        # avoids the 2026.8 "attach a device to an entity without a config entry"
+        # warning.
+        assert plant.platform is component._platforms[entry_id]
+        assert plant.platform.config_entry is not None
+        assert plant.platform.config_entry.entry_id == entry_id
+        assert "component" not in hass.data[DOMAIN][entry_id]
 
     async def test_shared_component_survives_unload(
         self,


### PR DESCRIPTION
## Problem
Addresses the **device-registry** half of #496. On HA 2026.8.0b0:
```
Detected that custom integration 'plant' attempts to attach a device to an entity
without a config entry. This will stop working in Home Assistant 2027.8.0
```
Root cause: the `plant.<name>` entity is added through the shared `EntityComponent`'s **default platform**, which has no `config_entry` (`entity_component.py` creates it with `config_entry=None`). HA's native device attach (`entity_platform.py:856`) only runs when the platform has a config entry, so the integration compensated with a manual `_plant_add_to_device_registry` patch — and the entity's `device_info` is still processed with no config entry, which is what 2026.8 warns about (`_check_device_attach`, `entity_platform.py:973`).

## Fix (the idiomatic "Option B")
- New **`plant.py` platform module** with `async_setup_entry(hass, entry, async_add_entities)`.
- `__init__.async_setup_entry` now drives it via **`component.async_setup_entry(entry)`** on the single shared component, so the per-entry `EntityPlatform` carries the config entry. HA then attaches the device and registers the entity to the config entry **natively**.
- `async_unload_entry` resets that per-entry platform via `component.async_unload_entry(entry)`.

This lets us **delete the `_plant_add_to_device_registry` hack and the reload stale-entity clearing** (net −34 lines in `__init__.py`). The entity still lives on the **one shared component** (issue #487 stays fixed); only a per-entry `EntityPlatform` inside it comes and goes with the entry — HA's standard config-entry lifecycle.

## Compatibility with #487
#487 was about throwaway *whole components* per entry leaving the entity platform-less. A per-entry `EntityPlatform` *inside* the shared component is HA's normal model and keeps a valid, stable platform throughout — verified by `test_plant_entity_added_via_shared_component` and `test_reload_no_platform_warning`.

## Testing
- **HA 2026.7.0b1** (repo test matrix): 376 tests pass.
- **HA 2026.8.0b0** (forced locally; no released `pytest-homeassistant-custom-component` pins the beta yet — its latest pins 2026.7.4 and patches `http.start_http_server_and_save_config`, removed in 2026.8, so a tiny **test-only** shim was used to load the plugin): 376 tests pass.
- **Warning confirmed present-before / absent-after** on 2026.8.0b0 via a throwaway test that resets the per-session `report_usage` dedup.
- Updated `test_plant_entity_added_via_shared_component` to assert the entity is on the config-entry-bound platform (`_platforms[entry_id]`, `platform.config_entry.entry_id == entry_id`) and `test_setup_entry_creates_device` to assert `entry_id in device.config_entries` — deterministic guards that the warning branch is unreachable.

## Note
**No `manifest.json` version bump** — per maintainer request, this needs a review pass before release. CI's "HA latest" job currently resolves to 2026.7.4 (beta not pulled), so the 2026.8 result above is from the local run.