### PR TITLE
chore: translate the VPD strings in every language

### DIFF
--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24h rollierend)"
+      },
+      "vpd": {
+        "name": "Dampfdruckdefizit"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Min. Bodentemperatur"
+      },
+      "max_vpd": {
+        "name": "Max. VPD"
+      },
+      "min_vpd": {
+        "name": "Min. VPD"
       },
       "lux_to_ppfd": {
         "name": "Lux-zu-PPFD-Faktor"
@@ -145,6 +154,8 @@
           "min_conductivity": "Min. Leitfähigkeit (uS/cm)",
           "max_humidity": "Max. Luftfeuchtigkeit (%)",
           "min_humidity": "Min. Luftfeuchtigkeit (%)",
+          "max_vpd": "Max. VPD (kPa)",
+          "min_vpd": "Min. VPD (kPa)",
           "entity_picture": "Bild-URL"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Temperatur als Problemauslöser verwenden",
           "co2_trigger": "CO2 als Problemauslöser verwenden",
-          "soil_temperature_trigger": "Bodentemperatur als Problemauslöser verwenden"
+          "soil_temperature_trigger": "Bodentemperatur als Problemauslöser verwenden",
+          "vpd_trigger": "VPD als Problemauslöser verwenden"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/dk.json
+++ b/custom_components/plant/translations/dk.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24t rullende)"
+      },
+      "vpd": {
+        "name": "Damptryksdeficit"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Min. jordtemperatur"
+      },
+      "max_vpd": {
+        "name": "Maks. VPD"
+      },
+      "min_vpd": {
+        "name": "Min. VPD"
       },
       "lux_to_ppfd": {
         "name": "Lux til PPFD faktor"
@@ -145,6 +154,8 @@
           "min_conductivity": "Min. ledningsevne (uS/cm)",
           "max_humidity": "Maks. luftfugtighed (%)",
           "min_humidity": "Min. luftfugtighed (%)",
+          "max_vpd": "Maks. VPD (kPa)",
+          "min_vpd": "Min. VPD (kPa)",
           "entity_picture": "Billed-URL"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Brug temperatur som problemudløser",
           "co2_trigger": "Brug CO2 som problemudløser",
-          "soil_temperature_trigger": "Brug jordtemperatur som problemudløser"
+          "soil_temperature_trigger": "Brug jordtemperatur som problemudløser",
+          "vpd_trigger": "Brug VPD som problemudløser"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24h móvil)"
+      },
+      "vpd": {
+        "name": "Déficit de presión de vapor"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Mín. temperatura del suelo"
+      },
+      "max_vpd": {
+        "name": "Máx. VPD"
+      },
+      "min_vpd": {
+        "name": "Mín. VPD"
       },
       "lux_to_ppfd": {
         "name": "Factor Lux a PPFD"
@@ -145,6 +154,8 @@
           "min_conductivity": "Mín. conductividad (uS/cm)",
           "max_humidity": "Máx. humedad del aire (%)",
           "min_humidity": "Mín. humedad del aire (%)",
+          "max_vpd": "Máx. VPD (kPa)",
+          "min_vpd": "Mín. VPD (kPa)",
           "entity_picture": "URL de la imagen"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Usar temperatura como desencadenante de problema",
           "co2_trigger": "Usar CO2 como desencadenante de problema",
-          "soil_temperature_trigger": "Usar temperatura del suelo como desencadenante de problema"
+          "soil_temperature_trigger": "Usar temperatura del suelo como desencadenante de problema",
+          "vpd_trigger": "Usar VPD como desencadenante de problema"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24h glissant)"
+      },
+      "vpd": {
+        "name": "Déficit de pression de vapeur"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Température du sol min."
+      },
+      "max_vpd": {
+        "name": "VPD max."
+      },
+      "min_vpd": {
+        "name": "VPD min."
       },
       "lux_to_ppfd": {
         "name": "Facteur Lux vers PPFD"
@@ -145,6 +154,8 @@
           "min_conductivity": "Conductivité min. (uS/cm)",
           "max_humidity": "Humidité de l'air max. (%)",
           "min_humidity": "Humidité de l'air min. (%)",
+          "max_vpd": "VPD max. (kPa)",
+          "min_vpd": "VPD min. (kPa)",
           "entity_picture": "URL de l'image"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Utiliser la température comme déclencheur de problème",
           "co2_trigger": "Utiliser le CO2 comme déclencheur de problème",
-          "soil_temperature_trigger": "Utiliser la température du sol comme déclencheur de problème"
+          "soil_temperature_trigger": "Utiliser la température du sol comme déclencheur de problème",
+          "vpd_trigger": "Utiliser le VPD comme déclencheur de problème"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24 órás gördülő)"
+      },
+      "vpd": {
+        "name": "Gőznyomáshiány"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Min. talajhőmérséklet"
+      },
+      "max_vpd": {
+        "name": "Max. VPD"
+      },
+      "min_vpd": {
+        "name": "Min. VPD"
       },
       "lux_to_ppfd": {
         "name": "Lux-PPFD átalakítási tényező"
@@ -145,6 +154,8 @@
           "min_conductivity": "Min. vezetőképesség (uS/cm)",
           "max_humidity": "Max. páratartalom (%)",
           "min_humidity": "Min. páratartalom (%)",
+          "max_vpd": "Max. VPD (kPa)",
+          "min_vpd": "Min. VPD (kPa)",
           "entity_picture": "Kép URL"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Hőmérséklet használata problémajelzőként",
           "co2_trigger": "CO2 használata problémajelzőként",
-          "soil_temperature_trigger": "Talajhőmérséklet használata problémajelzőként"
+          "soil_temperature_trigger": "Talajhőmérséklet használata problémajelzőként",
+          "vpd_trigger": "VPD használata problémajelzőként"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/nb.json
+++ b/custom_components/plant/translations/nb.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24t rullerende)"
+      },
+      "vpd": {
+        "name": "Damptrykkdefisitt"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Min. jordtemperatur"
+      },
+      "max_vpd": {
+        "name": "Maks. VPD"
+      },
+      "min_vpd": {
+        "name": "Min. VPD"
       },
       "lux_to_ppfd": {
         "name": "Lux til PPFD faktor"
@@ -145,6 +154,8 @@
           "min_conductivity": "Min. ledningsevne (uS/cm)",
           "max_humidity": "Maks. luftfuktighet (%)",
           "min_humidity": "Min. luftfuktighet (%)",
+          "max_vpd": "Maks. VPD (kPa)",
+          "min_vpd": "Min. VPD (kPa)",
           "entity_picture": "Bilde-URL"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Bruk temperatur som problemutløser",
           "co2_trigger": "Bruk CO2 som problemutløser",
-          "soil_temperature_trigger": "Bruk jordtemperatur som problemutløser"
+          "soil_temperature_trigger": "Bruk jordtemperatur som problemutløser",
+          "vpd_trigger": "Bruk VPD som problemutløser"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24u voortschrijdend)"
+      },
+      "vpd": {
+        "name": "Dampdrukdeficit"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Min. bodemtemperatuur"
+      },
+      "max_vpd": {
+        "name": "Max. VPD"
+      },
+      "min_vpd": {
+        "name": "Min. VPD"
       },
       "lux_to_ppfd": {
         "name": "Lux naar PPFD factor"
@@ -145,6 +154,8 @@
           "min_conductivity": "Min. geleidbaarheid (uS/cm)",
           "max_humidity": "Max. luchtvochtigheid (%)",
           "min_humidity": "Min. luchtvochtigheid (%)",
+          "max_vpd": "Max. VPD (kPa)",
+          "min_vpd": "Min. VPD (kPa)",
           "entity_picture": "Afbeeldings-URL"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Gebruik temperatuur als trigger voor probleem",
           "co2_trigger": "Gebruik CO2 als trigger voor probleem",
-          "soil_temperature_trigger": "Gebruik bodemtemperatuur als trigger voor probleem"
+          "soil_temperature_trigger": "Gebruik bodemtemperatuur als trigger voor probleem",
+          "vpd_trigger": "Gebruik VPD als trigger voor probleem"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24h contínuo)"
+      },
+      "vpd": {
+        "name": "Défice de pressão de vapor"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "Mín. temperatura do solo"
+      },
+      "max_vpd": {
+        "name": "Máx. VPD"
+      },
+      "min_vpd": {
+        "name": "Mín. VPD"
       },
       "lux_to_ppfd": {
         "name": "Fator Lux para PPFD"
@@ -145,6 +154,8 @@
           "min_conductivity": "Mín. condutividade (uS/cm)",
           "max_humidity": "Máx. humidade do ar (%)",
           "min_humidity": "Mín. humidade do ar (%)",
+          "max_vpd": "Máx. VPD (kPa)",
+          "min_vpd": "Mín. VPD (kPa)",
           "entity_picture": "URL da imagem"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "Usar temperatura como gatilho de problema",
           "co2_trigger": "Usar CO2 como gatilho de problema",
-          "soil_temperature_trigger": "Usar temperatura do solo como gatilho de problema"
+          "soil_temperature_trigger": "Usar temperatura do solo como gatilho de problema",
+          "vpd_trigger": "Usar VPD como gatilho de problema"
         }
       },
       "replace_sensor": {

--- a/custom_components/plant/translations/zh-Hans.json
+++ b/custom_components/plant/translations/zh-Hans.json
@@ -34,6 +34,9 @@
       },
       "dli_24h": {
         "name": "DLI (24小时滚动)"
+      },
+      "vpd": {
+        "name": "饱和水汽压差"
       }
     },
     "number": {
@@ -84,6 +87,12 @@
       },
       "min_soil_temperature": {
         "name": "最低土壤温度"
+      },
+      "max_vpd": {
+        "name": "最大VPD"
+      },
+      "min_vpd": {
+        "name": "最小VPD"
       },
       "lux_to_ppfd": {
         "name": "勒克斯转PPFD系数"
@@ -145,6 +154,8 @@
           "min_conductivity": "最小电导率(uS/cm)",
           "max_humidity": "最大空气湿度(%)",
           "min_humidity": "最小空气湿度(%)",
+          "max_vpd": "最大VPD(kPa)",
+          "min_vpd": "最小VPD(kPa)",
           "entity_picture": "图片URL"
         }
       }
