### PR TITLE
test: de-flake grace-period expiration test

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2488,7 +2488,13 @@ class TestMoistureGracePeriod:
 
         plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
 
-        # Start normal
+        # Freeze time BEFORE any reading so grace-period timing is fully
+        # deterministic (no real-clock leak into utility-meter timers).
+        base_time = dt_util.now()
+        freezer.move_to(base_time)
+
+        # Establish a low baseline so the next reading registers as a watering
+        # event. Kept separate (no watering yet: _last_moisture_value is None).
         await set_external_sensor_states(
             hass,
             temperature=25.0,
@@ -2499,22 +2505,13 @@ class TestMoistureGracePeriod:
         )
         await update_plant_sensors(hass, init_integration.entry_id)
 
-        # Freeze time at a known point
-        base_time = dt_util.now()
-        freezer.move_to(base_time)
-
-        # Water plant
-        await set_external_sensor_states(
-            hass,
-            temperature=25.0,
-            moisture=55.0,
-            conductivity=1000.0,
-            illuminance=5000.0,
-            humidity=40.0,
-        )
-        await update_plant_sensors(hass, init_integration.entry_id)
-
-        # Moisture goes high
+        # Single unambiguous watering event straight to a "high" value: one
+        # +25% jump (>> the 10% threshold) arms the grace period AND makes
+        # moisture high in the same step. Deliberately NOT a two-step
+        # 40->55->65 walk: the old 55->65 step was itself a boundary (+10%)
+        # watering event, so a single stale intermediate read under load made
+        # the final update mis-detect a fresh watering event and re-arm the
+        # grace period past the time jump -> alert suppressed -> flaky failure.
         await set_external_sensor_states(
             hass,
             temperature=25.0,
@@ -2525,14 +2522,15 @@ class TestMoistureGracePeriod:
         )
         await update_plant_sensors(hass, init_integration.entry_id)
 
-        # Problem suppressed during grace period
+        # Problem suppressed during grace period, which ends exactly 600s out.
         assert plant.moisture_status == STATE_HIGH
         assert plant.state == STATE_OK
+        assert plant._moisture_grace_end_time == base_time + timedelta(seconds=600)
 
         # Advance time past grace period (15 minutes > 10 minutes)
         freezer.move_to(base_time + timedelta(minutes=15))
 
-        # Trigger update - moisture still high
+        # Trigger update - moisture unchanged (delta 0, so no re-arm)
         await set_external_sensor_states(
             hass,
             temperature=25.0,


### PR DESCRIPTION
Fixes the flaky `test_grace_period_expiration_enables_high_alerts` that intermittently failed CI and (once) blocked the 2026.8.0 Auto Release. **Test-only — no manifest bump, no release.**

## Root cause
The test walked moisture **40 → 55 → 65**. With `MOISTURE_INCREASE_THRESHOLD = 10.0`, the 55→65 step is an increase of *exactly* 10% — a boundary watering event. Watering detection compares against `_last_moisture_value`; under CI load a single stale intermediate sensor read let that value lag one step, so the **final** post-time-jump update mis-detected a *fresh* watering event, re-armed the grace period past the jump, and suppressed the alert → `assert 'ok' == 'problem'`. It passed in isolation and only flaked in the full suite under load (accompanied by a leaked `utility_meter` dispatch in the log).

Not a product bug — re-arming grace on a real +10% jump is intended watering detection. Pure test fragility.

## Fix
- Freeze the clock **before** the baseline read (removes real-clock leak into utility-meter timers).
- Use a single unambiguous **40 → 65 (+25%)** watering event that is "high" in the same step; the post-jump update re-sends 65 (Δ0), so no re-arm is possible.
- Add an invariant assert on `_moisture_grace_end_time` so any regression fails loudly instead of flaking.

Deliberately did **not** add `pytest-rerunfailures` — masking flakes would hide future real races.

## Testing
- Fixed test: 10× isolated ✅
- Full suite: 2× ✅ (377 passed)
- `black` + `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)