### PR TITLE
release: 2026.8.0-beta1 (beta)

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.7.2"
+  "version": "2026.8.0-beta1"
 }


### PR DESCRIPTION
First **2026.8 beta** — Home Assistant 2026.8 compatibility.

Bumps `manifest.json` to `2026.8.0-beta1`, which makes the Auto Release workflow publish a **prerelease** `v2026.8.0-beta1` with label-categorized notes.

### What's in it
- **#498** — device-registry fix: the `plant.<name>` entity is now attached to its config entry via a real config-entry platform (`plant.py` + `component.async_setup_entry`), silencing HA 2026.8's *"attach a device to an entity without a config entry"* warning (a hard error in 2027.8). Verified on HA 2026.7.0b1 and 2026.8.0b0.
- (The units deprecation fix #497 / `UnitOfRatio` already shipped in stable 2026.7.2.)

Named for the HA 2026.8 release it targets (August is two days out).