@@ -177,7 +188,8 @@
           "moisture_grace_period": "Moisture grace period after watering (seconds, 0-86400)",
           "temperature_trigger": "使用温度作为问题触发器",
           "co2_trigger": "使用二氧化碳作为问题触发器",
-          "soil_temperature_trigger": "使用土壤温度作为问题触发器"
+          "soil_temperature_trigger": "使用土壤温度作为问题触发器",
+          "vpd_trigger": "使用VPD作为问题触发器"
         }
       },
       "replace_sensor": {


### PR DESCRIPTION
The VPD sensor, its min/max numbers and its trigger option existed only in English, so all nine other languages fell back for them.

Each language follows its own file's conventions — read off its existing humidity and DLI entries — so the acronym survives wherever English writes `VPD` and only the surrounding words are localised, while the sensor name is spelled out and translated. Same shape as the existing `DLI (24h rolling)` / `Daily light integral` pair.

| | sensor name | max | trigger option |
|---|---|---|---|
| de | Dampfdruckdefizit | Max. VPD | VPD als Problemauslöser verwenden |
| dk | Damptryksdeficit | Maks. VPD | Brug VPD som problemudløser |
| es | Déficit de presión de vapor | Máx. VPD | Usar VPD como desencadenante de problema |
| fr | Déficit de pression de vapeur | VPD max. | Utiliser le VPD comme déclencheur de problème |
| hu | Gőznyomáshiány | Max. VPD | VPD használata problémajelzőként |
| nb | Damptrykkdefisitt | Maks. VPD | Bruk VPD som problemutløser |
| nl | Dampdrukdeficit | Max. VPD | Gebruik VPD als trigger voor probleem |
| pt | Défice de pressão de vapor | Máx. VPD | Usar VPD como gatilho de problema |
| zh-Hans | 饱和水汽压差 | 最大VPD | 使用VPD作为问题触发器 |

Still untranslated everywhere: the 256-key `triggers.*`/`conditions.*` block from 2026.7.0. Full sentences, a separate job — HA falls back to English meanwhile.