### PR TITLE
ci: add non-blocking 'HA beta' test job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,8 @@ jobs:
   test:
     name: Tests (HA ${{ matrix.ha-version }})
     runs-on: ubuntu-latest
+    # Non-blocking for the experimental "beta" matrix entry; required otherwise.
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
@@ -53,6 +55,14 @@ jobs:
           # pytest-homeassistant-custom-component 0.13.320 -> HA 2026.3.4.
           - ha-version: "2026.3"
             pytest-ha-version: "==0.13.320"
+          # Latest HA prerelease/beta (NON-BLOCKING, see continue-on-error). Uses
+          # the latest plugin (which pins the newest *stable* HA), then force-
+          # upgrades HA to the newest prerelease so breakage in an upcoming HA
+          # release surfaces here early rather than in users' logs. The conftest
+          # HA-beta shim recreates symbols the lagging plugin still patches.
+          - ha-version: "beta"
+            pytest-ha-version: ""
+            experimental: true
     steps:
       - name: Check out code
         uses: actions/checkout@v7
@@ -85,6 +95,14 @@ jobs:
           ")
           # Install pytest-homeassistant-custom-component with version constraint
           uv pip install --no-cache "pytest-homeassistant-custom-component${{ matrix.pytest-ha-version }}"
+
+      - name: Force latest HA prerelease (beta job only)
+        if: matrix.ha-version == 'beta'
+        # Upgrade HA to the newest release INCLUDING prereleases, over the stable
+        # version the plugin pinned. Best-effort: the conftest HA-beta shim
+        # handles symbols the plugin still patches that a newer HA may have
+        # removed. This step is what makes the "beta" job test upcoming releases.
+        run: uv pip install --no-cache --prerelease=allow --upgrade homeassistant
 
       - name: Show installed versions
         run: |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,9 +34,7 @@ if not hasattr(_ha_http, "start_http_server_and_save_config"):
     def _noop_start_http_server_and_save_config(*args: Any, **kwargs: Any) -> None:
         return None
 
-    _ha_http.start_http_server_and_save_config = (
-        _noop_start_http_server_and_save_config
-    )
+    _ha_http.start_http_server_and_save_config = _noop_start_http_server_and_save_config
 
 
 from custom_components.plant.const import (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,24 @@ from pytest_homeassistant_custom_component.common import (
 pytest_plugins = "pytest_homeassistant_custom_component"
 
 
+# HA-beta compatibility shim (no-op on stable HA). pytest-homeassistant-custom-
+# component patches homeassistant.components.http.start_http_server_and_save_config
+# in an autouse fixture, but HA 2026.8 removed that symbol. The non-blocking
+# "HA beta" CI job force-installs a newer HA than the released plugin targets, so
+# the patch target is missing and every test would error at setup. Recreate a
+# no-op when it is absent; on HA versions that still export it this does nothing.
+from homeassistant.components import http as _ha_http
+
+if not hasattr(_ha_http, "start_http_server_and_save_config"):
+
+    def _noop_start_http_server_and_save_config(*args: Any, **kwargs: Any) -> None:
+        return None
+
+    _ha_http.start_http_server_and_save_config = (
+        _noop_start_http_server_and_save_config
+    )
+
+
 from custom_components.plant.const import (
     ATTR_CARE,
     ATTR_LIMITS,


### PR DESCRIPTION
Adds a third test-matrix entry so CI runs against **three** HA versions: oldest-supported stable (**2026.3**), **latest stable**, and the **latest prerelease/beta** — to catch upcoming-release breakage early.

### How the beta job works
- Installs the latest `pytest-homeassistant-custom-component` (which pins the newest *stable* HA), then **force-upgrades HA to the newest prerelease**: `uv pip install --prerelease=allow --upgrade homeassistant`.
- **Non-blocking**: `continue-on-error: ${{ matrix.experimental || false }}` — the beta entry sets `experimental: true`, so plugin/HA churn can't red the build. It's an early-warning signal, not a gate.
- **Shim**: the plugin patches HA internals that betas sometimes remove (2026.8 dropped `http.start_http_server_and_save_config`). A guard in `tests/conftest.py` recreates such symbols when absent — a **no-op on stable HA**.

### Why
This job would have caught the 2026.8 `IntegrationSensor`/`UtilityMeterSensor`/`StatisticsSensor` `hass`-arg breakage (#500) the moment 2026.8.0b1 dropped, instead of from users' logs on #496.

### Verified locally
- 2026.7.0b1: 377 pass. 2026.8.0b1: 377 pass **with only the conftest shim** (no external flag) — so the beta job runs clean today. On this PR the new `Tests (HA beta)` job will run live.