### PR TITLE
chore: release 2026.9.0

### DIFF
--- a/custom_components/plant/manifest.json
+++ b/custom_components/plant/manifest.json
@@ -18,5 +18,5 @@
   "requirements": [
     "async-timeout>=4.0.2"
   ],
-  "version": "2026.8.1"
+  "version": "2026.9.0"
 }


### PR DESCRIPTION
Version bump only — the changes are already on `main`.

## What is in this release

- **#519** — stop calling the deprecated `device_registry.async_get_device` (fixes #518). Both call sites; HA 2026.9 raises `RuntimeError` from the test harness rather than warning, so this was breaking the suite on `latest`/`beta`.
- **#520** — give the PPFD integral 4 decimals (addresses the precision half of #517), so a dim plant no longer loses a whole 0.01 mol/m² off its daily DLI.

Both keep working on the full supported range: the manifest declares 2025.8.0 and CI covers 2026.3, latest and beta.