### PR TITLE
chore: release 2026.8.1

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.8.0"
+  "version": "2026.8.1"
 }


### PR DESCRIPTION
Translations & plumbing only — no functional change since 2026.8.0.

- **VPD is named in all nine other languages** ([#512](https://github.com/Olen/homeassistant-plant/pull/512)), where it had been left in English while everything around it was translated.
- **The DLI sensor's name is keyed by `dli`** ([#513](https://github.com/Olen/homeassistant-plant/pull/513)), matching the key its own data already uses (`ATTR_DLI`, `min_dli`/`max_dli`, `plant.get_info`, the entity ids), so a consumer holding a reading key can look its name up without a special case. Nothing user-visible — the English name is still "Daily light integral", and entity ids are unaffected.
- Line endings normalised to LF via `.gitattributes` ([#511](https://github.com/Olen/homeassistant-plant/pull/511)).

The only Python change in the whole range is the three-line constant rename.