### PR TITLE
release: 2026.8.0-beta2 (beta)

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.8.0-beta1"
+  "version": "2026.8.0-beta2"
 }


### PR DESCRIPTION
Second **2026.8 beta**. Bumps `manifest.json` to `2026.8.0-beta2` → Auto Release publishes a **prerelease**.

### What's new since beta1
- **#500** — version-safe construction of HA's `IntegrationSensor` / `UtilityMeterSensor` / `StatisticsSensor`. HA 2026.8 (core PRs #177596/#177597/#177603) dropped their `hass` argument; the plant PPFD-integral / DLI / 24h-DLI sensors passed it positionally and broke on HA ≥ 2026.8.0b1 (#496). Also adds a test asserting those derived sensors are actually created.

Verified: 377 tests pass on HA 2026.7.0b1 and 2026.8.0b1.