### PR TITLE
chore: key the DLI sensor's name by "dli", as its data already is

### DIFF
--- a/custom_components/plant/const.py
+++ b/custom_components/plant/const.py
@@ -79,7 +79,10 @@ TRANSLATION_KEY_ILLUMINANCE = "illuminance"
 TRANSLATION_KEY_HUMIDITY = "humidity"
 TRANSLATION_KEY_PPFD = "ppfd"
 TRANSLATION_KEY_TOTAL_LIGHT_INTEGRAL = "total_light_integral"
-TRANSLATION_KEY_DAILY_LIGHT_INTEGRAL = "daily_light_integral"
+# The data vocabulary calls this reading "dli" (ATTR_DLI/READING_DLI, the
+# min_dli/max_dli options, the entity ids); the translation key follows it,
+# so consumers can look a name up by the key they already have.
+TRANSLATION_KEY_DLI = "dli"
 TRANSLATION_KEY_DLI_24H = "dli_24h"
 TRANSLATION_KEY_MAX_MOISTURE = "max_moisture"
 TRANSLATION_KEY_MIN_MOISTURE = "min_moisture"

--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -106,7 +106,7 @@ from .const import (
     RESTORE_GRACE_PERIOD,
     TRANSLATION_KEY_CO2,
     TRANSLATION_KEY_CONDUCTIVITY,
-    TRANSLATION_KEY_DAILY_LIGHT_INTEGRAL,
+    TRANSLATION_KEY_DLI,
     TRANSLATION_KEY_DLI_24H,
     TRANSLATION_KEY_HUMIDITY,
     TRANSLATION_KEY_ILLUMINANCE,
@@ -1319,7 +1319,7 @@ class PlantDailyLightIntegral(UtilityMeterSensor):
     _attr_device_class = ATTR_DLI
     _attr_icon = ICON_DLI
     _attr_suggested_display_precision = 2
-    _attr_translation_key = TRANSLATION_KEY_DAILY_LIGHT_INTEGRAL
+    _attr_translation_key = TRANSLATION_KEY_DLI
 
     def __init__(
         self,

--- a/custom_components/plant/strings.json
+++ b/custom_components/plant/strings.json
@@ -23,7 +23,7 @@
       "total_light_integral": {
         "name": "Total light integral"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Daily light integral"
       },
       "vpd": {

--- a/custom_components/plant/translations/de.json
+++ b/custom_components/plant/translations/de.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Gesamtlichtintegral"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Tägliches Lichtintegral"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/dk.json
+++ b/custom_components/plant/translations/dk.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Total lysintegral"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Daglig lysintegral"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/en.json
+++ b/custom_components/plant/translations/en.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Total light integral"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Daily light integral"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/es.json
+++ b/custom_components/plant/translations/es.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Integral de luz total"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Integral de luz diaria"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/fr.json
+++ b/custom_components/plant/translations/fr.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Intégrale de lumière totale"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Intégrale de lumière quotidienne"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/hu.json
+++ b/custom_components/plant/translations/hu.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Teljes fényintegrál"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Napi fényintegrál"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/nb.json
+++ b/custom_components/plant/translations/nb.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Total lysintegral"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Daglig lysintegral"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/nl.json
+++ b/custom_components/plant/translations/nl.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Totale lichtintegraal"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Dagelijkse lichtintegraal"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/pt.json
+++ b/custom_components/plant/translations/pt.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "Integral de luz total"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "Integral de luz diária"
       },
       "dli_24h": {

--- a/custom_components/plant/translations/zh-Hans.json
+++ b/custom_components/plant/translations/zh-Hans.json
@@ -29,7 +29,7 @@
       "total_light_integral": {
         "name": "总光照积分"
       },
-      "daily_light_integral": {
+      "dli": {
         "name": "每日光照积分"
       },
       "dli_24h": {


### PR DESCRIPTION
The integration called one reading two things:

| | key |
|---|---|
| data — `ATTR_DLI`, `READING_DLI`, `min_dli`/`max_dli` options, `plant.get_info`, entity ids | `dli` |
| translation key | `daily_light_integral` |

So anything holding a reading key and wanting its name had to special-case that one — the flower card hit it while moving to `hass.localize("component.plant.entity.sensor.<key>.name")`.

The data vocabulary is the one that cannot move: those option keys sit in every existing config entry, and the attribute names are in users' templates. The translation key follows it instead.

**Nothing user-visible changes.** The English name is still "Daily light integral" — only the key it is stored under moves — and entity ids are generated from `READING_DLI`, not from the translation key, so they are unaffected on existing and new installs alike.

377 tests pass, black clean.