### PR TITLE
Run number entity state listeners on the event loop

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.8.2"
+  "version": "2026.8.1"
 }

--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.8.1"
+  "version": "2026.8.2"
 }

--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -368,6 +368,7 @@ class PlantMinMax(RestoreNumber):
         self._attr_native_value = value
         self.async_write_ha_state()
 
+    @callback
     def _state_changed_event(self, event: Event) -> None:
         if event.data.get("old_state") is None or event.data.get("new_state") is None:
             return
@@ -382,6 +383,7 @@ class PlantMinMax(RestoreNumber):
             new_state=event.data.get("new_state").state,
         )
 
+    @callback
     def state_changed(self, old_state: str | None, new_state: str | None) -> None:
         """Store the state if changed from the UI."""
         _LOGGER.debug(
@@ -399,11 +401,13 @@ class PlantMinMax(RestoreNumber):
         else:
             self._attr_native_value = new_state
 
+    @callback
     def state_attributes_changed(
         self, old_attributes: dict[str, Any], new_attributes: dict[str, Any]
     ) -> None:
         """Handle attribute changes (placeholder for subclasses)."""
 
+    @callback
     def self_updated(self) -> None:
         """Allow the state to be changed from the UI and saved in restore_state."""
         if self._attr_state != self.hass.states.get(self.entity_id).state:
@@ -558,6 +562,7 @@ class PlantMaxTemperature(PlantMinMax):
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
+    @callback
     def state_attributes_changed(
         self, old_attributes: dict[str, Any], new_attributes: dict[str, Any]
     ) -> None:
@@ -654,6 +659,7 @@ class PlantMinTemperature(PlantMinMax):
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
+    @callback
     def state_attributes_changed(
         self, old_attributes: dict[str, Any], new_attributes: dict[str, Any]
     ) -> None:
@@ -1020,6 +1026,7 @@ class PlantMaxSoilTemperature(PlantMinMax):
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
+    @callback
     def state_attributes_changed(
         self, old_attributes: dict[str, Any], new_attributes: dict[str, Any]
     ) -> None:
@@ -1100,6 +1107,7 @@ class PlantMinSoilTemperature(PlantMinMax):
         super().__init__(hass, config, plantdevice)
         self._attr_native_unit_of_measurement = self.hass.config.units.temperature_unit
 
+    @callback
     def state_attributes_changed(
         self, old_attributes: dict[str, Any], new_attributes: dict[str, Any]
     ) -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1501,3 +1501,45 @@ class TestGetTemperatureDefaultMatrix:
         # Re-stamped as °F (e.g. after a refresh), read back on metric.
         back_on_metric = _temp_default(_F, _C, on_imperial)
         assert back_on_metric == 32  # 90°F -> 32°C
+
+
+class TestListenersRunOnTheEventLoop:
+    """Every state listener must be a @callback.
+
+    Home Assistant picks a job type from the function itself: an undecorated
+    sync function becomes HassJobType.Executor and is dispatched to a worker
+    thread. These listeners write _attr_native_value, so off the loop two
+    changes in quick succession can be applied out of order and the entity
+    keeps the older value - issue #515, where setting -10 then -45 left -10.
+    """
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "_state_changed_event",
+            "state_changed",
+            "state_attributes_changed",
+            "self_updated",
+        ],
+    )
+    def test_listener_is_a_callback(self, method):
+        """Check every class in number.py that defines one."""
+        import inspect
+
+        from homeassistant.core import HassJob, HassJobType
+
+        from custom_components.plant import number as number_module
+
+        checked = 0
+        for _, cls in inspect.getmembers(number_module, inspect.isclass):
+            if cls.__module__ != number_module.__name__:
+                continue
+            func = cls.__dict__.get(method)
+            if func is None:
+                continue
+            checked += 1
+            assert HassJob(func).job_type is HassJobType.Callback, (
+                f"{cls.__name__}.{method} is dispatched as "
+                f"{HassJob(func).job_type.name}, not on the event loop"
+            )
+        assert checked, f"no class defines {method} - has it been renamed?"


### PR DESCRIPTION
Fixes #515.

`PlantMinMax._state_changed_event` and friends are plain sync functions, so `HassJob` types them as `HassJobType.Executor` and Home Assistant dispatches them to a **worker thread** rather than running them on the event loop:

```python
>>> HassJob(PlantMinMax._state_changed_event).job_type
<HassJobType.Executor: 3>
```

They assign `self._attr_native_value` (and `self_updated` calls `async_write_ha_state`), so off the loop two changes close together can be applied out of order and the entity keeps the older value. That is exactly the reported failure — setting `-10` then `-45` left `-10.0`, and the value is a float because it came back through `float(new_state)` in `state_changed`, not from the caller.

`sensor.py` already decorates every one of its listeners with `@callback`; `number.py` was the only file that did not, in all 8 places.

The new test asserts the job type for every listener each class defines. It fails on `main` for all four method names and passes with the fix.

Thanks @SuperSandro2000 for the report — a genuinely intermittent failure that turned out to be a real threading bug, not test flakiness.