### PR TITLE
release: 2026.8.0 (stable)

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.8.0-beta2"
+  "version": "2026.8.0"
 }


### PR DESCRIPTION
Home Assistant 2026.8 shipped today, so promote the `2026.8.0` beta line to a stable release.

Bumps `manifest.json` from `2026.8.0-beta2` → `2026.8.0`. No code changes since beta2 (only the CI-only PRs #502/#503).

## What's in this release (since 2026.7.2)
- **#498** — attach the plant device via a config-entry-bound platform (fixes the HA 2026.8 "attach a device to an entity without a config entry" deprecation warning)
- **#500** — version-safe construction of HA helper sensors for 2026.8 (HA removed the `hass` positional arg from `IntegrationSensor`/`UtilityMeterSensor`/`StatisticsSensor`; `inspect.signature`-gated so it works on both <2026.8 and ≥2026.8)
- **#497** — use `UnitOfRatio.PARTS_PER_MILLION` instead of the deprecated `CONCENTRATION_PARTS_PER_MILLION`
- CI: non-blocking "HA beta" matrix job (#502), push-build scoping (#503)

## Testing
- Full suite: **377 passed** against `homeassistant==2026.8.0` (final)
- Betas confirmed working on 2026.8.0b1 by @hmmbob + @NorbertHD (#496)

Merging triggers Auto Release to cut the stable `v2026.8.0` tag + release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)