### PR TITLE
Keep build plumbing and the release bump out of the changelog

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,6 +3,15 @@
 # label every PR so it lands in the right category. Unlabeled PRs fall into
 # "Other Changes". See CONTRIBUTING.md.
 changelog:
+  # Nothing here changes what a user runs: `release` is the manifest bump
+  # itself, the rest is workflow and action plumbing. `chore` is deliberately
+  # NOT excluded -- it has carried translations and entity renames.
+  exclude:
+    labels:
+      - release
+      - ci
+      - github_actions
+      - dependencies
   categories:
     - title: 🚀 Features & Enhancements
       labels:
@@ -15,11 +24,8 @@ changelog:
     - title: 📚 Documentation
       labels:
         - documentation
-    - title: 🧹 Maintenance & CI
+    - title: 🧹 Maintenance
       labels:
-        - dependencies
-        - github_actions
-        - ci
         - chore
     - title: Other Changes
       labels:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,14 @@ Add a label so your change lands in the right section of the changelog:
 | `enhancement` or `feature` | 🚀 Features & Enhancements |
 | `bug` or `fix` | 🐛 Bug Fixes |
 | `documentation` | 📚 Documentation |
-| `dependencies`, `github_actions`, `ci`, `chore` | 🧹 Maintenance & CI |
+| `chore` | 🧹 Maintenance |
+| `ci`, `github_actions`, `dependencies` | _(excluded — build plumbing)_ |
+| `release` | _(excluded — see Releases below)_ |
 | _(no label)_ | Other Changes |
+
+Labels that change nothing a user runs are kept out of the changelog entirely.
+`chore` is **not** excluded — it has carried translations and entity renames,
+which users do notice.
 
 Pick the single label that best describes the PR's primary intent. Unlabeled PRs
 still appear under **Other Changes**, but a label makes the changelog readable.
@@ -44,8 +50,16 @@ Choose the label from the table above based on the PR's primary intent.
 
 ## Releases (maintainers)
 
-Releases are automated. Bump the version in
-`custom_components/plant/manifest.json` on `main`; on the next green CI run the
-**Auto Release** workflow tags `v<version>` and publishes a GitHub release
-(prerelease when the version contains `beta`), with notes categorized from the
-merged-PR labels. Version format: `YYYY.M.P` (stable) or `YYYY.M.P-betaN` (beta).
+**Never bump the version in a fix PR.** The bump gets its own PR so several
+changes can ship in one release, and so fix PRs stay mergeable without
+triggering a release.
+
+To cut a release, open a PR that changes only the version in
+`custom_components/plant/manifest.json`, title it `chore: release <version>`,
+and label it `release` — that label keeps the bump itself out of the changelog,
+which would otherwise list the release announcing itself.
+
+On the next green CI run after it merges, the **Auto Release** workflow tags
+`v<version>` and publishes a GitHub release (prerelease when the version
+contains `beta`), with notes categorized from the merged-PR labels. Version
+format: `YYYY.M.P` (stable) or `YYYY.M.P-betaN` (beta).


### PR DESCRIPTION
Now that every release gets its own version-bump PR, each set of notes would otherwise list the release announcing itself — `* chore: release 2026.9.0 by @Olen in #521` appeared in 2026.9.0 already.

Excludes `release`, `ci`, `github_actions` and `dependencies`. Audited against the merged history rather than guessed:

| Label | Merged PRs | What they actually are |
|---|---|---|
| `ci` | 3 | de-flake a test, push-build config, add the HA beta job |
| `github_actions` | 5 | action bumps + release-notes config |
| `dependencies` | 6 | **all** GitHub Actions bumps (`actions/checkout`, `setup-python`, `codecov-action`, `github-script`) |

None change what a user runs.

**`chore` is deliberately not excluded.** Of its 9 PRs, 6 were release bumps that now take the `release` label instead — but #513 keyed the DLI sensor's name and #512 translated the VPD strings. Both are things users notice, and excluding `chore` wholesale would have hidden them.

"🧹 Maintenance & CI" becomes "🧹 Maintenance", since CI no longer lands there.

CONTRIBUTING.md is updated to match, including the Releases section, which still described bumping the version on `main` rather than via a dedicated release PR.

The `release` label has been created on the repo so the exclusion has something to match.