### PR TITLE
ci: only run push builds on main/master (avoid double runs)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,14 @@
 name: CI
 
 on:
+  # Only run push on main/master. Feature branches are covered by the
+  # pull_request event, so this avoids running the whole matrix twice for a push
+  # to a branch that already has an open PR. Push-on-main is also what the Auto
+  # Release workflow keys on (CI completing on main), so it must stay.
   push:
+    branches:
+      - main
+      - master
   pull_request:
     branches:
       - main


### PR DESCRIPTION
The `push` trigger had no branch filter, so a push to a branch with an open PR ran the whole test matrix **twice** — once for `push`, once for `pull_request`.

Scope `push` to `main`/`master`; feature branches are still covered by the `pull_request` event. Push-on-`main` is kept because the **Auto Release** workflow keys on CI completing on `main`.

Result: one CI run per PR push, one on merge-to-main (which still triggers releases).