### PR TITLE
Stop calling the deprecated device_registry.async_get_device

### DIFF
--- a/custom_components/plant/__init__.py
+++ b/custom_components/plant/__init__.py
@@ -437,10 +437,9 @@ async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
         _LOGGER.debug("Removing entity registry entry: %s", entity_entry.entity_id)
         ent_reg.async_remove(entity_entry.entity_id)
 
-    # Remove device registry entry
+    # Remove device registry entries
     dev_reg = dr.async_get(hass)
-    device = dev_reg.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
-    if device:
+    for device in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
         _LOGGER.debug("Removing device registry entry: %s", device.id)
         dev_reg.async_remove_device(device.id)
 
@@ -1675,7 +1674,7 @@ class PlantDevice(RestoreEntity):
         # Is there a better way to add an entity to the device registry?
 
         device_registry = dr.async_get(self.hass)
-        device_registry.async_get_or_create(
+        device = device_registry.async_get_or_create(
             config_entry_id=self._config.entry_id,
             identifiers={(DOMAIN, self.unique_id)},
             name=self.name,
@@ -1683,9 +1682,6 @@ class PlantDevice(RestoreEntity):
             manufacturer=self.data_source,
         )
         if self._device_id is None:
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, self.unique_id)}
-            )
             self._device_id = device.id
 
     async def async_added_to_hass(self) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -50,10 +50,12 @@ class TestIntegrationSetup:
     ) -> None:
         """Test that setup creates a device in the device registry."""
         device_registry = dr.async_get(hass)
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, init_integration.entry_id)}
+        devices = dr.async_entries_for_config_entry(
+            device_registry, init_integration.entry_id
         )
-        assert device is not None
+        assert len(devices) == 1
+        device = devices[0]
+        assert (DOMAIN, init_integration.entry_id) in device.identifiers
         assert device.name == TEST_PLANT_NAME
         # The device is owned by the config entry - attached natively by the
         # config-entry-bound platform, not patched in after the fact.
@@ -228,11 +230,10 @@ class TestIntegrationSetup:
         device_registry = dr.async_get(hass)
 
         entities_before = er.async_entries_for_config_entry(entity_registry, entry_id)
-        device_before = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry_id)}
-        )
+        devices_before = dr.async_entries_for_config_entry(device_registry, entry_id)
         assert len(entities_before) > 0
-        assert device_before is not None
+        assert len(devices_before) == 1
+        assert (DOMAIN, entry_id) in devices_before[0].identifiers
 
         # Verify the main plant entity is tied to the config entry
         plant_entity_id = entity_registry.async_get_entity_id(DOMAIN, DOMAIN, entry_id)
@@ -252,10 +253,38 @@ class TestIntegrationSetup:
         assert entity_registry.async_get(plant_entity_id) is None
 
         # Verify device is removed from registry
-        device_after = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry_id)}
+        assert dr.async_entries_for_config_entry(device_registry, entry_id) == []
+
+    async def test_update_registry_sets_device_id(
+        self,
+        hass: HomeAssistant,
+        init_integration: MockConfigEntry,
+    ) -> None:
+        """Test update_registry records the device id without a registry lookup.
+
+        async_get_or_create already returns the device entry, so the plant must
+        not fall back to the deprecated device_registry.async_get_device().
+        """
+        plant = hass.data[DOMAIN][init_integration.entry_id][ATTR_PLANT]
+        device_registry = dr.async_get(hass)
+
+        devices = dr.async_entries_for_config_entry(
+            device_registry, init_integration.entry_id
         )
-        assert device_after is None
+        assert len(devices) == 1
+        assert plant.device_id == devices[0].id
+
+        # Re-running must be idempotent and keep the same device.
+        plant.update_registry()
+        assert plant.device_id == devices[0].id
+        assert (
+            len(
+                dr.async_entries_for_config_entry(
+                    device_registry, init_integration.entry_id
+                )
+            )
+            == 1
+        )
 
     async def test_setup_completes_when_registry_entry_not_immediate(
         self,


### PR DESCRIPTION
Fixes #518.

HA 2026.9 warns that `async_get_device` is deprecated because identifiers are no longer unique across config entries. There were **two** call sites, not just the one in the issue.

Both already knew their config entry, so neither needed a global lookup:

- `update_registry` keeps the entry `async_get_or_create` already returns, dropping a redundant second lookup.
- `async_remove_entry` uses `dr.async_entries_for_config_entry`, matching the entity cleanup directly above it.

**Not** using the suggested `async_get_device_by_identifier`: it was added in 2026.8.0 and is absent in 2025.8/2026.3/2026.7. The manifest supports 2025.8.0 and CI runs a 2026.3 job, so it would break both. `async_entries_for_config_entry` exists across the whole range.

The test suite had to move off it too — on 2026.9 the test harness raises `RuntimeError` rather than warning, so `test_setup_entry_creates_device` and `test_remove_entry` failed on `latest`/`beta` while `2026.3` passed. Asserting on `async_entries_for_config_entry` also pins the device count for the entry rather than just resolving one identifier.

Adds a test asserting `update_registry` populates `device_id` and is idempotent.

No version bump — that belongs in a separate release PR.