### PR TITLE
fix: keep the entity's own unit when restoring a threshold

### DIFF
--- a/custom_components/plant/number.py
+++ b/custom_components/plant/number.py
@@ -320,6 +320,12 @@ class PlantMinMax(RestoreNumber):
     _attr_mode = NumberMode.BOX
     # Subclasses should override this for entity_id generation
     _entity_id_key: str | None = None
+    # Whether a restored unit should win over the class's own. Only the
+    # temperature thresholds convert their value between °C and °F, so only
+    # they have to restore value and unit together. Everywhere else the unit
+    # belongs to the entity type, and a restored one would pin whatever an
+    # older version happened to write.
+    _restores_unit_of_measurement = False
 
     def __init__(
         self, hass: HomeAssistant, config: ConfigEntry, plantdevice: Entity
@@ -468,7 +474,10 @@ class PlantMinMax(RestoreNumber):
                 )
             else:
                 self._attr_native_value = state.native_value
-        if state.native_unit_of_measurement is not None:
+        if (
+            self._restores_unit_of_measurement
+            and state.native_unit_of_measurement is not None
+        ):
             self._attr_native_unit_of_measurement = state.native_unit_of_measurement
         # Final safety net: ensure we always have a valid numeric value
         if self._attr_native_value is None:
@@ -541,6 +550,7 @@ class PlantMaxTemperature(PlantMinMax):
     """Entity class for max temperature threshold"""
 
     _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _restores_unit_of_measurement = True
     _attr_icon = ICON_TEMPERATURE
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
@@ -638,6 +648,7 @@ class PlantMinTemperature(PlantMinMax):
     """Entity class for min temperature threshold"""
 
     _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _restores_unit_of_measurement = True
     _attr_icon = ICON_TEMPERATURE
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
@@ -1005,6 +1016,7 @@ class PlantMaxSoilTemperature(PlantMinMax):
     """Entity class for max soil temperature threshold"""
 
     _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _restores_unit_of_measurement = True
     _attr_icon = ICON_SOIL_TEMPERATURE
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE
@@ -1086,6 +1098,7 @@ class PlantMinSoilTemperature(PlantMinMax):
     """Entity class for min soil temperature threshold"""
 
     _attr_device_class = NumberDeviceClass.TEMPERATURE
+    _restores_unit_of_measurement = True
     _attr_icon = ICON_SOIL_TEMPERATURE
     _attr_native_max_value = TEMPERATURE_MAX_VALUE
     _attr_native_min_value = TEMPERATURE_MIN_VALUE

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1543,3 +1543,116 @@ class TestListenersRunOnTheEventLoop:
                 f"{HassJob(func).job_type.name}, not on the event loop"
             )
         assert checked, f"no class defines {method} - has it been renamed?"
+
+
+class TestThresholdRestoreUnit:
+    """A restored unit must not override one the entity type defines.
+
+    RestoreNumber stores the unit alongside the value, so an entity that
+    was written by an older version keeps that version's unit for good --
+    the DLI thresholds were still reporting the PPFD unit long after the
+    constant was corrected.
+    """
+
+    async def test_fixed_unit_ignores_restored_unit(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """A DLI threshold restored with a stale unit reports UNIT_DLI,
+        and still restores its value.
+        """
+        entry_id = "stale_unit_entry_id"
+        ent_reg = er.async_get(hass)
+        registry_entry = ent_reg.async_get_or_create(
+            domain="number",
+            platform=DOMAIN,
+            unique_id=f"{entry_id}-max-dli",
+        )
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [
+                (
+                    State(registry_entry.entity_id, "22.5"),
+                    {
+                        "native_max_value": 100,
+                        "native_min_value": 0,
+                        "native_step": 0.1,
+                        # What an older version wrote: PPFD, per second.
+                        "native_unit_of_measurement": "mol/s⋅m²",
+                        "native_value": 22.5,
+                    },
+                ),
+            ],
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        assert plant.max_dli.native_unit_of_measurement == UNIT_DLI
+        assert plant.max_dli.native_value == 22.5
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    async def test_temperature_still_restores_its_unit(
+        self,
+        hass: HomeAssistant,
+        plant_config_data: dict,
+        mock_external_sensors,
+        mock_no_openplantbook,
+    ) -> None:
+        """Temperature converts its value between °C and °F, so it has to
+        restore value and unit together.
+        """
+        entry_id = "fahrenheit_entry_id"
+        ent_reg = er.async_get(hass)
+        registry_entry = ent_reg.async_get_or_create(
+            domain="number",
+            platform=DOMAIN,
+            unique_id=f"{entry_id}-max-temperature",
+        )
+
+        mock_restore_cache_with_extra_data(
+            hass,
+            [
+                (
+                    State(registry_entry.entity_id, "90"),
+                    {
+                        "native_max_value": 200,
+                        "native_min_value": -100,
+                        "native_step": 1,
+                        "native_unit_of_measurement": _F,
+                        "native_value": 90,
+                    },
+                ),
+            ],
+        )
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data=plant_config_data,
+            entry_id=entry_id,
+            title=TEST_PLANT_NAME,
+        )
+        config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        plant = hass.data[DOMAIN][config_entry.entry_id][ATTR_PLANT]
+        assert plant.max_temperature.native_unit_of_measurement == _F
+        assert plant.max_temperature.native_value == 90
+
+        await hass.config_entries.async_unload(config_entry.entry_id)
+        await hass.async_block_till_done()


### PR DESCRIPTION
`RestoreNumber` stores the unit alongside the value, and the restore
overrode the class's unit unconditionally. A threshold therefore kept
whatever unit the version that last wrote it used, permanently — the
DLI thresholds still reported `mol/s⋅m²` (PPFD, per second) long after
`UNIT_DLI` was corrected to `mol/d⋅m²`, and no code fix could dislodge
it.

Restore the unit only where it genuinely varies. The four temperature
classes convert their value between °C and °F, so value and unit have
to be restored together; every other threshold's unit belongs to the
entity type.

Self-healing: affected entities pick up the right unit on next restart.

Tests: the DLI case fails without the fix; the temperature case guards
the exception.