### PR TITLE
fix: version-safe construction of HA helper sensors for 2026.8

### DIFF
--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import logging
 import math
 import random
@@ -122,6 +123,25 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _init_accepts_hass(cls: type) -> bool:
+    """Return True if ``cls.__init__`` still accepts a ``hass`` argument.
+
+    HA 2026.8 (core PRs #177596 / #177597 / #177603 - "Do not set a device on
+    YAML integration / statistics / utility_meter entities") dropped the leading
+    ``hass`` argument from ``IntegrationSensor`` / ``StatisticsSensor`` /
+    ``UtilityMeterSensor.__init__`` and added an optional ``device``. We pass
+    ``hass`` only on HA < 2026.8; on newer cores the plant subclasses still
+    supply their own device through the ``device_info`` property, so the new
+    ``device`` argument is not needed.
+    """
+    return "hass" in inspect.signature(cls.__init__).parameters
+
+
+_INTEGRATION_SENSOR_ACCEPTS_HASS = _init_accepts_hass(IntegrationSensor)
+_UTILITY_METER_SENSOR_ACCEPTS_HASS = _init_accepts_hass(UtilityMeterSensor)
+_STATISTICS_SENSOR_ACCEPTS_HASS = _init_accepts_hass(StatisticsSensor)
 
 
 async def async_setup_entry(
@@ -1203,17 +1223,19 @@ class PlantTotalLightIntegral(IntegrationSensor):
         self._source_unique_id = illuminance_ppfd_sensor.unique_id
         self._state_change_unsub = None
         self._state_report_unsub = None
-        super().__init__(
-            hass,
-            integration_method=METHOD_TRAPEZOIDAL,
-            name=f"Total {READING_PPFD} Integral",
-            round_digits=2,
-            source_entity=illuminance_ppfd_sensor.entity_id,
-            unique_id=f"{config.entry_id}-ppfd-integral",
-            unit_prefix=None,
-            unit_time=UnitOfTime.SECONDS,
-            max_sub_interval=None,
-        )
+        integration_kwargs = {
+            "integration_method": METHOD_TRAPEZOIDAL,
+            "name": f"Total {READING_PPFD} Integral",
+            "round_digits": 2,
+            "source_entity": illuminance_ppfd_sensor.entity_id,
+            "unique_id": f"{config.entry_id}-ppfd-integral",
+            "unit_prefix": None,
+            "unit_time": UnitOfTime.SECONDS,
+            "max_sub_interval": None,
+        }
+        if _INTEGRATION_SENSOR_ACCEPTS_HASS:
+            integration_kwargs["hass"] = hass
+        super().__init__(**integration_kwargs)
         ent_reg = er_async_get(hass)
         if ent_reg.async_get_entity_id(
             SENSOR_DOMAIN, DOMAIN, f"{config.entry_id}-ppfd-integral"
@@ -1311,23 +1333,25 @@ class PlantDailyLightIntegral(UtilityMeterSensor):
         # Store the source sensor's unique_id for tracking entity_id changes
         self._source_unique_id = illuminance_integration_sensor.unique_id
 
-        super().__init__(
-            hass,
-            cron_pattern=None,
-            delta_values=None,
-            meter_offset=timedelta(seconds=0),
-            meter_type=DAILY,
-            name=READING_DLI,
-            net_consumption=None,
-            parent_meter=config.entry_id,
-            source_entity=illuminance_integration_sensor.entity_id,
-            tariff_entity=None,
-            tariff=None,
-            unique_id=f"{config.entry_id}-dli",
-            sensor_always_available=True,
-            suggested_entity_id=None,
-            periodically_resetting=True,
-        )
+        utility_meter_kwargs = {
+            "cron_pattern": None,
+            "delta_values": None,
+            "meter_offset": timedelta(seconds=0),
+            "meter_type": DAILY,
+            "name": READING_DLI,
+            "net_consumption": None,
+            "parent_meter": config.entry_id,
+            "source_entity": illuminance_integration_sensor.entity_id,
+            "tariff_entity": None,
+            "tariff": None,
+            "unique_id": f"{config.entry_id}-dli",
+            "sensor_always_available": True,
+            "suggested_entity_id": None,
+            "periodically_resetting": True,
+        }
+        if _UTILITY_METER_SENSOR_ACCEPTS_HASS:
+            utility_meter_kwargs["hass"] = hass
+        super().__init__(**utility_meter_kwargs)
         ent_reg = er_async_get(hass)
         if ent_reg.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, f"{config.entry_id}-dli"):
             self.entity_id = async_generate_entity_id(
@@ -1428,18 +1452,20 @@ class PlantDailyLightIntegral24h(StatisticsSensor):
         self._plant = plantdevice
         self._source_unique_id = illuminance_integration_sensor.unique_id
 
-        super().__init__(
-            hass=hass,
-            source_entity_id=illuminance_integration_sensor.entity_id,
-            name=f"{READING_DLI} 24h",
-            unique_id=f"{config.entry_id}-dli-24h",
-            state_characteristic="change",
-            samples_max_buffer_size=None,  # Unlimited, driven by max_age
-            samples_max_age=timedelta(hours=24),
-            samples_keep_last=True,
-            precision=2,
-            percentile=50,  # Not used for "change" characteristic
-        )
+        statistics_kwargs = {
+            "source_entity_id": illuminance_integration_sensor.entity_id,
+            "name": f"{READING_DLI} 24h",
+            "unique_id": f"{config.entry_id}-dli-24h",
+            "state_characteristic": "change",
+            "samples_max_buffer_size": None,  # Unlimited, driven by max_age
+            "samples_max_age": timedelta(hours=24),
+            "samples_keep_last": True,
+            "precision": 2,
+            "percentile": 50,  # Not used for "change" characteristic
+        }
+        if _STATISTICS_SENSOR_ACCEPTS_HASS:
+            statistics_kwargs["hass"] = hass
+        super().__init__(**statistics_kwargs)
         ent_reg = er_async_get(hass)
         if ent_reg.async_get_entity_id(
             SENSOR_DOMAIN, DOMAIN, f"{config.entry_id}-dli-24h"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -74,6 +74,31 @@ class TestIntegrationSetup:
         # Plus potentially the main plant entity
         assert len(entities) >= 24  # At minimum sensors + thresholds
 
+    async def test_setup_creates_derived_light_sensors(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """The derived light sensors must actually be created.
+
+        The PPFD integral, DLI and 24h-DLI sensors subclass HA's
+        IntegrationSensor / UtilityMeterSensor / StatisticsSensor. HA 2026.8
+        (core PRs #177596 / #177597 / #177603) dropped the ``hass`` argument
+        from those constructors; passing it raised TypeError and aborted the
+        sensor-platform setup - yet the config entry still loaded, so a
+        setup-only check (entry LOADED) stayed green. Assert the entities exist
+        by unique_id so this class of regression is caught directly, not
+        swallowed as a logged platform error.
+        """
+        entity_registry = er.async_get(hass)
+        entry_id = init_integration.entry_id
+        for suffix in ("ppfd-integral", "dli", "dli-24h"):
+            unique_id = f"{entry_id}-{suffix}"
+            assert (
+                entity_registry.async_get_entity_id("sensor", DOMAIN, unique_id)
+                is not None
+            ), f"derived sensor {unique_id} was not created"
+
     async def test_unload_entry(
         self,
         hass: HomeAssistant,


### PR DESCRIPTION
## Problem (reported on #496, HA 2026.8.0b1)
```
Error while setting up plant platform for sensor:
IntegrationSensor.__init__() takes 1 positional argument but 2 positional
arguments (and 8 keyword-only arguments) were given
  sensor.py:1206  super().__init__(hass, ...)
```
HA 2026.8 dropped the leading `hass` argument from three helper-sensor constructors (and added an optional `device`), via the sibling PRs:

| Class | HA PR |
|---|---|
| `IntegrationSensor` | [#177596](https://github.com/home-assistant/core/pull/177596) |
| `StatisticsSensor` | [#177597](https://github.com/home-assistant/core/pull/177597) |
| `UtilityMeterSensor` | [#177603](https://github.com/home-assistant/core/pull/177603) |

`PlantTotalLightIntegral`, `PlantDailyLightIntegral` and `PlantDailyLightIntegral24h` passed `hass` positionally, so **all three** break on 2026.8.0b1. The reporters only saw the `IntegrationSensor` one because it's constructed first and aborts sensor-platform setup. The entry still loads, so the PPFD-integral / DLI / 24h-DLI sensors were silently missing.

**Not seen on 2026.7.4 / 2026.8.0b0** — those still accept `hass`. The change landed in **b1**.

## Fix
Detect per class whether `__init__` still accepts `hass` (via `inspect.signature`) and pass it only then. The plant subclasses keep supplying their own device through the `device_info` property, so the new `device` arg isn't needed. Works on HA < 2026.8 (passes `hass`) and ≥ 2026.8.0b1 (omits it).

## Test
Adds `test_setup_creates_derived_light_sensors` asserting the three derived sensors exist by unique_id. The old setup tests only checked the entry reached `LOADED` — which stayed green while the sensors silently failed to construct (the platform error is logged, not raised). The new test **fails without the fix** on b1.

## Verification
- **HA 2026.7.0b1:** 377 pass.
- **HA 2026.8.0b1:** 377 pass (was **35 failed** before the fix — all the same root cause, cascading through the PPFD/VPD/DLI/websocket tests).
- Both run locally; CI still can't pin a 2026.8 beta (no released `pytest-homeassistant-custom-component` for it — b1 forced + a test-only http shim).

No `manifest.json` bump here — cut `2026.8.0-beta2` separately once reviewed.