### PR TITLE
Give the PPFD integral 4 decimals so dim plants keep their DLI

### DIFF
--- a/custom_components/plant/sensor.py
+++ b/custom_components/plant/sensor.py
@@ -1226,7 +1226,10 @@ class PlantTotalLightIntegral(IntegrationSensor):
         integration_kwargs = {
             "integration_method": METHOD_TRAPEZOIDAL,
             "name": f"Total {READING_PPFD} Integral",
-            "round_digits": 2,
+            # The DLI meter reads this sensor's rounded state, so the rounding
+            # step is its resolution floor -- at 2 digits a dim plant loses a
+            # whole 0.01 mol/m² off its daily total.
+            "round_digits": 4,
             "source_entity": illuminance_ppfd_sensor.entity_id,
             "unique_id": f"{config.entry_id}-ppfd-integral",
             "unit_prefix": None,


### PR DESCRIPTION
Addresses the precision half of #517. (The constructor break in that issue is #509, already fixed.)

## What actually happens

The reporter describes low readings being "rounded away before the DLI meter sees them". That is not the mechanism — `IntegrationSensor` accumulates into an exact `Decimal` and rounds only on output:

```python
self._state += area_scaled                          # exact, never rounded
...
return round(self._state, self._round_digits)       # output only
```

Because the DLI meter accumulates *differences* of that output, the quantization telescopes: the error is one quantum **per day**, not per update. But `round_digits: 2` makes that quantum `0.01 mol/m²`.

## Measured

`sensor.plant_001_total_ppfd_mol_integral`, one full day on a dim indoor plant:

```
state changes:      26
every delta:        exactly 0.0100  (25 of them)
integral day total: 0.2500 mol/m²
DLI reported:       0.26            <- one quantum out, as predicted
```

| DLI/day | error from a 0.01 quantum |
|---|---|
| 0.25 | ~4% |
| 1.9  | ~0.6% |
| 4.9  | ~0.3% |
| 20+  | negligible |

So it only matters for dim plants — which is the reporter's case, if not his reasoning.

## Why 4 and not the 6 that was suggested

The integral can only tick when its source changes. The illuminance source updates ~880x/day, so tick rate is `min(day_total / quantum, source_updates)` and saturates:

| round_digits | ticks/day | recorder cost | error at 0.25 mol/d |
|---|---|---|---|
| 2 (current) | 26 | 1x | 4% |
| 3 | ~250 | ~10x | 0.4% |
| **4** | **880 (saturated)** | **~34x** | **0.04%** |
| 6 | 880 (saturated) | ~34x | 0.0001% |

6 costs the same as 4 and buys nothing.

`suggested_display_precision` follows `round_digits` and is deliberately left to do so: this is a hidden diagnostic entity, where more digits help debugging.

No version bump — that belongs in a release PR.